### PR TITLE
Establish a fail-closed inference soundness corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The exact dialect boundaries are versioned in the
 The release gate exercises what users actually install:
 
 - package-owned Poku suites with 95% statement/line/function and 90% branch gates on critical code;
+- a cross-dialect fail-closed soundness corpus shared by grammars, compiler, CLI, bridge, and editor service;
 - deterministic Biome formatting, import organization, and recommended lint rules;
 - 2,000 deterministic parser fuzz inputs and explicit parser/token resource limits;
 - explicit compiler, structural-expansion, resolver-index, and query-rendering performance budgets;
@@ -340,6 +341,7 @@ pnpm e2e:packed
 
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Public API and stability boundary](./docs/PUBLIC_API.md)
+- [Inference soundness policy and corpus](./docs/SOUNDNESS.md)
 - [Compatibility and performance](./docs/COMPATIBILITY.md)
 - [Releasing](./docs/RELEASING.md)
 - [Diagnostic code registry](./packages/core/README.md#diagnostics)

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -103,6 +103,9 @@ application-owned driver loading and adapters are isolated under `/pg` and `/mys
   replace runtime validation at external trust boundaries.
 - Conditional structural analysis is finite and bounded by `compiler.maxStructuralVariants`.
 
+The release-blocking classification and cross-surface regression rules are defined in the
+[inference soundness policy](./SOUNDNESS.md).
+
 Diagnostic codes become stable at 1.0. Automation should depend on the exported code and registry,
 not English message text.
 

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -1,0 +1,67 @@
+# Inference soundness policy
+
+typed-sql's primary correctness rule is fail closed: a query may produce an exact type, a
+conservative `unknown`, or a stable diagnostic. It must never produce a plausible but confidently
+incorrect row or ordered parameter type.
+
+## Classification
+
+Every soundness-corpus case has one of three outcomes:
+
+- **Exact:** the complete row type, parameter tuple, result kind, and relevant nullability are known
+  and asserted exactly.
+- **Unknown:** analysis has insufficient evidence, so the uncertain row property or parameter
+  position is `unknown`. Warnings may explain the boundary, but `any` is forbidden.
+- **Diagnostic:** invalid, ambiguous, conflicting, stale, malformed, or unsupported SQL produces a
+  stable error code. The compiler emits no confident query overlay for that statement.
+
+A confidently incorrect inference is a release blocker. A conservative `unknown` is not a
+correctness defect, although expanding supported inference can still be a feature. Diagnostic
+message prose may improve without a major release; automation depends on codes and mapped ranges.
+
+## Corpus layers
+
+[`test/soundness/corpus.ts`](../test/soundness/corpus.ts) is the shared PostgreSQL/MySQL grammar
+matrix. It covers selects, aliases, joins and nullability, CTEs, correlated subqueries, aggregates,
+windows, catalog functions, casts, enums, DML results and commands, ordered and unconstrained
+parameters, stale schemas, ambiguous and duplicate output columns, unsupported dialect syntax, and
+malformed SQL.
+
+[`test/soundness/source-corpus.ts`](../test/soundness/source-corpus.ts) exercises ordinary
+TypeScript source. It covers exact row and parameter overlays, conditional projections and filters,
+fragment diagnostic mapping, incompatible structural parameter contexts, malformed fragments, and
+the deliberate `sql.dynamic()` escape to `Query<unknown>`.
+
+Thin Poku runners execute those same expectations through:
+
+- the PostgreSQL and MySQL grammar packages;
+- the grammar-neutral compiler;
+- the `typed-sql check` CLI process, including TypeScript 7 validation;
+- the TypeScript bridge and its transformed overlay;
+- the editor-facing language service, including hover and diagnostic ranges.
+
+The package `test` commands include their soundness files, so protected `pnpm verify` runs the
+corpus. Run only this gate with:
+
+```sh
+pnpm test:soundness
+```
+
+Each participating package also owns a direct command, for example:
+
+```sh
+pnpm --filter @typed-sql/postgres test:soundness
+pnpm --filter @typed-sql/mysql test:soundness
+pnpm --filter @typed-sql/compiler test:soundness
+```
+
+## Regression rule
+
+Every beta, RC, or stable correctness fix must add the smallest case that reproduces the defect.
+Use the raw SQL corpus when the behavior belongs to a grammar. Use the source corpus when it depends
+on template extraction, fragments, conditional structure, overlay generation, CLI behavior, or
+editor mapping. If the grammars intentionally differ, record both outcomes in the shared case.
+
+The regression must assert the former unsafe outcome cannot return: exact cases freeze the whole
+contract; unknown cases assert the uncertain position; diagnostic cases assert the code, severity,
+absence of a query overlay, and an original-source range.

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -12,8 +12,8 @@ current public release line is `1.0.0-beta.*` under the npm `next` tag.
 
 The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
 of a complete registry-only consumer test, an unrehearsed stable version transition, and
-insufficient external beta soak time. The editor and public query API boundaries must also be
-decided before the 1.0 contract is frozen.
+insufficient external beta soak time. Reproducible editor installation, runtime codec fidelity,
+grammar conformance, and performance budgets also remain open gates.
 
 ## Definition of ready
 
@@ -106,7 +106,13 @@ types have contract tests. Internal compiler structural helpers are no longer pa
 Ongoing work:
 
 - document the supported SQL/type behavior and the deliberately unsupported cases;
-- classify confidently wrong inferred types as release-blocking correctness defects.
+
+The fail-closed classification is enforced by the shared
+[inference soundness corpus](./SOUNDNESS.md). PostgreSQL and MySQL cases classify exact inference,
+conservative `unknown`, and stable diagnostics, while compiler, CLI, bridge, and editor runners
+assert equivalent transformed output and original-source diagnostic mapping. A confidently wrong
+inference is a release-blocking correctness defect, and every correction requires a minimal corpus
+regression.
 
 Acceptance criteria:
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "pnpm typecheck && pnpm --filter @typed-sql/e2e-postgres generate:snapshot && pnpm --filter @typed-sql/e2e-mysql generate:snapshot && pnpm --filter './packages/**' --if-present test && pnpm test:contracts",
     "test:contracts": "poku test/contracts --reporter=compact --enforce",
     "test:pack": "poku test/contracts/packed-consumer.test.ts --reporter=compact --enforce",
+    "test:soundness": "poku packages/postgres/test/soundness.test.ts packages/mysql/test/soundness.test.ts packages/compiler/test/soundness.test.ts packages/cli/test/soundness.test.ts packages/ts-bridge/test/soundness.test.ts packages/language-server/test/soundness.test.ts --reporter=compact --enforce",
     "release:artifacts": "pnpm build && pnpm test:pack",
     "release:assert": "node scripts/assert-release-channel.mjs",
     "release:security": "node scripts/code-scanning-policy.mjs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
     "typed-sql": "./dist/packages/cli/src/cli.js"
   },
   "scripts": {
-    "test": "poku test --reporter=compact --enforce"
+    "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce"
   },
   "dependencies": {
     "@typed-sql/compiler": "workspace:*",

--- a/packages/cli/test/soundness.test.ts
+++ b/packages/cli/test/soundness.test.ts
@@ -1,0 +1,114 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { compileSource } from "@typed-sql/compiler";
+import type { DialectPlugin, SchemaSnapshot } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import {
+  type SourceSoundnessCase,
+  sourceForDialect,
+  sourceSoundnessCorpus,
+} from "../../../test/soundness/source-corpus.js";
+import { type MySqlSchemaSnapshot, mysql } from "../../mysql/src/index.js";
+import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
+
+const execFile = promisify(execFileCallback);
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workspace = resolve(packageDirectory, "../..");
+const postgresDirectory = resolve(workspace, "e2e/postgres");
+const mysqlDirectory = resolve(workspace, "e2e/mysql");
+const postgresSchema = JSON.parse(
+  await readFile(resolve(postgresDirectory, "generated/db/schema.json"), "utf8"),
+) as PostgresSchemaSnapshot;
+const mysqlSchema = JSON.parse(
+  await readFile(resolve(mysqlDirectory, "generated/db/schema.json"), "utf8"),
+) as MySqlSchemaSnapshot;
+const cli = join(packageDirectory, "src", "cli.ts");
+const tsx = fileURLToPath(import.meta.resolve("tsx"));
+
+interface CliFixture<Snapshot extends SchemaSnapshot, Policy> {
+  readonly name: "postgres" | "mysql";
+  readonly directory: string;
+  readonly schema: Snapshot;
+  readonly dialect: DialectPlugin<Snapshot, Policy>;
+}
+
+async function execute(file: string, fixture: Pick<CliFixture<SchemaSnapshot, unknown>, "directory">) {
+  return execFile(
+    process.execPath,
+    [
+      "--import",
+      tsx,
+      cli,
+      "check",
+      "--config",
+      resolve(fixture.directory, "typed-sql.config.ts"),
+      "--file",
+      file,
+      "--project",
+      resolve(fixture.directory, "tsconfig.json"),
+    ],
+    { cwd: workspace },
+  );
+}
+
+async function verifyCase<Snapshot extends SchemaSnapshot, Policy>(
+  testCase: SourceSoundnessCase,
+  fixture: CliFixture<Snapshot, Policy>,
+  temporary: string,
+  index: number,
+): Promise<void> {
+  const source = sourceForDialect(testCase, fixture.name);
+  const file = resolve(temporary, `${index}-${testCase.id}.ts`);
+  await writeFile(file, source);
+  const compilation = compileSource({ source, schema: fixture.schema, dialect: fixture.dialect });
+  if (testCase.expectation.kind !== "diagnostic") {
+    const result = await execute(file, fixture);
+    strict.strictEqual(result.stderr, "");
+    return;
+  }
+
+  await strict.rejects(execute(file, fixture), (error: unknown) => {
+    if (!(error instanceof Error && "stderr" in error)) return false;
+    const stderr = String(error.stderr);
+    for (const diagnostic of compilation.diagnostics) {
+      strict.ok(
+        stderr.includes(
+          `${file}:${diagnostic.range.line}:${diagnostic.range.column} - ${diagnostic.severity} ${diagnostic.code}:`,
+        ),
+        stderr,
+      );
+    }
+    return true;
+  });
+}
+
+await describe("CLI soundness corpus parity", async () => {
+  const postgresTemporary = await mkdtemp(resolve(postgresDirectory, ".soundness-cli-"));
+  const mysqlTemporary = await mkdtemp(resolve(mysqlDirectory, ".soundness-cli-"));
+  try {
+    for (const [index, testCase] of sourceSoundnessCorpus.entries()) {
+      await it(`postgres: ${testCase.id}`, () =>
+        verifyCase(
+          testCase,
+          { name: "postgres", directory: postgresDirectory, schema: postgresSchema, dialect: postgres() },
+          postgresTemporary,
+          index,
+        ));
+      await it(`mysql: ${testCase.id}`, () =>
+        verifyCase(
+          testCase,
+          { name: "mysql", directory: mysqlDirectory, schema: mysqlSchema, dialect: mysql() },
+          mysqlTemporary,
+          index,
+        ));
+    }
+  } finally {
+    await Promise.all([
+      rm(postgresTemporary, { recursive: true, force: true }),
+      rm(mysqlTemporary, { recursive: true, force: true }),
+    ]);
+  }
+});

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -34,6 +34,7 @@
   "type": "module",
   "scripts": {
     "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce",
     "coverage": "poku test --coverage=@pokujs/c8 --coverageConfig=.c8rc.json --reporter=compact --enforce"
   },
   "exports": {

--- a/packages/compiler/test/soundness.test.ts
+++ b/packages/compiler/test/soundness.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "poku";
+import { assertSourceCompilation } from "../../../test/soundness/assert-source-corpus.js";
+import { sourceForDialect, sourceSoundnessCorpus } from "../../../test/soundness/source-corpus.js";
+import { type MySqlSchemaSnapshot, mysql } from "../../mysql/src/index.js";
+import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
+import { compileSource } from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const postgresSchema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/postgres/generated/db/schema.json"), "utf8"),
+) as PostgresSchemaSnapshot;
+const mysqlSchema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/mysql/generated/db/schema.json"), "utf8"),
+) as MySqlSchemaSnapshot;
+const postgresDialect = postgres();
+const mysqlDialect = mysql();
+
+await describe("compiler fail-closed source corpus", async () => {
+  for (const testCase of sourceSoundnessCorpus) {
+    await it(`postgres: ${testCase.id}`, () => {
+      const sourceCase = { ...testCase, source: sourceForDialect(testCase, "postgres") };
+      assertSourceCompilation(
+        sourceCase,
+        compileSource({ source: sourceCase.source, schema: postgresSchema, dialect: postgresDialect }),
+      );
+    });
+    await it(`mysql: ${testCase.id}`, () => {
+      const sourceCase = { ...testCase, source: sourceForDialect(testCase, "mysql") };
+      assertSourceCompilation(
+        sourceCase,
+        compileSource({ source: sourceCase.source, schema: mysqlSchema, dialect: mysqlDialect }),
+      );
+    });
+  }
+});

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce",
     "start": "node dist/packages/language-server/src/server.js --stdio"
   },
   "dependencies": {

--- a/packages/language-server/test/soundness.test.ts
+++ b/packages/language-server/test/soundness.test.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, it, strict } from "poku";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  type SourceSoundnessCase,
+  sourceForDialect,
+  sourceSoundnessCorpus,
+} from "../../../test/soundness/source-corpus.js";
+import { compileSource } from "../../compiler/src/index.js";
+import type { DialectPlugin, SchemaSnapshot } from "../../core/src/index.js";
+import { type MySqlSchemaSnapshot, mysql } from "../../mysql/src/index.js";
+import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
+import { TypedSqlLanguageService } from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const postgresDirectory = resolve(workspace, "e2e/postgres");
+const mysqlDirectory = resolve(workspace, "e2e/mysql");
+const postgresSchema = JSON.parse(
+  await readFile(resolve(postgresDirectory, "generated/db/schema.json"), "utf8"),
+) as PostgresSchemaSnapshot;
+const mysqlSchema = JSON.parse(
+  await readFile(resolve(mysqlDirectory, "generated/db/schema.json"), "utf8"),
+) as MySqlSchemaSnapshot;
+
+interface EditorFixture<Snapshot extends SchemaSnapshot, Policy> {
+  readonly name: "postgres" | "mysql";
+  readonly directory: string;
+  readonly schema: Snapshot;
+  readonly dialect: DialectPlugin<Snapshot, Policy>;
+  readonly service: TypedSqlLanguageService;
+}
+
+function editorService(directory: string): TypedSqlLanguageService {
+  return new TypedSqlLanguageService(workspace, {
+    configPath: resolve(directory, "typed-sql.config.ts"),
+    schemaPath: resolve(directory, "generated/db/schema.json"),
+    projectFile: resolve(directory, "tsconfig.json"),
+    nativePreview: false,
+  });
+}
+
+async function verifyCase<Snapshot extends SchemaSnapshot, Policy>(
+  fixture: EditorFixture<Snapshot, Policy>,
+  testCase: SourceSoundnessCase,
+  index: number,
+): Promise<void> {
+  const source = sourceForDialect(testCase, fixture.name);
+  const document = TextDocument.create(
+    pathToFileURL(resolve(fixture.directory, `.soundness-editor-${index}.ts`)).href,
+    "typescript",
+    1,
+    source,
+  );
+  const compilation = compileSource({ source, schema: fixture.schema, dialect: fixture.dialect });
+  const analysis = await fixture.service.analysis(document);
+  strict.ok(analysis !== undefined);
+  strict.strictEqual(analysis?.transformedSource, compilation.transformedSource);
+  strict.deepStrictEqual(analysis?.diagnostics, compilation.diagnostics);
+
+  const diagnostics = await fixture.service.diagnostics(document);
+  strict.strictEqual(diagnostics.length, compilation.diagnostics.length);
+  diagnostics.forEach((diagnostic, diagnosticIndex) => {
+    const expected = compilation.diagnostics[diagnosticIndex]!;
+    strict.strictEqual(diagnostic.code, expected.code);
+    strict.strictEqual(document.offsetAt(diagnostic.range.start), expected.range.start);
+    strict.strictEqual(document.offsetAt(diagnostic.range.end), expected.range.end);
+  });
+
+  if (testCase.expectation.kind === "exact" || testCase.expectation.kind === "structural") {
+    const queryOffset = source.indexOf("sql`") + 1;
+    const hover = await fixture.service.hover(document, document.positionAt(queryOffset));
+    const text = JSON.stringify(hover?.contents ?? "");
+    strict.ok(text.includes("Query<"), text);
+    strict.ok(!text.includes(": any"), text);
+  }
+}
+
+await describe("editor service soundness parity", async () => {
+  const postgresFixture = {
+    name: "postgres" as const,
+    directory: postgresDirectory,
+    schema: postgresSchema,
+    dialect: postgres(),
+    service: editorService(postgresDirectory),
+  };
+  const mysqlFixture = {
+    name: "mysql" as const,
+    directory: mysqlDirectory,
+    schema: mysqlSchema,
+    dialect: mysql(),
+    service: editorService(mysqlDirectory),
+  };
+  try {
+    for (const [index, testCase] of sourceSoundnessCorpus.entries()) {
+      await it(`postgres: ${testCase.id}`, () => verifyCase(postgresFixture, testCase, index));
+      await it(`mysql: ${testCase.id}`, () => verifyCase(mysqlFixture, testCase, index));
+    }
+  } finally {
+    await Promise.all([postgresFixture.service.close(), mysqlFixture.service.close()]);
+  }
+});

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -34,6 +34,7 @@
   "type": "module",
   "scripts": {
     "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce",
     "coverage": "poku test --coverage=@pokujs/c8 --coverageConfig=.c8rc.json --reporter=compact --enforce"
   },
   "exports": {

--- a/packages/mysql/test/soundness.test.ts
+++ b/packages/mysql/test/soundness.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "poku";
+import { assertSoundnessCase } from "../../../test/soundness/assert-corpus.js";
+import { soundnessCorpus } from "../../../test/soundness/corpus.js";
+import { type MySqlSchemaSnapshot, mysql } from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const schema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/mysql/generated/db/schema.json"), "utf8"),
+) as MySqlSchemaSnapshot;
+const dialect = mysql();
+
+await describe("MySQL fail-closed soundness corpus", async () => {
+  for (const testCase of soundnessCorpus) {
+    await it(`${testCase.family}: ${testCase.id}`, () => {
+      assertSoundnessCase("mysql", testCase.mysql, dialect, schema);
+    });
+  }
+});

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -34,6 +34,7 @@
   "type": "module",
   "scripts": {
     "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce",
     "coverage": "poku test --coverage=@pokujs/c8 --coverageConfig=.c8rc.json --reporter=compact --enforce"
   },
   "exports": {

--- a/packages/postgres/test/soundness.test.ts
+++ b/packages/postgres/test/soundness.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "poku";
+import { assertSoundnessCase } from "../../../test/soundness/assert-corpus.js";
+import { soundnessCorpus } from "../../../test/soundness/corpus.js";
+import { type PostgresSchemaSnapshot, postgres } from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const schema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/postgres/generated/db/schema.json"), "utf8"),
+) as PostgresSchemaSnapshot;
+const dialect = postgres();
+
+await describe("PostgreSQL fail-closed soundness corpus", async () => {
+  for (const testCase of soundnessCorpus) {
+    await it(`${testCase.family}: ${testCase.id}`, () => {
+      assertSoundnessCase("postgres", testCase.postgres, dialect, schema);
+    });
+  }
+});

--- a/packages/ts-bridge/package.json
+++ b/packages/ts-bridge/package.json
@@ -33,7 +33,8 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "test": "poku test --reporter=compact --enforce"
+    "test": "poku test --reporter=compact --enforce",
+    "test:soundness": "poku test/soundness.test.ts --reporter=compact --enforce"
   },
   "exports": {
     ".": "./dist/packages/ts-bridge/src/index.js",

--- a/packages/ts-bridge/test/soundness.test.ts
+++ b/packages/ts-bridge/test/soundness.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, strict } from "poku";
+import { assertSourceCompilation } from "../../../test/soundness/assert-source-corpus.js";
+import { sourceForDialect, sourceSoundnessCorpus } from "../../../test/soundness/source-corpus.js";
+import { compileSource } from "../../compiler/src/index.js";
+import { type MySqlSchemaSnapshot, mysql } from "../../mysql/src/index.js";
+import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
+import { analyzeSource } from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const postgresSchema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/postgres/generated/db/schema.json"), "utf8"),
+) as PostgresSchemaSnapshot;
+const mysqlSchema = JSON.parse(
+  await readFile(resolve(workspace, "e2e/mysql/generated/db/schema.json"), "utf8"),
+) as MySqlSchemaSnapshot;
+const postgresDialect = postgres();
+const mysqlDialect = mysql();
+
+function assertParity(
+  sourceCase: (typeof sourceSoundnessCorpus)[number],
+  compilation: ReturnType<typeof compileSource>,
+  bridge: ReturnType<typeof analyzeSource>,
+): void {
+  assertSourceCompilation(sourceCase, compilation);
+  strict.deepStrictEqual(bridge.diagnostics, compilation.diagnostics);
+  strict.deepStrictEqual(
+    bridge.queries.map(({ rowType, parameterType }) => ({ rowType, parameterType })),
+    compilation.queries.map(({ rowType, parameterType }) => ({ rowType, parameterType })),
+  );
+  strict.strictEqual(bridge.transformedSource, compilation.transformedSource);
+}
+
+await describe("TypeScript bridge soundness parity", async () => {
+  for (const testCase of sourceSoundnessCorpus) {
+    await it(`postgres: ${testCase.id}`, () => {
+      const sourceCase = { ...testCase, source: sourceForDialect(testCase, "postgres") };
+      assertParity(
+        sourceCase,
+        compileSource({ source: sourceCase.source, schema: postgresSchema, dialect: postgresDialect }),
+        analyzeSource(sourceCase.source, postgresSchema, postgresDialect),
+      );
+    });
+    await it(`mysql: ${testCase.id}`, () => {
+      const sourceCase = { ...testCase, source: sourceForDialect(testCase, "mysql") };
+      assertParity(
+        sourceCase,
+        compileSource({ source: sourceCase.source, schema: mysqlSchema, dialect: mysqlDialect }),
+        analyzeSource(sourceCase.source, mysqlSchema, mysqlDialect),
+      );
+    });
+  }
+});

--- a/test/soundness/assert-corpus.ts
+++ b/test/soundness/assert-corpus.ts
@@ -1,0 +1,50 @@
+import { type DialectPlugin, parameterTypeLiteral, rowTypeLiteral, type SchemaSnapshot } from "@typed-sql/core";
+import { strict } from "poku";
+import type { DialectSoundnessCase, SoundnessDialect, SoundnessExpectation } from "./corpus.js";
+
+function diagnosticCodes(expectation: SoundnessExpectation): readonly string[] {
+  if (expectation.kind === "diagnostic") return expectation.codes;
+  return expectation.kind === "unknown" ? (expectation.diagnosticCodes ?? []) : [];
+}
+
+export function assertSoundnessCase<Snapshot extends SchemaSnapshot, Policy>(
+  dialectName: SoundnessDialect,
+  testCase: DialectSoundnessCase,
+  dialect: DialectPlugin<Snapshot, Policy>,
+  schema: Snapshot,
+): void {
+  const sql = testCase.sql((index) => dialect.placeholder(index));
+  const analysis = dialect.analyze(sql, schema);
+  const actualCodes = analysis.diagnostics.map(({ code }) => code);
+  const errors = analysis.diagnostics.filter(({ severity }) => severity === "error");
+  const rowType = analysis.resultKind === "command" ? "never" : rowTypeLiteral(analysis.columns);
+  const parameterType = parameterTypeLiteral(testCase.parameterCount ?? 0, analysis.parameters);
+
+  strict.ok(!rowType.includes("any"), `${dialectName}/${sql} inferred an unsafe row: ${rowType}`);
+  strict.ok(!parameterType.includes("any"), `${dialectName}/${sql} inferred unsafe parameters: ${parameterType}`);
+  for (const diagnostic of analysis.diagnostics) {
+    strict.ok(diagnostic.range.start >= 0, `${dialectName}/${sql} produced a negative diagnostic start`);
+    strict.ok(diagnostic.range.end >= diagnostic.range.start, `${dialectName}/${sql} produced an inverted range`);
+    strict.ok(diagnostic.range.end <= sql.length, `${dialectName}/${sql} produced an out-of-bounds diagnostic`);
+  }
+
+  const expectation = testCase.expectation;
+  if (expectation.kind === "exact") {
+    strict.deepStrictEqual(errors, [], `${dialectName}/${sql} unexpectedly failed`);
+    strict.strictEqual(rowType, expectation.rowType, `${dialectName}/${sql} row type changed`);
+    strict.strictEqual(parameterType, expectation.parameterType, `${dialectName}/${sql} parameters changed`);
+    strict.strictEqual(analysis.resultKind ?? "rows", expectation.resultKind ?? "rows");
+    return;
+  }
+
+  for (const code of diagnosticCodes(expectation)) {
+    strict.ok(actualCodes.includes(code), `${dialectName}/${sql} did not produce ${code}: ${actualCodes.join(", ")}`);
+  }
+  if (expectation.kind === "diagnostic") {
+    strict.ok(errors.length > 0, `${dialectName}/${sql} must fail closed with an error`);
+    return;
+  }
+
+  const inferred = expectation.target === "row" ? rowType : parameterType;
+  strict.ok(inferred.includes("unknown"), `${dialectName}/${sql} must remain conservative: ${inferred}`);
+}

--- a/test/soundness/assert-source-corpus.ts
+++ b/test/soundness/assert-source-corpus.ts
@@ -1,0 +1,44 @@
+import { strict } from "poku";
+import type { CompileSourceResult } from "../../packages/compiler/src/index.js";
+import type { SourceSoundnessCase } from "./source-corpus.js";
+
+export function assertSourceCompilation(testCase: SourceSoundnessCase, compilation: CompileSourceResult): void {
+  strict.ok(!compilation.transformedSource.includes(": any"), `${testCase.id} introduced any`);
+  const expectation = testCase.expectation;
+  if (expectation.kind === "dynamic") {
+    strict.strictEqual(compilation.queries.length, 0);
+    strict.strictEqual(compilation.fragments.length, 0);
+    strict.deepStrictEqual(compilation.diagnostics, []);
+    strict.strictEqual(compilation.transformedSource, testCase.source);
+    return;
+  }
+  if (expectation.kind === "diagnostic") {
+    const codes = compilation.diagnostics.map(({ code }) => code);
+    for (const code of expectation.codes) strict.ok(codes.includes(code), `${testCase.id} did not produce ${code}`);
+    strict.ok(compilation.diagnostics.some(({ severity }) => severity === "error"));
+    strict.ok(
+      compilation.diagnostics.some(({ range }) =>
+        testCase.source.slice(range.start, range.end).includes(expectation.sourceTarget),
+      ),
+      `${testCase.id} did not map its diagnostic to ${expectation.sourceTarget}`,
+    );
+    strict.strictEqual(compilation.queries.length, 0, `${testCase.id} must not emit a confident query overlay`);
+    return;
+  }
+
+  strict.deepStrictEqual(compilation.diagnostics, []);
+  strict.strictEqual(compilation.queries.length, 1);
+  const query = compilation.queries[0]!;
+  if (expectation.kind === "exact") {
+    strict.strictEqual(query.rowType, expectation.rowType);
+    strict.strictEqual(query.parameterType, expectation.parameterType);
+    return;
+  }
+
+  strict.strictEqual(query.structural, true);
+  for (const value of expectation.rowIncludes) strict.ok(query.rowType.includes(value), query.rowType);
+  const parameterTypes = compilation.fragments.map(({ parameterType }) => parameterType);
+  for (const value of expectation.fragmentParameterTypes) {
+    strict.ok(parameterTypes.includes(value), `${testCase.id} did not infer fragment ${value}`);
+  }
+}

--- a/test/soundness/corpus.ts
+++ b/test/soundness/corpus.ts
@@ -1,0 +1,277 @@
+export type SoundnessDialect = "postgres" | "mysql";
+
+export type SoundnessExpectation =
+  | {
+      readonly kind: "exact";
+      readonly rowType: string;
+      readonly parameterType: string;
+      readonly resultKind?: "rows" | "command";
+    }
+  | {
+      readonly kind: "unknown";
+      readonly target: "row" | "parameters";
+      readonly diagnosticCodes?: readonly string[];
+    }
+  | {
+      readonly kind: "diagnostic";
+      readonly codes: readonly string[];
+    };
+
+export interface DialectSoundnessCase {
+  readonly sql: (placeholder: (index: number) => string) => string;
+  readonly parameterCount?: number;
+  readonly expectation: SoundnessExpectation;
+}
+
+export interface SoundnessCase {
+  readonly id: string;
+  readonly family: string;
+  readonly postgres: DialectSoundnessCase;
+  readonly mysql: DialectSoundnessCase;
+}
+
+const exact = (
+  rowType: string,
+  parameterType = "readonly []",
+  resultKind: "rows" | "command" = "rows",
+): SoundnessExpectation => ({ kind: "exact", rowType, parameterType, resultKind });
+
+const diagnostic = (...codes: readonly string[]): SoundnessExpectation => ({ kind: "diagnostic", codes });
+
+const unknown = (target: "row" | "parameters", diagnosticCodes: readonly string[] = []): SoundnessExpectation => ({
+  kind: "unknown",
+  target,
+  diagnosticCodes,
+});
+
+export const soundnessCorpus: readonly SoundnessCase[] = [
+  {
+    id: "select-columns",
+    family: "select",
+    postgres: {
+      sql: () => "SELECT users.id, users.email FROM users",
+      expectation: exact('{ "id": bigint; "email": string; }'),
+    },
+    mysql: {
+      sql: () => "SELECT users.id, users.email FROM users",
+      expectation: exact('{ "id": bigint; "email": string; }'),
+    },
+  },
+  {
+    id: "left-join-nullability",
+    family: "join",
+    postgres: {
+      sql: () => "SELECT users.id, projects.budget FROM users LEFT JOIN projects ON users.id = projects.owner_id",
+      expectation: exact('{ "id": bigint; "budget": string | null; }'),
+    },
+    mysql: {
+      sql: () => "SELECT users.id, projects.budget FROM users LEFT JOIN projects ON users.id = projects.owner_id",
+      expectation: exact('{ "id": bigint; "budget": string | null; }'),
+    },
+  },
+  {
+    id: "alias-and-enum",
+    family: "alias",
+    postgres: {
+      sql: () => "SELECT account.id AS account_id, account.status FROM users AS account",
+      expectation: exact('{ "account_id": bigint; "status": "active" | "suspended"; }'),
+    },
+    mysql: {
+      sql: () => "SELECT account.id AS account_id, account.status FROM users AS account",
+      expectation: exact('{ "account_id": bigint; "status": "active" | "suspended"; }'),
+    },
+  },
+  {
+    id: "common-table-expression",
+    family: "cte",
+    postgres: {
+      sql: () =>
+        "WITH selected AS (SELECT users.id, users.email FROM users) SELECT selected.id, selected.email FROM selected",
+      expectation: exact('{ "id": bigint; "email": string; }'),
+    },
+    mysql: {
+      sql: () =>
+        "WITH selected AS (SELECT users.id, users.email FROM users) SELECT selected.id, selected.email FROM selected",
+      expectation: exact('{ "id": bigint; "email": string; }'),
+    },
+  },
+  {
+    id: "correlated-subquery",
+    family: "subquery",
+    postgres: {
+      sql: () =>
+        "SELECT users.id, (SELECT projects.budget FROM projects WHERE projects.owner_id = users.id) AS budget FROM users",
+      expectation: exact('{ "id": bigint; "budget": string | null; }'),
+    },
+    mysql: {
+      sql: () =>
+        "SELECT users.id, (SELECT projects.budget FROM projects WHERE projects.owner_id = users.id) AS budget FROM users",
+      expectation: exact('{ "id": bigint; "budget": string | null; }'),
+    },
+  },
+  {
+    id: "aggregate-window",
+    family: "aggregate-window",
+    postgres: {
+      sql: () => "SELECT COUNT(*) OVER (PARTITION BY users.status) AS total FROM users",
+      expectation: exact('{ "total": bigint; }'),
+    },
+    mysql: {
+      sql: () => "SELECT COUNT(*) OVER (PARTITION BY users.status) AS total FROM users",
+      expectation: exact('{ "total": bigint; }'),
+    },
+  },
+  {
+    id: "catalog-function",
+    family: "function",
+    postgres: {
+      sql: () => "SELECT active_user_count() AS total",
+      expectation: exact('{ "total": bigint | null; }'),
+    },
+    mysql: {
+      sql: () => "SELECT user_count() AS total",
+      expectation: exact('{ "total": bigint | null; }'),
+    },
+  },
+  {
+    id: "dialect-cast",
+    family: "cast",
+    postgres: {
+      sql: () => "SELECT users.id::text AS id_text FROM users",
+      expectation: exact('{ "id_text": string; }'),
+    },
+    mysql: {
+      sql: () => "SELECT CAST(users.id AS CHAR) AS id_text FROM users",
+      expectation: exact('{ "id_text": string; }'),
+    },
+  },
+  {
+    id: "insert-returning",
+    family: "dml",
+    postgres: {
+      sql: (placeholder) =>
+        `INSERT INTO users (email, status) VALUES (${placeholder(1)}, ${placeholder(2)}) RETURNING id, status`,
+      parameterCount: 2,
+      expectation: exact(
+        '{ "id": bigint; "status": "active" | "suspended"; }',
+        'readonly [string, "active" | "suspended"]',
+      ),
+    },
+    mysql: {
+      sql: (placeholder) =>
+        `INSERT INTO users (email, status) VALUES (${placeholder(1)}, ${placeholder(2)}) RETURNING id, status`,
+      parameterCount: 2,
+      expectation: diagnostic("TSQ401"),
+    },
+  },
+  {
+    id: "update-command",
+    family: "dml",
+    postgres: {
+      sql: (placeholder) => `UPDATE users SET status = ${placeholder(1)} WHERE id = ${placeholder(2)}`,
+      parameterCount: 2,
+      expectation: exact("never", 'readonly ["active" | "suspended", bigint]', "command"),
+    },
+    mysql: {
+      sql: (placeholder) => `UPDATE users SET status = ${placeholder(1)} WHERE id = ${placeholder(2)}`,
+      parameterCount: 2,
+      expectation: exact("never", 'readonly ["active" | "suspended", bigint]', "command"),
+    },
+  },
+  {
+    id: "ordered-parameters",
+    family: "parameters",
+    postgres: {
+      sql: (placeholder) =>
+        `SELECT users.id FROM users WHERE users.status = ${placeholder(1)} AND users.id >= ${placeholder(2)}`,
+      parameterCount: 2,
+      expectation: exact('{ "id": bigint; }', 'readonly ["active" | "suspended", bigint]'),
+    },
+    mysql: {
+      sql: (placeholder) =>
+        `SELECT users.id FROM users WHERE users.status = ${placeholder(1)} AND users.id >= ${placeholder(2)}`,
+      parameterCount: 2,
+      expectation: exact('{ "id": bigint; }', 'readonly ["active" | "suspended", bigint]'),
+    },
+  },
+  {
+    id: "unconstrained-parameter",
+    family: "unknown",
+    postgres: {
+      sql: (placeholder) => `SELECT ${placeholder(1)} AS value`,
+      parameterCount: 1,
+      expectation: unknown("parameters"),
+    },
+    mysql: {
+      sql: (placeholder) => `SELECT ${placeholder(1)} AS value`,
+      parameterCount: 1,
+      expectation: unknown("parameters"),
+    },
+  },
+  {
+    id: "unknown-function",
+    family: "unknown",
+    postgres: {
+      sql: () => "SELECT unregistered_function(users.id) AS value FROM users",
+      expectation: unknown("row", ["TSQ202"]),
+    },
+    mysql: {
+      sql: () => "SELECT unregistered_function(users.id) AS value FROM users",
+      expectation: unknown("row", ["TSQ202"]),
+    },
+  },
+  {
+    id: "missing-column-stale-schema",
+    family: "diagnostic",
+    postgres: {
+      sql: () => "SELECT users.deleted_at FROM users",
+      expectation: diagnostic("TSQ101"),
+    },
+    mysql: {
+      sql: () => "SELECT users.deleted_at FROM users",
+      expectation: diagnostic("TSQ103"),
+    },
+  },
+  {
+    id: "ambiguous-column",
+    family: "diagnostic",
+    postgres: {
+      sql: () => "SELECT id FROM users JOIN projects ON users.id = projects.owner_id",
+      expectation: diagnostic("TSQ102"),
+    },
+    mysql: {
+      sql: () => "SELECT id FROM users JOIN projects ON users.id = projects.owner_id",
+      expectation: diagnostic("TSQ102"),
+    },
+  },
+  {
+    id: "duplicate-output-name",
+    family: "diagnostic",
+    postgres: {
+      sql: () => "SELECT users.id, projects.id FROM users JOIN projects ON users.id = projects.owner_id",
+      expectation: diagnostic("TSQ105"),
+    },
+    mysql: {
+      sql: () => "SELECT users.id, projects.id FROM users JOIN projects ON users.id = projects.owner_id",
+      expectation: diagnostic("TSQ105"),
+    },
+  },
+  {
+    id: "dialect-specific-filter",
+    family: "unsupported",
+    postgres: {
+      sql: () => "SELECT COUNT(*) FILTER (WHERE users.status = 'active') AS total FROM users",
+      expectation: exact('{ "total": bigint; }'),
+    },
+    mysql: {
+      sql: () => "SELECT COUNT(*) FILTER (WHERE users.status = 'active') AS total FROM users",
+      expectation: diagnostic("TSQ001"),
+    },
+  },
+  {
+    id: "malformed-query",
+    family: "diagnostic",
+    postgres: { sql: () => "SELECT users.id FROM users WHERE", expectation: diagnostic("TSQ001") },
+    mysql: { sql: () => "SELECT users.id FROM users WHERE", expectation: diagnostic("TSQ001") },
+  },
+] as const;

--- a/test/soundness/source-corpus.ts
+++ b/test/soundness/source-corpus.ts
@@ -1,0 +1,114 @@
+export type SourceSoundnessExpectation =
+  | {
+      readonly kind: "exact";
+      readonly rowType: string;
+      readonly parameterType: string;
+    }
+  | {
+      readonly kind: "structural";
+      readonly rowIncludes: readonly string[];
+      readonly fragmentParameterTypes: readonly string[];
+    }
+  | {
+      readonly kind: "diagnostic";
+      readonly codes: readonly string[];
+      readonly sourceTarget: string;
+    }
+  | { readonly kind: "dynamic" };
+
+export interface SourceSoundnessCase {
+  readonly id: string;
+  readonly source: string;
+  readonly expectation: SourceSoundnessExpectation;
+}
+
+export function sourceForDialect(testCase: SourceSoundnessCase, dialect: "postgres" | "mysql"): string {
+  return testCase.source.replace("@typed-sql/postgres", `@typed-sql/${dialect}`);
+}
+
+const moduleImport = 'import { sql } from "@typed-sql/postgres";';
+const interpolation = (expression: string): string => `\${${expression}}`;
+
+export const sourceSoundnessCorpus: readonly SourceSoundnessCase[] = [
+  {
+    id: "exact-row-and-ordered-parameters",
+    source: [
+      moduleImport,
+      'const status: "active" | "suspended" = "active";',
+      "const minimumId = 1n;",
+      `export const query = sql\`SELECT users.id, users.email, users.status FROM users WHERE users.status = ${interpolation("status")} AND users.id >= ${interpolation("minimumId")}\`;`,
+    ].join("\n"),
+    expectation: {
+      kind: "exact",
+      rowType: '{ "id": bigint; "email": string; "status": "active" | "suspended"; }',
+      parameterType: 'readonly ["active" | "suspended", bigint]',
+    },
+  },
+  {
+    id: "conditional-projection-and-filters",
+    source: [
+      moduleImport,
+      'interface Filters { readonly status?: "active" | "suspended" | null; readonly minimumId?: bigint | null }',
+      "interface AccountSelect { readonly status: boolean }",
+      "export function accounts<const Select extends AccountSelect>(filters: Filters, select: Select) {",
+      "  return sql`",
+      "    SELECT users.id, users.email",
+      `      ${interpolation("select.status ? sql.fragment`, users.status` : sql.empty")}`,
+      "    FROM users",
+      "    WHERE 1 = 1",
+      `      ${interpolation(
+        `filters.status == null ? sql.empty : sql.fragment\`AND users.status = ${interpolation("filters.status")}\``,
+      )}`,
+      `      ${interpolation(
+        `filters.minimumId == null ? sql.empty : sql.fragment\`AND users.id >= ${interpolation("filters.minimumId")}\``,
+      )}`,
+      "  `;",
+      "}",
+    ].join("\n"),
+    expectation: {
+      kind: "structural",
+      rowIncludes: ['Select["status"] extends true', '"id": bigint', '"email": string', '"status": "active"'],
+      fragmentParameterTypes: ['readonly ["active" | "suspended"]', "readonly [bigint]"],
+    },
+  },
+  {
+    id: "mapped-fragment-diagnostic",
+    source: [
+      moduleImport,
+      "const cutoff = new Date();",
+      `export const query = sql\`SELECT users.id FROM users WHERE 1 = 1 ${interpolation(
+        `sql.fragment\`AND deleted_at >= ${interpolation("cutoff")}\``,
+      )}\`;`,
+    ].join("\n"),
+    expectation: { kind: "diagnostic", codes: ["TSQ101"], sourceTarget: "deleted_at" },
+  },
+  {
+    id: "incompatible-structural-parameter-context",
+    source: [
+      moduleImport,
+      "declare const fromUsers: boolean;",
+      "declare const value: string | bigint;",
+      "export const query = sql`SELECT account.value FROM",
+      `  ${interpolation(
+        "fromUsers ? sql.fragment`(SELECT users.status AS value FROM users) AS account` : sql.fragment`(SELECT projects.owner_id AS value FROM projects) AS account`",
+      )}`,
+      `  WHERE 1 = 1 ${interpolation(`sql.fragment\`AND account.value = ${interpolation("value")}\``)}\`;`,
+    ].join("\n"),
+    expectation: { kind: "diagnostic", codes: ["TSQ205"], sourceTarget: "value" },
+  },
+  {
+    id: "malformed-structural-fragment",
+    source: [
+      moduleImport,
+      `export const query = sql\`SELECT users.id FROM users ${interpolation(
+        `sql.fragment\`AND users.id > ${interpolation("1n")}\``,
+      )}\`;`,
+    ].join("\n"),
+    expectation: { kind: "diagnostic", codes: ["TSQ001"], sourceTarget: "AND" },
+  },
+  {
+    id: "dynamic-query-remains-unknown",
+    source: [moduleImport, "declare const text: string;", "export const query = sql.dynamic(text);"].join("\n"),
+    expectation: { kind: "dynamic" },
+  },
+] as const;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "rootDir": ".."
   },
-  "include": ["../packages/*/test/**/*.test.ts", "contracts/**/*.test.ts"],
+  "include": ["../packages/*/test/**/*.test.ts", "contracts/**/*.test.ts", "soundness/**/*.ts"],
   "exclude": ["fixtures"],
   "references": [
     { "path": "../packages/core" },


### PR DESCRIPTION
## Summary

- add one shared PostgreSQL/MySQL corpus classifying exact inference, conservative `unknown`, and stable diagnostics
- cover selects, joins/nullability, aliases, CTEs, subqueries, aggregates, windows, functions, casts, enums, DML, parameters, ambiguity, stale schemas, unsupported syntax, and malformed SQL
- add a shared TypeScript-source corpus for structural projections/filters, mapped fragment diagnostics, incompatible parameter contexts, malformed fragments, and `sql.dynamic()`
- run equivalent assertions through grammar packages, compiler, CLI + TypeScript 7, bridge, and editor service
- expose root and per-package Poku soundness commands and document the release-blocking correctness policy

## Acceptance evidence

- no `any` and no confident overlay on error paths
- exact rows and ordered parameter tuples asserted in both grammars
- original source ranges asserted in compiler, CLI, and editor diagnostics
- dialect differences recorded explicitly in the shared matrix
- every future correctness fix requires a minimal corpus regression
- standard package tests include the corpus, so protected `pnpm verify` runs it

## Verification

- `pnpm test:soundness`
- `pnpm verify`
- `git diff --check`

Closes #16
