### PR TITLE
Harden CLI and repository supply chain

### DIFF
--- a/.changeset/quiet-cats-help.md
+++ b/.changeset/quiet-cats-help.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/cli": patch
+---
+
+Show help and version information without requiring a project configuration, and reject unknown commands before config discovery.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @Lojhan
+
+/.github/ @Lojhan
+/.changeset/ @Lojhan
+/scripts/ @Lojhan
+/release-manifest.json @Lojhan
+/SECURITY.md @Lojhan

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: cargo
+    directory: /editors/zed
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high
+
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.11
           cache: pnpm
@@ -30,11 +39,11 @@ jobs:
   postgres-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.11
           cache: pnpm
@@ -46,11 +55,11 @@ jobs:
   mysql-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.11
           cache: pnpm
@@ -62,11 +71,11 @@ jobs:
   packed-real-databases:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.11
           cache: pnpm
@@ -78,11 +87,11 @@ jobs:
   editor-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.11
           cache: pnpm
@@ -93,7 +102,7 @@ jobs:
       - run: cargo test --manifest-path editors/zed/Cargo.toml
       - run: cargo build --release --target wasm32-wasip2 --manifest-path editors/zed/Cargo.toml
       - run: cp editors/zed/target/wasm32-wasip2/release/typed_sql_zed.wasm artifacts/typed-sql-zed.wasm
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: typed-sql-editor-artifacts
           path: artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.14
           cache: pnpm
@@ -46,7 +46,7 @@ jobs:
           else
             echo 'present=false' >> "$GITHUB_OUTPUT"
           fi
-      - uses: changesets/action/version@v2
+      - uses: changesets/action/version@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: steps.pending_changesets.outputs.present == 'true'
         with:
           script: pnpm version-packages
@@ -59,13 +59,13 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           package-manager-cache: false
@@ -82,13 +82,13 @@ jobs:
       - name: Assert stable release contract
         if: inputs.channel == 'stable'
         run: pnpm release:assert stable
-      - uses: changesets/action/publish@v2
+      - uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'beta'
         with:
           script: pnpm release:beta
           create-github-releases: true
           push-git-tags: true
-      - uses: changesets/action/publish@v2
+      - uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'stable'
         with:
           script: pnpm release:stable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,16 @@ as untrusted input. Database credentials and executable config files remain appl
 Config files are executable TypeScript and therefore have the same authority as other application
 build scripts. Do not run typed-sql against an untrusted repository outside an appropriate sandbox.
 Live introspection should use a least-privilege, read-only database account where possible.
+
+## Repository and release controls
+
+- `main` accepts changes only through pull requests with an up-to-date branch, resolved
+  conversations, signed commits, linear history, and all required CI checks. Administrators are
+  subject to the same rules.
+- GitHub Actions run with read-only permissions by default. External actions are allowlisted,
+  required to use full commit SHAs, and maintained through Dependabot.
+- Dependency Review blocks pull requests that add high-severity vulnerable dependencies. CodeQL,
+  Dependabot security updates, secret scanning, and push protection are enabled.
+- npm publication uses the protected `npm` environment and trusted publishing through OIDC. Package
+  publishing requires 2FA and rejects traditional automation tokens.
+- Published `@typed-sql/*` GitHub tags cannot be deleted or moved.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,11 @@ Install one dialect and its application-owned driver, then create `typed-sql.con
 the [root guide](https://github.com/Lojhan/typed-sql#configure-the-database-contract).
 
 ```sh
+pnpm exec typed-sql --help
+pnpm exec typed-sql --version
+```
+
+```sh
 # Introspect the configured database and write schema metadata.
 pnpm exec typed-sql generate
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
   "publishConfig": { "access": "public" },
   "type": "module",
   "bin": { "typed-sql": "./dist/packages/cli/src/cli.js" },
+  "scripts": { "test": "poku test --reporter=compact --enforce" },
   "dependencies": {
     "@typed-sql/compiler": "workspace:*",
     "@typed-sql/config": "workspace:*",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, join, parse, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { checkFile } from "@typed-sql/compiler";
 import { fromConfig, loadConfig } from "@typed-sql/config";
 import type { SchemaSnapshot } from "@typed-sql/core";
@@ -13,6 +14,48 @@ import {
 interface ParsedArguments {
   readonly command?: string;
   readonly options: Readonly<Record<string, string>>;
+}
+
+const commands = new Set(["check", "generate", "drift"]);
+
+async function packageVersion(): Promise<string> {
+  let directory = dirname(fileURLToPath(import.meta.url));
+  const root = parse(directory).root;
+  while (directory !== root) {
+    try {
+      const manifest = JSON.parse(await readFile(join(directory, "package.json"), "utf8")) as {
+        readonly name?: string;
+        readonly version?: string;
+      };
+      if (manifest.name === "@typed-sql/cli" && manifest.version !== undefined) return manifest.version;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+    directory = dirname(directory);
+  }
+  throw new Error("Could not determine the @typed-sql/cli version");
+}
+
+function help(version: string): string {
+  return `typed-sql ${version}
+
+Usage:
+  typed-sql <command> [options]
+
+Commands:
+  check      Infer SQL result types and verify them with TypeScript 7
+  generate   Introspect or load a schema snapshot and generate the typed contract
+  drift      Compare the generated contract with the live database catalog
+
+Global options:
+  -h, --help       Show this help
+  -v, --version    Show the installed CLI version
+
+Examples:
+  typed-sql check --config typed-sql.config.ts --file src/query.ts --project tsconfig.json
+  typed-sql generate --config typed-sql.config.ts --out generated/db
+  typed-sql drift --config typed-sql.config.ts
+`;
 }
 
 function parseArguments(args: readonly string[]): ParsedArguments {
@@ -44,7 +87,21 @@ async function readSnapshot(path: string, validate: (value: unknown) => SchemaSn
 }
 
 async function main(): Promise<void> {
-  const parsed = parseArguments(process.argv.slice(2));
+  const args = process.argv.slice(2);
+  const version = await packageVersion();
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(help(version));
+    return;
+  }
+  if (args.includes("--version") || args.includes("-v")) {
+    process.stdout.write(`${version}\n`);
+    return;
+  }
+
+  const parsed = parseArguments(args);
+  if (parsed.command === undefined || !commands.has(parsed.command)) {
+    throw new Error(`Unknown command ${parsed.command ?? "<none>"}. Run typed-sql --help for usage.`);
+  }
   const loaded = await loadConfig({ ...(parsed.options.config === undefined ? {} : { file: parsed.options.config }) });
   const config = loaded.config;
   const dialect = config.dialect;
@@ -95,10 +152,6 @@ async function main(): Promise<void> {
     } else process.stdout.write("No schema drift detected\n");
     return;
   }
-
-  process.stdout.write("typed-sql check --config typed-sql.config.ts --file <query.ts> [--project tsconfig.json]\n");
-  process.stdout.write("typed-sql generate --config typed-sql.config.ts [--out <directory>]\n");
-  process.stdout.write("typed-sql drift --config typed-sql.config.ts\n");
 }
 
 main().catch((error: unknown) => {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,66 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, it, strict } from "poku";
+
+const execFile = promisify(execFileCallback);
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(packageDirectory, "src", "cli.ts");
+const tsx = fileURLToPath(import.meta.resolve("tsx"));
+const version = (JSON.parse(await readFile(join(packageDirectory, "package.json"), "utf8")) as {
+  readonly version: string;
+}).version;
+
+async function execute(args: readonly string[], cwd: string) {
+  return execFile(process.execPath, ["--import", tsx, cli, ...args], { cwd });
+}
+
+await describe("typed-sql CLI discovery-free commands", async () => {
+  await it("shows help without requiring a project config", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-cli-"));
+    try {
+      for (const args of [[], ["--help"], ["-h"], ["generate", "--help"]]) {
+        const result = await execute(args, temporary);
+        strict.match(result.stdout, new RegExp(`typed-sql ${version}`, "u"));
+        strict.match(result.stdout, /Usage:\n  typed-sql <command> \[options\]/u);
+        strict.match(result.stdout, /check[\s\S]*generate[\s\S]*drift/u);
+        strict.strictEqual(result.stderr, "");
+      }
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("shows the installed package version without requiring a project config", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-cli-"));
+    try {
+      for (const flag of ["--version", "-v"]) {
+        const result = await execute([flag], temporary);
+        strict.strictEqual(result.stdout, `${version}\n`);
+        strict.strictEqual(result.stderr, "");
+      }
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("rejects unknown commands before config discovery", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-cli-"));
+    try {
+      await strict.rejects(
+        execute(["unknown"], temporary),
+        (error: unknown) => {
+          if (!(error instanceof Error && "stderr" in error)) return false;
+          strict.match(String(error.stderr), /Unknown command unknown/u);
+          strict.ok(!String(error.stderr).includes("typed-sql.config.ts"));
+          return true;
+        },
+      );
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../packages/postgres" },
     { "path": "../packages/mysql" },
     { "path": "../packages/compiler" },
+    { "path": "../packages/cli" },
     { "path": "../packages/ts-bridge" },
     { "path": "../packages/language-server" }
   ]


### PR DESCRIPTION
## Summary

- make CLI help and version commands config-independent
- add Poku subprocess regression coverage and a CLI patch changeset
- pin GitHub Actions to immutable commits
- add Dependency Review, Dependabot, and CODEOWNERS
- document repository and npm release controls

## Verification

- pnpm verify
- built CLI help and version smoke tests

## Release impact

- CLI patch release through the beta Changesets flow