### PR TITLE
fix: harden parsers and CI security

### DIFF
--- a/.changeset/security-parsers-and-actions.md
+++ b/.changeset/security-parsers-and-actions.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/compiler": patch
+"@typed-sql/mysql": patch
+"@typed-sql/language-server": patch
+---
+
+Replace potentially expensive parser regular expressions with bounded scanners, tighten editor
+completion matching, and prevent releases while high-severity CodeQL alerts remain open.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: cargo
     directory: /editors/zed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,19 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
 
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.11
           cache: pnpm
@@ -39,11 +39,11 @@ jobs:
   postgres-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.11
           cache: pnpm
@@ -55,11 +55,11 @@ jobs:
   mysql-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.11
           cache: pnpm
@@ -71,11 +71,11 @@ jobs:
   packed-real-databases:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.11
           cache: pnpm
@@ -87,11 +87,11 @@ jobs:
   editor-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.11
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.14
           cache: pnpm
@@ -58,14 +58,15 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      security-events: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           package-manager-cache: false
@@ -76,6 +77,10 @@ jobs:
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
       - run: pnpm audit --prod --audit-level high
+      - name: Assert CodeQL release policy
+        run: pnpm release:security
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Assert beta release contract
         if: inputs.channel == 'beta'
         run: pnpm release:assert beta

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -29,6 +29,7 @@ Publishing is blocked unless all of these pass:
 - isolated tarball installation without database drivers;
 - real PostgreSQL and MySQL generation, inference, execution, and drift flows;
 - packed real-database consumers with no workspace links;
+- no open critical- or high-severity CodeQL alert;
 - production dependency audit with no high-severity advisory.
 
 ## Trusted publishing

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -1,0 +1,252 @@
+# Stable 1.0 Release Plan
+
+This document tracks the work required before publishing the first stable typed-sql release. It is
+more detailed than [`RELEASING.md`](./RELEASING.md): that document defines the release mechanism,
+while this one defines the temporary path from the current beta to `1.0.0`.
+
+## Current position
+
+The package architecture, PostgreSQL and MySQL integrations, test infrastructure, trusted npm
+publishing, provenance, security release enforcement, and repository protections are in place. The
+current public release line is `1.0.0-beta.*` under the npm `next` tag.
+
+The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
+of a complete registry-only consumer test, an unrehearsed stable version transition, and
+insufficient external beta soak time. The editor and public query API boundaries must also be
+decided before the 1.0 contract is frozen.
+
+## Definition of ready
+
+The stable release is ready when all of the following are true:
+
+- a clean external project installs typed-sql exclusively from npm and passes the PostgreSQL,
+  MySQL, TypeScript, generation, execution, drift, server, and editor scenarios;
+- the complete prerelease-to-stable transition has been rehearsed without publishing;
+- the intended stable packages are exactly `1.0.0`, with correct internal dependency ranges,
+  changelogs, exports, declarations, and tarball contents;
+- an RC has been exercised in independent projects for the agreed soak period;
+- no open correctness issue can cause typed-sql to confidently report an incorrect row type;
+- the stability boundary for the TypeScript preview bridge and editor tooling is explicit;
+- the public query and parameter-typing contract is intentionally frozen;
+- protected CI passes on the exact commit that is published;
+- npm `latest`, GitHub tags, GitHub releases, and provenance all agree on the stable version.
+
+## Milestone 1: Prove a registry-only user installation
+
+The external playground currently installs local `vendor` tarballs and uses pnpm overrides. This is
+useful for packed-artifact testing, but it does not prove that the published npm graph works exactly
+as a user receives it.
+
+Create a clean registry mode in `typed-sql-playground` that:
+
+- installs `@typed-sql/*@next` from npm;
+- contains no workspace links, `file:` dependencies, local tarballs, or typed-sql overrides;
+- starts fresh from an empty `node_modules` and a newly resolved lockfile;
+- installs database drivers only in the consumer project;
+- generates PostgreSQL and MySQL artifacts from real schemas;
+- typechecks with the supported TypeScript 7 version;
+- verifies exact inferred result types for simple and complex queries;
+- exercises CTEs, joins, aliases, nullable relations, enums, database functions, and parameters;
+- executes the generated queries against real PostgreSQL and MySQL containers;
+- exercises the fake GET server and verifies its response type and runtime output;
+- detects schema drift for both dialects;
+- starts the language server from the installed package;
+- verifies the documented Zed and VS Code installation paths outside the monorepo.
+
+Acceptance criteria:
+
+- one reproducible command provisions databases, installs registry packages, generates artifacts,
+  typechecks, executes runtime tests, checks drift, and shuts down cleanly;
+- the test fails if any typed-sql package resolves from the repository or local filesystem;
+- the installed package graph contains no database driver unless the consumer selected it;
+- editor hover output shows the same exact row types as the compiler result.
+
+## Milestone 2: Decide the 1.0 package boundary
+
+The core inference path targets TypeScript 7, while `@typed-sql/ts-bridge` currently uses a
+TypeScript 7.1 development snapshot and the editor integrations still have development-oriented
+installation paths. A stable version must not imply a stronger compatibility promise than the
+upstream API allows.
+
+Recommended decision:
+
+- stabilize `@typed-sql/core`, `ast`, `schema`, `config`, `compiler`, `postgres`, `mysql`, and `cli`;
+- keep `@typed-sql/ts-bridge` and `@typed-sql/language-server` explicitly experimental until the
+  TypeScript API they require is stable;
+- keep editor extensions experimental until their supported installation and upgrade paths are
+  tested outside the repository;
+- update the release manifest and assertions to support separate stable and experimental release
+  trains.
+
+Alternative decision:
+
+- delay every package's `1.0.0` until the TypeScript 7.1 bridge API and editor distribution are
+  stable enough to support as part of the same contract.
+
+Acceptance criteria:
+
+- the selected package boundary is represented in release automation, manifests, documentation,
+  compatibility tables, and npm dist-tags;
+- experimental packages are unmistakably labeled and do not receive a misleading stable tag;
+- supported editors have a user-facing installation procedure that does not rely on the monorepo.
+
+## Milestone 3: Freeze the public query contract
+
+Typed result rows are the core 1.0 feature. Interpolated parameter values still cross parts of the
+public API as `unknown`, so the future parameter-typing direction must be decided before freezing
+`Query<Row>`.
+
+Decision options:
+
+1. Introduce a future-compatible parameter type now, such as `Query<Row, Parameters>`, even if the
+   first stable compiler cannot infer every parameter.
+2. Keep `Query<Row>` for 1.0 and explicitly document parameter inference as a post-1.0 feature,
+   after proving that it can be added without breaking existing consumers.
+
+Work:
+
+- inventory every public export and generic type in all intended stable packages;
+- write public type-contract tests for query construction, execution, adapters, and generated APIs;
+- prove the chosen parameter evolution path with a small compatibility prototype;
+- document the supported SQL/type behavior and the deliberately unsupported cases;
+- classify confidently wrong inferred types as release-blocking correctness defects.
+
+Acceptance criteria:
+
+- the parameter-typing decision is documented and tested;
+- a future parameter feature does not require an avoidable breaking change;
+- all stable exports have intentional names, generic ordering, variance, and runtime behavior;
+- no generated-path import is required for the normal public API.
+
+## Milestone 4: Rehearse stable versioning and publication
+
+The repository remains in Changesets prerelease mode and `release-manifest.json` still declares the
+beta channel. The entire transition must be tested on a disposable branch or isolated worktree
+without publishing to npm.
+
+Rehearsal sequence:
+
+```sh
+pnpm changeset pre exit
+pnpm version-packages
+pnpm release:assert stable
+pnpm release:verify
+```
+
+The rehearsal must additionally inspect every `pnpm pack` result and simulate the stable publisher's
+package order and retry behavior.
+
+Work:
+
+- add automated coverage for the stable release path, not only the beta publisher;
+- test the current prerelease state before relying on `changeset pre exit`;
+- switch the rehearsed manifest to `channel: stable` and `npmTag: latest`;
+- ensure only the selected stable packages become exactly `1.0.0`;
+- verify internal dependency ranges resolve to the intended stable or experimental versions;
+- verify all package changelogs and the root release notes;
+- test interrupted and partially completed publication recovery;
+- confirm that a stable workflow dispatch cannot publish a beta version or use the `next` tag.
+
+Acceptance criteria:
+
+- the rehearsal produces a deterministic, reviewable diff;
+- `release:assert stable` and the complete CI suite pass;
+- clean tarball installations succeed without workspace metadata;
+- the stable publisher is safe to retry after any package boundary;
+- no command in the rehearsal writes to npm or creates a public GitHub release.
+
+## Milestone 5: Publish a final beta and release candidate
+
+After the security, registry-consumer, API, and release-path work is complete:
+
+1. publish the fixes as the next beta, expected to be `beta.3` or later;
+2. run the complete registry-only playground against that beta;
+3. publish `1.0.0-rc.0` under `next` once the beta is clean;
+4. test the RC in independent projects that do not share the monorepo configuration;
+5. allow an agreed soak period, recommended as one to two weeks;
+6. require at least three representative consumers across PostgreSQL, MySQL, and editor usage;
+7. publish another RC whenever a release-blocking fix changes generated output, inference,
+   runtime contracts, package exports, or release mechanics.
+
+During the soak, track:
+
+- incorrect inferred types;
+- valid queries rejected by the compiler;
+- invalid queries accepted without diagnostics;
+- introspection or generation nondeterminism;
+- driver/version interoperability;
+- package installation and export failures;
+- language-server crashes or editor configuration failures;
+- documentation gaps that prevent a clean installation.
+
+Acceptance criteria:
+
+- the agreed soak period completes without an unresolved release-blocking issue;
+- all representative projects can upgrade using only npm versions;
+- generated output is deterministic and checked into consumers without unexplained churn;
+- every reported correctness issue has a regression test before resolution.
+
+## Milestone 6: Repository and documentation cleanup
+
+Before the stable version PR:
+
+- remove the stale deleted-document reference from `.changeset/README.md`;
+- make the root README show the registry-first installation and stable package boundary;
+- ensure package READMEs describe only exports and commands that exist in their packed artifacts;
+- update compatibility documentation with exact TypeScript, Node.js, PostgreSQL, MySQL, pg, mysql2,
+  Zed, and VS Code support levels;
+- document which editor functionality is stable and which remains experimental;
+- verify every local documentation link and command from a clean checkout;
+- prepare concise stable release notes with known limitations and upgrade guidance.
+
+Acceptance criteria:
+
+- no stale roadmap, deleted-document, workspace-only, or prerelease instruction remains in stable
+  user documentation;
+- documentation commands pass when copied into a clean external project;
+- open dependency-update PRs have an explicit disposition before the version commit.
+
+## Milestone 7: Publish `1.0.0`
+
+Create a dedicated version PR only after every previous milestone is complete.
+
+Version PR checklist:
+
+- exit Changesets prerelease mode;
+- set the release manifest to the stable channel and `latest` npm tag;
+- set every selected stable package to exactly `1.0.0`;
+- preserve explicit prerelease versions for packages outside the stable boundary;
+- update every internal dependency range;
+- update package changelogs and release notes;
+- run the complete protected CI suite on the exact proposed commit;
+- review packed contents and install them in isolation;
+- obtain the required repository and npm environment approvals.
+
+After the version PR merges:
+
+1. dispatch the protected Release workflow with channel `stable`;
+2. verify every expected npm version and dist-tag;
+3. verify provenance and the trusted GitHub publisher identity for every package;
+4. verify immutable Git tags and the GitHub release point to the published commit;
+5. install `@typed-sql/*@latest` into a new empty project;
+6. rerun the registry-only PostgreSQL and MySQL smoke tests;
+7. verify that `next` remains intentional and does not unexpectedly replace `latest`;
+8. announce the stable release only after all registry and runtime checks pass.
+
+## Release sequence
+
+The intended order is:
+
+1. complete the registry-only playground;
+2. decide the package stability boundary;
+3. freeze the public query contract;
+4. rehearse the stable transition and recovery path;
+5. publish the final beta;
+6. publish and soak an RC in independent projects;
+7. finish repository and documentation cleanup;
+8. merge the stable version PR;
+9. publish and verify `1.0.0`.
+
+Stable promotion must stop if any step reveals a confidently wrong inferred type, an unsafe release
+path, a broken clean registry installation, or a security issue that meets the release-blocking
+threshold.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:pack": "poku test/contracts/packed-consumer.test.ts --reporter=compact --enforce",
     "release:artifacts": "pnpm build && pnpm test:pack",
     "release:assert": "node scripts/assert-release-channel.mjs",
+    "release:security": "node scripts/code-scanning-policy.mjs",
     "release:beta": "pnpm release:assert beta && node scripts/publish-prerelease.mjs",
     "release:stable": "pnpm release:assert stable && changeset publish --tag latest",
     "release:check": "pnpm verify && pnpm --filter @typed-sql/e2e-packed e2e && pnpm audit --prod --audit-level high",

--- a/packages/compiler/src/scanner.ts
+++ b/packages/compiler/src/scanner.ts
@@ -9,19 +9,107 @@ export interface ExtractedQuery {
   readonly sqlOffsetMap: readonly number[];
 }
 
-const importPattern = /import\s*\{([\s\S]*?)\}\s*from\s*["']([^"']+)["']/g;
+function isIdentifierStart(char: string | undefined): boolean {
+  if (char === undefined) return false;
+  const code = char.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122) || char === "_" || char === "$";
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  if (isIdentifierStart(char)) return true;
+  if (char === undefined) return false;
+  const code = char.charCodeAt(0);
+  return code >= 48 && code <= 57;
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\f" || char === "\v";
+}
+
+function identifierAt(source: string, start: number): { readonly value: string; readonly end: number } | undefined {
+  if (!isIdentifierStart(source[start])) return undefined;
+  let end = start + 1;
+  while (isIdentifierPart(source[end])) end += 1;
+  return { value: source.slice(start, end), end };
+}
+
+function skipTrivia(source: string, start: number): number {
+  let index = start;
+  while (index < source.length) {
+    if (isWhitespace(source[index])) index += 1;
+    else if (source[index] === "/" && source[index + 1] === "/") index = skipLineComment(source, index);
+    else if (source[index] === "/" && source[index + 1] === "*") index = skipBlockComment(source, index);
+    else break;
+  }
+  return index;
+}
+
+function closingImportBrace(source: string, start: number): number | undefined {
+  let depth = 1;
+  let index = start + 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '"' || char === "'") index = skipQuoted(source, index, char);
+    else if (char === "/" && source[index + 1] === "/") index = skipLineComment(source, index);
+    else if (char === "/" && source[index + 1] === "*") index = skipBlockComment(source, index);
+    else if (char === "{") { depth += 1; index += 1; }
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index;
+      index += 1;
+    } else index += 1;
+  }
+  return undefined;
+}
+
+function importedSqlName(specifier: string): string | undefined {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < specifier.length) {
+    index = skipTrivia(specifier, index);
+    const token = identifierAt(specifier, index);
+    if (token === undefined) { index += 1; continue; }
+    tokens.push(token.value);
+    index = token.end;
+  }
+  if (tokens[0] !== "sql") return undefined;
+  if (tokens.length === 1) return "sql";
+  return tokens[1] === "as" && tokens[2] !== undefined ? tokens[2] : undefined;
+}
 
 function importedSqlNames(source: string, sqlModules: ReadonlySet<string>): ReadonlySet<string> {
   const names = new Set<string>();
-  for (const match of source.matchAll(importPattern)) {
-    const specifiers = match[1];
-    const moduleName = match[2];
-    if (specifiers === undefined || moduleName === undefined) continue;
-    if (!sqlModules.has(moduleName)) continue;
-    for (const specifier of specifiers.split(",")) {
-      const parts = specifier.trim().split(/\s+as\s+/);
-      if (parts[0] === "sql") names.add(parts[1] ?? "sql");
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '"' || char === "'" || char === "`") { index = skipQuoted(source, index, char); continue; }
+    if (char === "/" && source[index + 1] === "/") { index = skipLineComment(source, index); continue; }
+    if (char === "/" && source[index + 1] === "*") { index = skipBlockComment(source, index); continue; }
+    const keyword = identifierAt(source, index);
+    if (keyword === undefined) { index += 1; continue; }
+    index = keyword.end;
+    if (keyword.value !== "import") continue;
+    let cursor = skipTrivia(source, index);
+    if (source[cursor] !== "{") continue;
+    const close = closingImportBrace(source, cursor);
+    if (close === undefined) break;
+    const specifiers = source.slice(cursor + 1, close);
+    cursor = skipTrivia(source, close + 1);
+    const from = identifierAt(source, cursor);
+    if (from?.value !== "from") continue;
+    cursor = skipTrivia(source, from.end);
+    const quote = source[cursor];
+    if (quote !== '"' && quote !== "'") continue;
+    const moduleEnd = skipQuoted(source, cursor, quote);
+    if (moduleEnd > source.length || source[moduleEnd - 1] !== quote) continue;
+    const moduleName = source.slice(cursor + 1, moduleEnd - 1);
+    if (sqlModules.has(moduleName)) {
+      for (const specifier of specifiers.split(",")) {
+        const localName = importedSqlName(specifier);
+        if (localName !== undefined) names.add(localName);
+      }
     }
+    index = moduleEnd;
   }
   return names;
 }
@@ -135,10 +223,10 @@ export function extractStaticQueries(
     if (char === "`" ) { index = skipQuoted(source, index, "`"); continue; }
     if (char === "/" && source[index + 1] === "/") { index = skipLineComment(source, index); continue; }
     if (char === "/" && source[index + 1] === "*") { index = skipBlockComment(source, index); continue; }
-    if (char !== undefined && /[A-Za-z_$]/.test(char)) {
+    if (isIdentifierStart(char)) {
       const start = index;
       index += 1;
-      while (index < source.length && /[A-Za-z0-9_$]/.test(source[index]!)) index += 1;
+      while (index < source.length && isIdentifierPart(source[index])) index += 1;
       const name = source.slice(start, index);
       if (!names.has(name)) continue;
       let cursor = index;

--- a/packages/compiler/test/compiler.test.ts
+++ b/packages/compiler/test/compiler.test.ts
@@ -43,6 +43,21 @@ await describe("TypeScript 7 compiler wrapper", async () => {
     strict.deepStrictEqual(extractStaticQueries('import { sql } from "@typed-sql/core"; // unterminated', placeholder), []);
   });
 
+  await it("parses multiline and commented SQL imports without regular-expression backtracking", () => {
+    const source = [
+      "import {",
+      "  type Query,",
+      "  sql /* public tag */ as",
+      "    query,",
+      '} from "@typed-sql/core";',
+      "const result = query`SELECT 1 AS value`;",
+    ].join("\n");
+    const extracted = extractStaticQueries(source, (index) => `$${index}`);
+    strict.strictEqual(extracted.length, 1);
+    strict.strictEqual(extracted[0]?.tagName, "query");
+    strict.strictEqual(extracted[0]?.sql, "SELECT 1 AS value");
+  });
+
   await it("injects an inferred row type without changing SQL text", async () => {
     const schema = await loadSchemaSnapshot(schemaPath);
     const source = 'import { sql } from "@typed-sql/postgres";\nconst q = sql`SELECT id FROM users`;';

--- a/packages/compiler/test/performance.test.ts
+++ b/packages/compiler/test/performance.test.ts
@@ -1,7 +1,7 @@
 import { performance } from "node:perf_hooks";
 import { describe, it, strict } from "poku";
 import type { DialectPlugin, SchemaSnapshot } from "../../core/src/index.js";
-import { compileSource } from "../src/index.js";
+import { compileSource, extractStaticQueries } from "../src/index.js";
 
 const schema = { formatVersion: 1, dialect: "performance", tables: {} } as const satisfies SchemaSnapshot;
 const dialect: DialectPlugin<typeof schema, Record<string, never>> = {
@@ -37,5 +37,15 @@ await describe("compiler performance budget", async () => {
     const duration = performance.now() - start;
     strict.strictEqual(result.queries.length, 1_000);
     strict.ok(duration <= budget, `Compiler took ${duration.toFixed(1)}ms; budget is ${budget}ms`);
+  });
+
+  await it("rejects a large malformed import in linear time", () => {
+    const source = "import{{".repeat(100_000);
+    const budget = Number(process.env.TYPED_SQL_SCANNER_SECURITY_BUDGET_MS ?? "1000");
+    const start = performance.now();
+    const result = extractStaticQueries(source, (index) => `$${index}`);
+    const duration = performance.now() - start;
+    strict.deepStrictEqual(result, []);
+    strict.ok(duration <= budget, `Scanner took ${duration.toFixed(1)}ms; budget is ${budget}ms`);
   });
 });

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -215,7 +215,7 @@ export class TypedSqlLanguageService {
     cancelled(token);
     const source = document.getText();
     const before = source.slice(query.sourceRange.start, offset);
-    const qualifier = /([A-Za-z_$][\w$]*)\.[A-Za-z_$\w]*$/u.exec(before)?.[1];
+    const qualifier = /([A-Za-z_$][A-Za-z0-9_$]*)\.[A-Za-z0-9_$]*$/u.exec(before)?.[1];
     const aliasTable = qualifier === undefined ? undefined : this.#tableForAlias(
       source.slice(query.sourceRange.start, query.sourceRange.end), qualifier, result.snapshot,
     );

--- a/packages/mysql/src/type-policy.ts
+++ b/packages/mysql/src/type-policy.ts
@@ -18,15 +18,69 @@ export const defaultMySqlTypePolicy: MySqlTypePolicy = Object.freeze({
   unknown: "unknown",
 });
 
-const normalized = (value: string): string => value.trim().toLowerCase().replace(/\s+/gu, " ");
-const baseType = (value: string): string => normalized(value).replace(/\s+unsigned$/u, "").replace(/\(.*/u, "");
+function isTypeWhitespace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\f" || char === "\v";
+}
+
+function normalized(value: string): string {
+  const input = value.trim().toLowerCase();
+  let output = "";
+  let pendingSpace = false;
+  for (const char of input) {
+    if (isTypeWhitespace(char)) {
+      pendingSpace = output.length > 0;
+      continue;
+    }
+    if (pendingSpace) output += " ";
+    output += char;
+    pendingSpace = false;
+  }
+  return output;
+}
+
+function baseType(value: string): string {
+  let type = normalized(value);
+  if (type.endsWith(" unsigned")) type = type.slice(0, -" unsigned".length);
+  const parameters = type.indexOf("(");
+  return parameters === -1 ? type : type.slice(0, parameters);
+}
 
 function enumValues(databaseType: string): readonly string[] | undefined {
-  const match = /^enum\((.*)\)$/iu.exec(databaseType.trim());
-  if (match?.[1] === undefined) return undefined;
+  const type = databaseType.trim();
+  if (type.slice(0, 5).toLowerCase() !== "enum(" || !type.endsWith(")")) return undefined;
+  const body = type.slice(5, -1);
   const values: string[] = [];
-  const pattern = /'((?:''|\\.|[^'])*)'/gu;
-  for (const value of match[1].matchAll(pattern)) values.push(value[1]!.replaceAll("''", "'").replace(/\\(.)/gu, "$1"));
+  let index = 0;
+  while (index < body.length) {
+    while (index < body.length && isTypeWhitespace(body[index]!)) index += 1;
+    if (body[index] !== "'") return undefined;
+    index += 1;
+    let value = "";
+    let closed = false;
+    while (index < body.length) {
+      const char = body[index]!;
+      if (char === "\\" && index + 1 < body.length) {
+        value += body[index + 1]!;
+        index += 2;
+      } else if (char === "'" && body[index + 1] === "'") {
+        value += "'";
+        index += 2;
+      } else if (char === "'") {
+        closed = true;
+        index += 1;
+        break;
+      } else {
+        value += char;
+        index += 1;
+      }
+    }
+    if (!closed) return undefined;
+    values.push(value);
+    while (index < body.length && isTypeWhitespace(body[index]!)) index += 1;
+    if (index === body.length) break;
+    if (body[index] !== ",") return undefined;
+    index += 1;
+  }
   return values;
 }
 

--- a/packages/mysql/test/mysql.test.ts
+++ b/packages/mysql/test/mysql.test.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { describe, it, strict } from "poku";
 import { parseStatement } from "../../ast/src/index.js";
 import type { SchemaSnapshot } from "../../schema/src/index.js";
@@ -130,5 +131,20 @@ await describe("MySQL dialect", async () => {
     strict.strictEqual(mapMySqlType("mystery", defaultMySqlTypePolicy), "unknown");
     strict.strictEqual(isKnownMySqlType("varchar(100)"), true);
     strict.strictEqual(isKnownMySqlType("mystery"), false);
+  });
+
+  await it("parses escaped enums and hostile catalog types in linear time", () => {
+    strict.strictEqual(
+      mapMySqlType(String.raw`enum('back\\slash','quote\'d','double''quote')`, defaultMySqlTypePolicy),
+      '"back\\\\slash" | "quote\'d" | "double\'quote"',
+    );
+    const malformedEnum = `enum('${"\\\\".repeat(100_000)}missing-close)`;
+    const spacedType = `bigint${" ".repeat(100_000)}signed`;
+    const budget = Number(process.env.TYPED_SQL_MYSQL_TYPE_SECURITY_BUDGET_MS ?? "1000");
+    const start = performance.now();
+    strict.strictEqual(mapMySqlType(malformedEnum, defaultMySqlTypePolicy), "unknown");
+    strict.strictEqual(mapMySqlType(spacedType, defaultMySqlTypePolicy), "unknown");
+    const duration = performance.now() - start;
+    strict.ok(duration <= budget, `MySQL type parsing took ${duration.toFixed(1)}ms; budget is ${budget}ms`);
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -150,7 +150,7 @@ async function provideCompletionItems(document: vscode.TextDocument, position: v
   const query = queryAtPosition(result.analysis, offset);
   if (query === undefined) return [];
   const before = document.getText().slice(query.sourceRange.start, offset);
-  const qualifier = /([A-Za-z_$][\w$]*)\.[A-Za-z_$\w]*$/u.exec(before)?.[1];
+  const qualifier = /([A-Za-z_$][A-Za-z0-9_$]*)\.[A-Za-z0-9_$]*$/u.exec(before)?.[1];
   const selected = qualifier === undefined ? undefined : tableForAlias(document.getText().slice(query.sourceRange.start, query.sourceRange.end), qualifier, result.snapshot);
   const tables = selected === undefined ? Object.values(result.snapshot.tables) : [selected];
   const items = new Map<string, vscode.CompletionItem>();

--- a/scripts/code-scanning-policy.d.mts
+++ b/scripts/code-scanning-policy.d.mts
@@ -1,0 +1,30 @@
+export interface CodeScanningAlert {
+  readonly number?: number;
+  readonly rule?: {
+    readonly id?: string;
+    readonly security_severity_level?: string;
+  };
+  readonly most_recent_instance?: {
+    readonly location?: {
+      readonly path?: string;
+    };
+  };
+}
+
+export interface CodeScanningPolicyOptions {
+  readonly repository?: string;
+  readonly token?: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+export function blockingCodeScanningAlerts(
+  alerts: readonly CodeScanningAlert[],
+): readonly CodeScanningAlert[];
+export function fetchOpenCodeScanningAlerts(
+  repository: string,
+  options?: CodeScanningPolicyOptions,
+): Promise<readonly CodeScanningAlert[]>;
+export function assertCodeScanningPolicy(
+  options?: CodeScanningPolicyOptions,
+): Promise<{ readonly open: number; readonly blocking: 0 }>;
+export function main(): Promise<void>;

--- a/scripts/code-scanning-policy.mjs
+++ b/scripts/code-scanning-policy.mjs
@@ -1,0 +1,69 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const blockingSeverities = new Set(["critical", "high"]);
+
+export function blockingCodeScanningAlerts(alerts) {
+  return alerts.filter((alert) => blockingSeverities.has(alert.rule?.security_severity_level));
+}
+
+export async function fetchOpenCodeScanningAlerts(repository, options = {}) {
+  const repositoryParts = repository.split("/");
+  if (repositoryParts.length !== 2 || repositoryParts.some((part) => part.length === 0)) {
+    throw new Error(`Invalid GitHub repository name: ${repository}`);
+  }
+  const request = options.fetch ?? globalThis.fetch;
+  const token = options.token ?? process.env.GITHUB_TOKEN;
+  if (token === undefined || token.length === 0) throw new Error("GITHUB_TOKEN is required to inspect CodeQL alerts");
+  const alerts = [];
+  for (let page = 1; ; page += 1) {
+    const url = new URL(`https://api.github.com/repos/${repositoryParts.map(encodeURIComponent).join("/")}/code-scanning/alerts`);
+    url.searchParams.set("state", "open");
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+    const response = await request(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 500);
+      throw new Error(`GitHub code-scanning lookup failed (${response.status}): ${detail}`);
+    }
+    const pageAlerts = await response.json();
+    if (!Array.isArray(pageAlerts)) throw new Error("GitHub code-scanning response was not an array");
+    alerts.push(...pageAlerts);
+    if (pageAlerts.length < 100) return alerts;
+  }
+}
+
+export async function assertCodeScanningPolicy(options = {}) {
+  const repository = options.repository ?? process.env.GITHUB_REPOSITORY;
+  if (repository === undefined || repository.length === 0) throw new Error("GITHUB_REPOSITORY is required to inspect CodeQL alerts");
+  const alerts = await fetchOpenCodeScanningAlerts(repository, options);
+  const blocking = blockingCodeScanningAlerts(alerts);
+  if (blocking.length > 0) {
+    const summary = blocking.map((alert) => {
+      const severity = alert.rule?.security_severity_level ?? "unknown";
+      const rule = alert.rule?.id ?? "unknown-rule";
+      const location = alert.most_recent_instance?.location?.path ?? "unknown-location";
+      return `#${alert.number ?? "?"} ${severity} ${rule} at ${location}`;
+    }).join("\n");
+    throw new Error(`Release blocked by ${blocking.length} open high-severity CodeQL alert(s):\n${summary}`);
+  }
+  return { open: alerts.length, blocking: 0 };
+}
+
+export async function main() {
+  const result = await assertCodeScanningPolicy();
+  process.stdout.write(`CodeQL release policy verified: ${result.open} open alert(s), none high severity\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/contracts/code-scanning-policy.test.ts
+++ b/test/contracts/code-scanning-policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, strict } from "poku";
+import {
+  assertCodeScanningPolicy,
+  blockingCodeScanningAlerts,
+  fetchOpenCodeScanningAlerts,
+  type CodeScanningAlert,
+} from "../../scripts/code-scanning-policy.mjs";
+
+function alert(number: number, severity: string): CodeScanningAlert {
+  return {
+    number,
+    rule: { id: `test/rule-${number}`, security_severity_level: severity },
+    most_recent_instance: { location: { path: `src/file-${number}.ts` } },
+  };
+}
+
+await describe("CodeQL release policy", async () => {
+  await it("blocks critical and high alerts while allowing lower severities", () => {
+    strict.deepStrictEqual(
+      blockingCodeScanningAlerts([
+        alert(1, "critical"),
+        alert(2, "high"),
+        alert(3, "medium"),
+        alert(4, "low"),
+      ]).map((item) => item.number),
+      [1, 2],
+    );
+  });
+
+  await it("paginates through every open alert", async () => {
+    const pages = [
+      Array.from({ length: 100 }, (_, index) => alert(index + 1, "medium")),
+      [alert(101, "low")],
+    ];
+    const requestedPages: string[] = [];
+    const alerts = await fetchOpenCodeScanningAlerts("Lojhan/typed-sql", {
+      token: "test-token",
+      fetch: async (input) => {
+        const url = new URL(String(input));
+        requestedPages.push(url.searchParams.get("page") ?? "");
+        return Response.json(pages.shift() ?? []);
+      },
+    });
+    strict.strictEqual(alerts.length, 101);
+    strict.deepStrictEqual(requestedPages, ["1", "2"]);
+  });
+
+  await it("fails closed for alerts and API errors", async () => {
+    await strict.rejects(
+      assertCodeScanningPolicy({
+        repository: "Lojhan/typed-sql",
+        token: "test-token",
+        fetch: async () => Response.json([alert(11, "high")]),
+      }),
+      /#11 high test\/rule-11 at src\/file-11\.ts/u,
+    );
+    await strict.rejects(
+      fetchOpenCodeScanningAlerts("Lojhan/typed-sql", {
+        token: "test-token",
+        fetch: async () => new Response("forbidden", { status: 403 }),
+      }),
+      /lookup failed \(403\): forbidden/u,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- replace potentially expensive compiler and MySQL regex parsing with linear scanners
- tighten language-server and VS Code qualifier matching for all reported CodeQL locations
- add adversarial Poku regression tests and a fail-closed high-severity CodeQL release gate
- update SHA-pinned checkout to 7.0.1, setup-node to 7.0.0, and dependency-review-action to 5.0.0
- group future GitHub Actions Dependabot updates and advance the stable-release plan

Supersedes #4, #5, #6, and the unsigned branch in #11. The commit was created through GitHub’s native signing API to satisfy the protected branch policy.

## Verification

- `pnpm verify` on Node 24.10.0
- `pnpm audit --prod --audit-level high`
- targeted compiler, MySQL, language-server, and contract Poku suites
