### PR TITLE
Fix independently versioned beta publishing

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -156,11 +156,12 @@ OIDC, publish under `next`, create annotated GitHub tags/releases, and attach np
 Changesets normally requires its prerelease identifier (`beta`) to also be the npm dist-tag. The
 repository therefore uses Changesets for versioning, changelogs, and release tags, but publishes the
 registry graph through a small manifest-driven adapter. It publishes each package in
-`release-manifest.json` order under `next`, skips exact versions already present on npm so a failed
-run can be retried safely, and creates tags only after the entire graph succeeds. pnpm packs each
-workspace package so `workspace:` ranges are resolved, then npm 12 publishes that immutable tarball
-through its native OIDC exchange. The workflow deliberately omits setup-node's `registry-url` option
-so its generated token placeholder cannot suppress that exchange.
+`release-manifest.json` order under `next`, permits independently versioned packages, skips exact
+versions already present on npm so a failed run can be retried safely, and creates tags only after
+the entire graph succeeds. pnpm packs each workspace package so `workspace:` ranges are resolved,
+then npm 12 publishes that immutable tarball through its native OIDC exchange. The workflow
+deliberately omits setup-node's `registry-url` option so its generated token placeholder cannot
+suppress that exchange.
 
 ```sh
 npm view @typed-sql/core@next version dist.tarball

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,8 +50,9 @@ in GitHub or the repository.
 Beta registry publication is intentionally separate from Changesets' prerelease publish planner.
 The planner cannot represent `-beta.N` versions published under the independent `next` dist-tag.
 `release:beta` instead follows `release-manifest.json` deterministically, checks npm before every
-write for retry safety, packs workspace-resolved tarballs with pnpm, publishes them through npm's
-native OIDC client, and asks Changesets to create tags only after every package is published.
+write for retry safety, supports independently versioned packages in the same release graph, packs
+workspace-resolved tarballs with pnpm, publishes them through npm's native OIDC client, and asks
+Changesets to create tags only after every package is published.
 
 After trusted publishing is operational, package settings should require 2FA and disallow
 traditional tokens. See [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/).

--- a/scripts/publish-prerelease.mjs
+++ b/scripts/publish-prerelease.mjs
@@ -58,8 +58,6 @@ export async function loadPrereleasePlan(workspace = defaultWorkspace) {
     packages.push({ name: manifest.name, version: manifest.version, directory });
   }
 
-  const versions = new Set(packages.map(({ version }) => version));
-  if (versions.size !== 1) throw new Error(`Release packages disagree on version: ${[...versions].join(", ")}`);
   return { npmTag: release.npmTag, packages };
 }
 

--- a/test/contracts/release-publisher.test.ts
+++ b/test/contracts/release-publisher.test.ts
@@ -88,7 +88,7 @@ await describe("prerelease publisher", async () => {
     strict.deepStrictEqual(events, ["publish:@typed-sql/core", "publish:@typed-sql/ast"]);
   });
 
-  await it("loads and validates the declared package graph", async () => {
+  await it("loads independently versioned packages in the declared graph", async () => {
     const temporary = await mkdtemp(join(tmpdir(), "typed-sql-publish-"));
     try {
       await writeFile(join(temporary, "release-manifest.json"), JSON.stringify({
@@ -97,18 +97,18 @@ await describe("prerelease publisher", async () => {
         npmTag: "next",
         packages: ["@typed-sql/core", "@typed-sql/ast"],
       }));
-      for (const name of ["core", "ast"]) {
+      for (const [name, version] of [["core", "1.0.0-beta.1"], ["ast", "1.0.0-beta.2"]] as const) {
         const directory = join(temporary, "packages", name);
         await mkdir(directory, { recursive: true });
         await writeFile(join(directory, "package.json"), JSON.stringify({
           name: `@typed-sql/${name}`,
-          version: "1.0.0-beta.2",
+          version,
         }));
       }
       strict.deepStrictEqual(await loadPrereleasePlan(temporary), {
         npmTag: "next",
         packages: [
-          { name: "@typed-sql/core", version: "1.0.0-beta.2", directory: join(temporary, "packages", "core") },
+          { name: "@typed-sql/core", version: "1.0.0-beta.1", directory: join(temporary, "packages", "core") },
           { name: "@typed-sql/ast", version: "1.0.0-beta.2", directory: join(temporary, "packages", "ast") },
         ],
       });


### PR DESCRIPTION
## Summary
- allow packages in the beta release graph to carry independent prerelease numbers
- retain per-package version validation and retry-safe registry checks
- add a Poku regression test for mixed beta versions
- document the independent-version release contract

## Verification
- PATH=/Users/viniciuslojhan/.nvm/versions/node/v24.10.0/bin:$PATH pnpm verify

This fixes the failed protected beta.2 publish run: https://github.com/Lojhan/typed-sql/actions/runs/32799060941