### PR TITLE
Prove PostgreSQL and MySQL runtime codec fidelity

### DIFF
--- a/.changeset/runtime-codec-fidelity.md
+++ b/.changeset/runtime-codec-fidelity.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/postgres": patch
+"@typed-sql/mysql": patch
+---
+
+Prove and document runtime codec fidelity against live PostgreSQL and MySQL values. PostgreSQL now
+delegates non-policy OIDs to the installed pg parser table, MySQL maps BIT to Uint8Array, and the
+mysql2 adapter rejects pool settings that would contradict its type policy.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ pnpm e2e:packed
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Public API and stability boundary](./docs/PUBLIC_API.md)
 - [Inference soundness policy and corpus](./docs/SOUNDNESS.md)
+- [PostgreSQL and MySQL runtime codec fidelity](./docs/CODEC_FIDELITY.md)
 - [Compatibility and performance](./docs/COMPATIBILITY.md)
 - [Releasing](./docs/RELEASING.md)
 - [Diagnostic code registry](./packages/core/README.md#diagnostics)

--- a/docs/CODEC_FIDELITY.md
+++ b/docs/CODEC_FIDELITY.md
@@ -1,0 +1,96 @@
+# Runtime codec fidelity
+
+typed-sql's result types describe the values returned by its application-owned `pg` and `mysql2`
+adapters. The schema policy used for generation and the runtime `typePolicy` passed to the adapter
+must be the same object. The defaults prioritize lossless values.
+
+This contract is tested as one chain: live catalog type → generated snapshot type → inferred query
+row and parameter tuple → rendered parameter → driver field metadata → decoded JavaScript value.
+The container suites use PostgreSQL 18.4 with `pg` 8.23.0 and MySQL 8.4.11 with `mysql2` 3.24.1.
+
+## PostgreSQL and `pg`
+
+| PostgreSQL catalog type | Default TypeScript type | Runtime representation |
+| --- | --- | --- |
+| `smallint`, `integer` | `number` | finite JavaScript number from `pg`'s native parser |
+| `bigint` | `bigint` | native `bigint`; values outside the safe-number range are tested |
+| `numeric`, `decimal` | `string` | exact decimal text, including aggregate results |
+| `real`, `double precision` | `number` | JavaScript number from `pg`'s native parser |
+| `boolean` | `boolean` | JavaScript boolean from `pg`'s native parser |
+| text, character and `uuid` types | `string` | JavaScript string |
+| `date`, `timestamp`, `timestamptz` | `Date` | JavaScript `Date` |
+| `json`, `jsonb` | `unknown` | value produced by `JSON.parse` |
+| `bytea` | `Uint8Array` | Node.js `Buffer`, which is a `Uint8Array` subclass |
+| enum | literal string union | JavaScript string |
+| supported `T[]` | `readonly (MappedT)[]` | recursively decoded array with nullable elements preserved |
+| nullable column | `T \| null` | `null` is never passed through a scalar codec |
+
+The adapter installs parsers per query and does not mutate `pg.types`. Policy-controlled OIDs are
+decoded by typed-sql; every other OID delegates to the installed `pg` parser table. Application
+`poolConfig.types` is excluded at the type level and rejected at runtime because it could make the
+runtime disagree with the generated policy. Binary-result mode is not currently exposed by the
+typed-sql query renderer.
+
+Policy alternatives:
+
+| Policy field | Supported values | Runtime guarantee |
+| --- | --- | --- |
+| `bigint` | `bigint`, `string`, `number` | `number` throws outside `Number.isSafeInteger` |
+| `numeric` | `string`, `number`, `Decimal` | `number` rejects non-finite results; `Decimal` requires `decimal(value)` |
+| `date` | `Date`, `string` | `Date` follows JavaScript millisecond precision; `string` preserves driver text |
+| `json` | `unknown`, `JsonValue`, `string` | object modes parse JSON; `string` preserves JSON text |
+| `enums` | `string-union`, `string` | both decode as strings; only the inferred type changes |
+
+`timestamp without time zone` follows the Node process timezone when represented as `Date`, just
+as `pg` does. JavaScript dates lose PostgreSQL sub-millisecond precision. Choose the `string` policy
+when those semantics are not acceptable.
+
+## MySQL and `mysql2`
+
+| MySQL catalog type | Default TypeScript type | Runtime representation |
+| --- | --- | --- |
+| `tinyint(1)`, `boolean`, `bool` | `boolean` | strict `0`/`1` conversion |
+| other `tinyint`, `smallint`, `mediumint`, `int` | `number` | JavaScript number |
+| `bigint` | `bigint` | native `bigint`; values outside the safe-number range are tested |
+| `decimal`, `numeric` | `string` | exact decimal text, including `SUM`/`AVG` results |
+| `float`, `double`, `real` | `number` | JavaScript number |
+| `bit` | `Uint8Array` | Node.js `Buffer`; it is deliberately not inferred as `number` |
+| character, text, `time` and `set` types | `string` | JavaScript string |
+| binary and blob types | `Uint8Array` | Node.js `Buffer` |
+| `date`, `datetime`, `timestamp` | `Date` | typed-sql converts lossless driver text to `Date` |
+| `year` | `number` | JavaScript number |
+| `json` | `unknown` | parsed JSON value |
+| enum | literal string union | JavaScript string |
+| nullable column | `T \| null` | `null` is never passed through a scalar codec |
+
+The adapter owns the mysql2 settings that affect row shape and decoding:
+`supportBigNumbers: true`, `bigNumberStrings: true`, `decimalNumbers: false`, `dateStrings: true`,
+`jsonStrings: false`, and `rowsAsArray: false`. Supplying those keys—or `typeCast`—inside
+`poolConfig` fails before a pool is created with guidance to remove the option. Connection, TLS,
+timeout and pool-capacity settings remain application-owned.
+
+Policy alternatives:
+
+| Policy field | Supported values | Runtime guarantee |
+| --- | --- | --- |
+| `bigint` | `bigint`, `string`, `number` | `number` throws outside `Number.isSafeInteger` |
+| `decimal` | `string`, `number`, `Decimal` | `number` may approximate decimal fractions and rejects non-finite results; `Decimal` requires `decimal(value)` |
+| `date` | `Date`, `string` | conversion happens after mysql2 returns date text |
+| `json` | `unknown`, `JsonValue`, `string` | object modes use parsed JSON; `string` serializes the value |
+| `tinyint1` | `boolean`, `number` | conversion is driven by field type and length metadata |
+
+## Joins, aggregates and drift
+
+Nullability is applied after scalar mapping. A nullable column and a column from the nullable side
+of an outer join both infer `T | null`, while non-null runtime values retain the codec representation
+above. `COUNT` uses the dialect's `bigint` policy and decimal-producing aggregates use the numeric
+or decimal policy.
+
+Generated snapshots store a `typePolicyHash`. `typed-sql drift` compares it alongside the live
+catalog hash, so a policy change invalidates generated output even when the database schema did not
+change. Regenerate before compiling or executing with a different policy.
+
+The upstream behavior this adapter contract relies on is documented by
+[node-postgres type parsing](https://node-postgres.com/features/types),
+[node-postgres per-query parsers](https://node-postgres.com/features/queries), and
+[mysql2 type conversion](https://sidorares.github.io/node-mysql2/docs/documentation).

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -24,6 +24,9 @@ the same classification in `typedSql.releaseTrack`. See [Public API](./PUBLIC_AP
 | @types/pg | PostgreSQL package supplies declarations-only 8.23.1; no runtime driver is installed |
 | mysql2 | E2E application owns 3.24.1 |
 
+Database-to-TypeScript mappings, supported driver settings, precision behavior, and live runtime
+assertions are defined in [Runtime codec fidelity](./CODEC_FIDELITY.md).
+
 The compiler performance gate transforms 1,000 static query templates in at most 3,000ms on an
 unwarmed CI-compatible Node process. Parser fuzzing runs 2,000 deterministic arbitrary inputs.
 Compiler-critical packages enforce at least 95% statements, lines, and functions plus 90% branches.

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -12,8 +12,8 @@ current public release line is `1.0.0-beta.*` under the npm `next` tag.
 
 The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
 of a complete registry-only consumer test, an unrehearsed stable version transition, and
-insufficient external beta soak time. Reproducible editor installation, runtime codec fidelity,
-grammar conformance, and performance budgets also remain open gates.
+insufficient external beta soak time. Reproducible editor installation, grammar conformance, and
+performance budgets also remain open gates.
 
 ## Definition of ready
 
@@ -113,6 +113,12 @@ conservative `unknown`, and stable diagnostics, while compiler, CLI, bridge, and
 assert equivalent transformed output and original-source diagnostic mapping. A confidently wrong
 inference is a release-blocking correctness defect, and every correction requires a minimal corpus
 regression.
+
+Runtime fidelity is enforced by the live [codec matrix](./CODEC_FIDELITY.md). Catalog types,
+generated types, inferred row/parameter contracts, driver metadata, and decoded values are tested
+together for PostgreSQL/`pg` and MySQL/`mysql2`, including unsafe integers, exact decimals, dates,
+JSON, binary values, arrays, enums, nullability, joins, aggregates, and functions. Decoder-changing
+driver settings are either owned by the adapter or rejected before connecting.
 
 Acceptance criteria:
 

--- a/e2e/mysql/schema/001-schema.sql
+++ b/e2e/mysql/schema/001-schema.sql
@@ -15,5 +15,32 @@ CREATE TABLE projects (
   CONSTRAINT projects_owner_fk FOREIGN KEY (owner_id) REFERENCES users(id)
 );
 
+CREATE TABLE codec_fidelity (
+  id INT NOT NULL PRIMARY KEY,
+  boolean_value TINYINT(1) NOT NULL,
+  tinyint_value TINYINT NOT NULL,
+  smallint_value SMALLINT NOT NULL,
+  mediumint_value MEDIUMINT NOT NULL,
+  integer_value INT NOT NULL,
+  bigint_value BIGINT NOT NULL,
+  decimal_value DECIMAL(30, 10) NOT NULL,
+  float_value FLOAT NOT NULL,
+  double_value DOUBLE NOT NULL,
+  bit_value BIT(8) NOT NULL,
+  text_value TEXT NOT NULL,
+  varchar_value VARCHAR(40) NOT NULL,
+  binary_value VARBINARY(8) NOT NULL,
+  blob_value BLOB NOT NULL,
+  date_value DATE NOT NULL,
+  datetime_value DATETIME(3) NOT NULL,
+  timestamp_value TIMESTAMP(3) NOT NULL,
+  time_value TIME NOT NULL,
+  year_value YEAR NOT NULL,
+  json_value JSON NOT NULL,
+  enum_value ENUM('ready', 'waiting') NOT NULL,
+  set_value SET('read', 'write') NOT NULL,
+  nullable_text TEXT
+);
+
 CREATE FUNCTION user_count() RETURNS BIGINT DETERMINISTIC
 RETURN (SELECT COUNT(*) FROM users);

--- a/e2e/mysql/schema/002-seed.sql
+++ b/e2e/mysql/schema/002-seed.sql
@@ -4,3 +4,30 @@ INSERT INTO users (id, email, status, profile, active) VALUES
 
 INSERT INTO projects (id, owner_id, name, budget) VALUES
   (1, 1, 'Compiler', 12500.50);
+
+INSERT INTO codec_fidelity VALUES (
+  1,
+  1,
+  127,
+  32767,
+  8388607,
+  2147483647,
+  9007199254740993,
+  12345678901234567890.1234567890,
+  1.25,
+  2.5,
+  b'10100101',
+  'codec',
+  'typed-sql',
+  X'00A5FF',
+  X'0102FEFF',
+  '2026-08-25',
+  '2026-08-25 12:34:56.789',
+  '2026-08-25 12:34:56.789',
+  '12:34:56',
+  2026,
+  JSON_OBJECT('kind', 'json', 'count', 1),
+  'ready',
+  'read,write',
+  NULL
+);

--- a/e2e/mysql/src/codec-query.ts
+++ b/e2e/mysql/src/codec-query.ts
@@ -1,0 +1,30 @@
+import { sql } from "@typed-sql/mysql";
+
+export const mysqlCodecFidelity = sql`
+  SELECT id,
+         boolean_value,
+         tinyint_value,
+         smallint_value,
+         mediumint_value,
+         integer_value,
+         bigint_value,
+         decimal_value,
+         float_value,
+         double_value,
+         bit_value,
+         text_value,
+         varchar_value,
+         binary_value,
+         blob_value,
+         date_value,
+         datetime_value,
+         timestamp_value,
+         time_value,
+         year_value,
+         json_value,
+         enum_value,
+         set_value,
+         nullable_text
+  FROM codec_fidelity
+  WHERE id = ${1}
+`;

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -8,6 +8,7 @@ import { analyzeSource } from "@typed-sql/ts-bridge";
 import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-preview";
 import { createPool } from "mysql2/promise";
 import { describe, it, log, strict, waitForExpectedResult, waitForPort } from "poku";
+import { mysqlCodecFidelity } from "../src/codec-query.js";
 
 interface CommandResult {
   readonly code: number;
@@ -153,6 +154,11 @@ try {
       strict.strictEqual(snapshot.tables.users?.columns.active?.tsType, "boolean");
       strict.strictEqual(snapshot.tables.projects?.columns.budget?.databaseType, "decimal(14,2)");
       strict.strictEqual(snapshot.functions?.["typed_sql_e2e.user_count()"]?.returnType, "bigint");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.boolean_value?.tsType, "boolean");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.bigint_value?.tsType, "bigint");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.decimal_value?.tsType, "string");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.bit_value?.tsType, "Uint8Array");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.binary_value?.tsType, "Uint8Array");
       strict.strictEqual(snapshot.metadata.schemaHash.length, 64);
       strict.strictEqual(snapshot.metadata.typePolicyHash.length, 64);
     });
@@ -191,6 +197,51 @@ try {
           'Query<never, readonly [string, "active" | "suspended", unknown]>',
         );
         strict.ok(inspections.slice(0, 2).every((inspection) => !inspection.typeText.includes("unknown")));
+      } finally {
+        await bridge.close();
+      }
+    });
+
+    await it("proves the default MySQL codec matrix at the inferred type boundary", async () => {
+      const sourcePath = join(packageDirectory, "src/codec-query.ts");
+      const source = await readFile(sourcePath, "utf8");
+      const snapshot = JSON.parse(await readFile(generatedSnapshotPath, "utf8")) as Parameters<typeof analyzeSource>[1];
+      const analysis = analyzeSource(source, snapshot as MySqlSchemaSnapshot, mysql());
+      strict.deepStrictEqual(analysis.diagnostics, []);
+      strict.strictEqual(analysis.queries.length, 1);
+      const contract = analysis.queries[0]!;
+      strict.strictEqual(contract.parameterType, "readonly [number]");
+      const rowType = contract.rowType.replace(/"([^"]+)":/gu, "$1:");
+      for (const exact of [
+        "id: number",
+        "boolean_value: boolean",
+        "tinyint_value: number",
+        "bigint_value: bigint",
+        "decimal_value: string",
+        "bit_value: Uint8Array",
+        "binary_value: Uint8Array",
+        "date_value: Date",
+        "time_value: string",
+        "year_value: number",
+        "json_value: unknown",
+        'enum_value: "ready" | "waiting"',
+        "set_value: string",
+        "nullable_text: string | null",
+      ])
+        strict.ok(rowType.includes(exact), `Missing ${exact} in ${contract.rowType}`);
+      const bridge = NativePreviewTypeScriptBridge.spawn({ cwd: workspaceDirectory });
+      try {
+        const inspections = await bridge.inspectFile({
+          fileName: sourcePath,
+          projectFile: join(packageDirectory, "tsconfig.json"),
+          analysis,
+        });
+        strict.strictEqual(inspections.length, 1);
+        const inferred = inspections[0]!.typeText;
+        strict.ok(inferred.startsWith("Query<"));
+        strict.ok(inferred.includes("id: number"));
+        strict.ok(inferred.includes("bigint_value: bigint"));
+        strict.ok(inferred.endsWith("readonly [number]>") || inferred.endsWith("readonly [...]>"));
       } finally {
         await bridge.close();
       }
@@ -255,6 +306,34 @@ try {
           return values[0]?.total;
         });
         strict.strictEqual(total, 2n);
+
+        const codecRows = await database.execute(mysqlCodecFidelity);
+        const codec = codecRows[0] as Record<string, unknown>;
+        strict.strictEqual(codec.id, 1);
+        strict.strictEqual(codec.boolean_value, true);
+        strict.strictEqual(codec.tinyint_value, 127);
+        strict.strictEqual(codec.smallint_value, 32767);
+        strict.strictEqual(codec.mediumint_value, 8388607);
+        strict.strictEqual(codec.integer_value, 2147483647);
+        strict.strictEqual(codec.bigint_value, 9007199254740993n);
+        strict.strictEqual(codec.decimal_value, "12345678901234567890.1234567890");
+        strict.strictEqual(codec.float_value, 1.25);
+        strict.strictEqual(codec.double_value, 2.5);
+        strict.ok(codec.bit_value instanceof Uint8Array);
+        strict.deepStrictEqual(Array.from(codec.bit_value as Uint8Array), [165]);
+        strict.strictEqual(codec.text_value, "codec");
+        strict.strictEqual(codec.varchar_value, "typed-sql");
+        strict.deepStrictEqual(Array.from(codec.binary_value as Uint8Array), [0, 165, 255]);
+        strict.deepStrictEqual(Array.from(codec.blob_value as Uint8Array), [1, 2, 254, 255]);
+        strict.ok(codec.date_value instanceof Date);
+        strict.ok(codec.datetime_value instanceof Date);
+        strict.ok(codec.timestamp_value instanceof Date);
+        strict.strictEqual(codec.time_value, "12:34:56");
+        strict.strictEqual(codec.year_value, 2026);
+        strict.deepStrictEqual(codec.json_value, { count: 1, kind: "json" });
+        strict.strictEqual(codec.enum_value, "ready");
+        strict.strictEqual(codec.set_value, "read,write");
+        strict.strictEqual(codec.nullable_text, null);
       } finally {
         await database.close();
       }

--- a/e2e/postgres/schema/001-schema.sql
+++ b/e2e/postgres/schema/001-schema.sql
@@ -21,6 +21,29 @@ CREATE TABLE public.projects (
   tags text[] NOT NULL DEFAULT '{}'
 );
 
+CREATE TABLE public.codec_fidelity (
+  id integer PRIMARY KEY,
+  smallint_value smallint NOT NULL,
+  integer_value integer NOT NULL,
+  bigint_value bigint NOT NULL,
+  numeric_value numeric(30, 10) NOT NULL,
+  real_value real NOT NULL,
+  double_value double precision NOT NULL,
+  boolean_value boolean NOT NULL,
+  text_value text NOT NULL,
+  uuid_value uuid NOT NULL,
+  date_value date NOT NULL,
+  timestamp_value timestamp without time zone NOT NULL,
+  timestamptz_value timestamp with time zone NOT NULL,
+  json_value json NOT NULL,
+  jsonb_value jsonb NOT NULL,
+  binary_value bytea NOT NULL,
+  bigint_array bigint[] NOT NULL,
+  numeric_array numeric[] NOT NULL,
+  text_array text[] NOT NULL,
+  nullable_text text
+);
+
 CREATE VIEW public.active_users AS
 SELECT id, email, created_at
 FROM public.users

--- a/e2e/postgres/schema/002-seed.sql
+++ b/e2e/postgres/schema/002-seed.sql
@@ -12,3 +12,26 @@ SELECT setval(
 
 INSERT INTO public.projects (id, owner_id, name, budget, tags) VALUES
   ('11111111-1111-1111-1111-111111111111', 1, 'Compiler', 12500.50, ARRAY['typescript', 'sql']);
+
+INSERT INTO public.codec_fidelity VALUES (
+  1,
+  32767,
+  2147483647,
+  9007199254740993,
+  12345678901234567890.1234567890,
+  1.25,
+  2.5,
+  true,
+  'codec',
+  '22222222-2222-2222-2222-222222222222',
+  DATE '2026-08-25',
+  TIMESTAMP '2026-08-25 12:34:56.789',
+  TIMESTAMPTZ '2026-08-25 12:34:56.789+00',
+  '{"kind":"json","count":1}',
+  '{"kind":"jsonb","enabled":true}',
+  decode('00a5ff', 'hex'),
+  ARRAY[1::bigint, 9007199254740993::bigint],
+  ARRAY[1.25::numeric, 12345678901234567890.1234567890::numeric],
+  ARRAY['one', 'two'],
+  NULL
+);

--- a/e2e/postgres/src/codec-query.ts
+++ b/e2e/postgres/src/codec-query.ts
@@ -1,0 +1,26 @@
+import { sql } from "@typed-sql/postgres";
+
+export const postgresCodecFidelity = sql`
+  SELECT id,
+         smallint_value,
+         integer_value,
+         bigint_value,
+         numeric_value,
+         real_value,
+         double_value,
+         boolean_value,
+         text_value,
+         uuid_value,
+         date_value,
+         timestamp_value,
+         timestamptz_value,
+         json_value,
+         jsonb_value,
+         binary_value,
+         bigint_array,
+         numeric_array,
+         text_array,
+         nullable_text
+  FROM codec_fidelity
+  WHERE id = ${1}
+`;

--- a/e2e/postgres/test/developer-flow.e2e.test.ts
+++ b/e2e/postgres/test/developer-flow.e2e.test.ts
@@ -8,6 +8,7 @@ import { analyzeSource } from "@typed-sql/ts-bridge";
 import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-preview";
 import { Pool } from "pg";
 import { describe, it, log, strict, waitForExpectedResult, waitForPort } from "poku";
+import { postgresCodecFidelity } from "../src/codec-query.js";
 
 interface CommandResult {
   readonly code: number;
@@ -170,6 +171,11 @@ try {
       strict.deepStrictEqual(snapshot.enums?.account_status, ["active", "suspended"]);
       strict.strictEqual(snapshot.domains?.email_address?.tsType, "string");
       strict.strictEqual(snapshot.functions?.["active_user_count()"]?.returnType, "bigint");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.id?.tsType, "number");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.bigint_value?.tsType, "bigint");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.numeric_value?.tsType, "string");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.binary_value?.tsType, "Uint8Array");
+      strict.strictEqual(snapshot.tables.codec_fidelity?.columns.bigint_array?.tsType, "readonly (bigint)[]");
       strict.ok(snapshot.metadata.schemaHash.length === 64);
       strict.ok(snapshot.metadata.typePolicyHash.length === 64);
     });
@@ -211,6 +217,50 @@ try {
         strict.ok(inspections[2]?.typeText.includes('status: "active" | "suspended"'));
         strict.ok(!inspections[2]?.typeText.includes("unknown"));
         strict.strictEqual(inspections[3]?.typeText, "Query<never, readonly [unknown, bigint]>");
+      } finally {
+        await bridge.close();
+      }
+    });
+
+    await it("proves the default PostgreSQL codec matrix at the inferred type boundary", async () => {
+      const sourcePath = join(packageDirectory, "src/codec-query.ts");
+      const source = await readFile(sourcePath, "utf8");
+      const snapshot = JSON.parse(await readFile(generatedSnapshotPath, "utf8")) as Parameters<typeof analyzeSource>[1];
+      const analysis = analyzeSource(source, snapshot as PostgresSchemaSnapshot, postgres());
+      strict.deepStrictEqual(analysis.diagnostics, []);
+      strict.strictEqual(analysis.queries.length, 1);
+      const contract = analysis.queries[0]!;
+      strict.strictEqual(contract.parameterType, "readonly [number]");
+      const rowType = contract.rowType.replace(/"([^"]+)":/gu, "$1:");
+      for (const exact of [
+        "id: number",
+        "smallint_value: number",
+        "integer_value: number",
+        "bigint_value: bigint",
+        "numeric_value: string",
+        "boolean_value: boolean",
+        "uuid_value: string",
+        "date_value: Date",
+        "json_value: unknown",
+        "binary_value: Uint8Array",
+        "bigint_array: readonly (bigint)[]",
+        "numeric_array: readonly (string)[]",
+        "nullable_text: string | null",
+      ])
+        strict.ok(rowType.includes(exact), `Missing ${exact} in ${contract.rowType}`);
+      const bridge = NativePreviewTypeScriptBridge.spawn({ cwd: workspaceDirectory });
+      try {
+        const inspections = await bridge.inspectFile({
+          fileName: sourcePath,
+          projectFile: join(packageDirectory, "tsconfig.json"),
+          analysis,
+        });
+        strict.strictEqual(inspections.length, 1);
+        const inferred = inspections[0]!.typeText;
+        strict.ok(inferred.startsWith("Query<"));
+        strict.ok(inferred.includes("id: number"));
+        strict.ok(inferred.includes("bigint_value: bigint"));
+        strict.ok(inferred.endsWith("readonly [number]>") || inferred.endsWith("readonly [...]>"));
       } finally {
         await bridge.close();
       }
@@ -333,6 +383,30 @@ try {
           DELETE FROM users WHERE id = ${inserted.id} RETURNING id
         `);
         strict.deepStrictEqual(deleted, [{ id: inserted.id }]);
+
+        const codecRows = await database.execute(postgresCodecFidelity);
+        const codec = codecRows[0] as Record<string, unknown>;
+        strict.strictEqual(codec.id, 1);
+        strict.strictEqual(codec.smallint_value, 32767);
+        strict.strictEqual(codec.integer_value, 2147483647);
+        strict.strictEqual(codec.bigint_value, 9007199254740993n);
+        strict.strictEqual(codec.numeric_value, "12345678901234567890.1234567890");
+        strict.strictEqual(codec.real_value, 1.25);
+        strict.strictEqual(codec.double_value, 2.5);
+        strict.strictEqual(codec.boolean_value, true);
+        strict.strictEqual(codec.text_value, "codec");
+        strict.strictEqual(codec.uuid_value, "22222222-2222-2222-2222-222222222222");
+        strict.ok(codec.date_value instanceof Date);
+        strict.ok(codec.timestamp_value instanceof Date);
+        strict.ok(codec.timestamptz_value instanceof Date);
+        strict.deepStrictEqual(codec.json_value, { kind: "json", count: 1 });
+        strict.deepStrictEqual(codec.jsonb_value, { enabled: true, kind: "jsonb" });
+        strict.ok(codec.binary_value instanceof Uint8Array);
+        strict.deepStrictEqual(Array.from(codec.binary_value as Uint8Array), [0, 165, 255]);
+        strict.deepStrictEqual(codec.bigint_array, [1n, 9007199254740993n]);
+        strict.deepStrictEqual(codec.numeric_array, ["1.25", "12345678901234567890.1234567890"]);
+        strict.deepStrictEqual(codec.text_array, ["one", "two"]);
+        strict.strictEqual(codec.nullable_text, null);
       } finally {
         await database.close();
       }

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -62,7 +62,9 @@ const rows = await database.execute(query);
 ```
 
 The adapter enables lossless bigint/decimal defaults, explicit alternative codecs, catalog
-introspection, and nested savepoints without changing global `mysql2` behavior.
+introspection, and nested savepoints without changing global `mysql2` behavior. It rejects
+`poolConfig` options that would contradict the selected type policy. See the tested
+[runtime codec matrix](https://github.com/Lojhan/typed-sql/blob/main/docs/CODEC_FIDELITY.md#mysql-and-mysql2).
 
 ## Supported SQL
 

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -13,7 +13,17 @@ import type { MySqlTypePolicy } from "./type-policy.js";
 
 export interface MySql2Options {
   readonly connectionUri: string | (() => string | Promise<string>);
-  readonly poolConfig?: Omit<PoolOptions, "uri">;
+  readonly poolConfig?: Omit<
+    PoolOptions,
+    | "uri"
+    | "supportBigNumbers"
+    | "bigNumberStrings"
+    | "decimalNumbers"
+    | "dateStrings"
+    | "jsonStrings"
+    | "typeCast"
+    | "rowsAsArray"
+  >;
   readonly typePolicy?: MySqlTypePolicy;
   readonly decimal?: (value: string) => unknown;
   /** Test or host-injected loader. Applications normally leave this unset. */
@@ -55,6 +65,28 @@ async function uri(value: MySql2Options["connectionUri"]): Promise<string> {
   const result = typeof value === "function" ? await value() : value;
   if (result.length === 0) throw new TypeError("MySQL connectionUri must not be empty");
   return result;
+}
+
+const managedPoolOptions = [
+  "supportBigNumbers",
+  "bigNumberStrings",
+  "decimalNumbers",
+  "dateStrings",
+  "jsonStrings",
+  "typeCast",
+  "rowsAsArray",
+] as const;
+
+function validatePoolConfig(poolConfig: MySql2Options["poolConfig"]): void {
+  if (poolConfig === undefined) return;
+  const configured = poolConfig as Readonly<Record<string, unknown>>;
+  for (const option of managedPoolOptions) {
+    if (option in configured) {
+      throw new TypeError(
+        `@typed-sql/mysql/mysql2 owns poolConfig.${option} so decoded values match typePolicy; remove that option`,
+      );
+    }
+  }
 }
 
 function fields(values: readonly FieldPacket[]): readonly MySqlFieldLike[] {
@@ -106,6 +138,7 @@ export function adaptMySql2Pool(pool: Pool): MySqlPoolLike {
 }
 
 export async function createMySql2Database(options: MySql2Options): Promise<MySqlDatabase> {
+  validatePoolConfig(options.poolConfig);
   const driver = await loadMySql2Driver(options.driverImporter);
   const pool = driver.createPool({
     ...options.poolConfig,
@@ -114,6 +147,8 @@ export async function createMySql2Database(options: MySql2Options): Promise<MySq
     bigNumberStrings: true,
     decimalNumbers: false,
     dateStrings: true,
+    jsonStrings: false,
+    rowsAsArray: false,
   });
   return createMySqlDatabase({
     pool: adaptMySql2Pool(pool),

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,5 +1,5 @@
 import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
-import type { MySqlTypePolicy } from "./type-policy.js";
+import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
 
 export interface MySqlFieldLike {
   readonly name: string;
@@ -38,13 +38,7 @@ export interface MySqlDatabaseOptions {
   readonly decimal?: (value: string) => unknown;
 }
 
-const defaultRuntimePolicy = {
-  bigint: "bigint",
-  decimal: "string",
-  date: "Date",
-  json: "unknown",
-  tinyint1: "boolean",
-} as const;
+const defaultRuntimePolicy = defaultMySqlTypePolicy;
 
 const mysqlTypes = { tiny: 1, longlong: 8, date: 10, datetime: 12, timestamp: 7, json: 245, decimal: 246 } as const;
 

--- a/packages/mysql/src/type-policy.ts
+++ b/packages/mysql/src/type-policy.ts
@@ -131,8 +131,9 @@ export function mapMySqlType(databaseType: string, policy: MySqlTypePolicy, sche
   const values = enumValues(databaseType);
   if (values !== undefined) return values.map((value) => JSON.stringify(value)).join(" | ") || "never";
   if (type === "tinyint" && /^tinyint\(1\)/iu.test(databaseType)) return policy.tinyint1;
-  if (["tinyint", "smallint", "mediumint", "int", "integer", "float", "double", "real", "bit", "year"].includes(type))
+  if (["tinyint", "smallint", "mediumint", "int", "integer", "float", "double", "real", "year"].includes(type))
     return "number";
+  if (type === "bit") return "Uint8Array";
   if (type === "bigint") return policy.bigint;
   if (type === "decimal" || type === "numeric") return policy.decimal;
   if (type === "boolean" || type === "bool") return "boolean";

--- a/packages/mysql/test/mysql.test.ts
+++ b/packages/mysql/test/mysql.test.ts
@@ -263,6 +263,7 @@ await describe("MySQL dialect", async () => {
     strict.strictEqual(mapMySqlType("decimal(14,2)", defaultMySqlTypePolicy), "string");
     strict.strictEqual(mapMySqlType("enum('a','b''s')", defaultMySqlTypePolicy), '"a" | "b\'s"');
     strict.strictEqual(mapMySqlType("blob", defaultMySqlTypePolicy), "Uint8Array");
+    strict.strictEqual(mapMySqlType("bit(8)", defaultMySqlTypePolicy), "Uint8Array");
     strict.strictEqual(mapMySqlType("datetime", defaultMySqlTypePolicy), "Date");
     strict.strictEqual(mapMySqlType("json", defaultMySqlTypePolicy), "unknown");
     strict.strictEqual(mapMySqlType("mystery", defaultMySqlTypePolicy), "unknown");

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -85,6 +85,30 @@ await describe("application-owned mysql2 integration", async () => {
     await strict.rejects(() => createMySql2Database({ connectionUri: "" }), /must not be empty/);
   });
 
+  await it("rejects mysql2 settings that would invalidate the runtime type policy", async () => {
+    const raw = new FakeRawPool();
+    const incompatible = [
+      "supportBigNumbers",
+      "bigNumberStrings",
+      "decimalNumbers",
+      "dateStrings",
+      "jsonStrings",
+      "typeCast",
+      "rowsAsArray",
+    ] as const;
+    for (const option of incompatible) {
+      await strict.rejects(
+        () =>
+          createMySql2Database({
+            connectionUri: "mysql://unused/app",
+            poolConfig: { [option]: true } as never,
+            driverImporter: async () => fakeDriver(raw),
+          }),
+        new RegExp(`owns poolConfig\\.${option}`),
+      );
+    }
+  });
+
   await it("supports injected catalog clients and validates provider options", async () => {
     const snapshot = await mysql2({ client: new CatalogClient(), schemas: ["app"] }).introspect();
     strict.strictEqual(snapshot.version, "8.4.11");

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -68,7 +68,9 @@ const rows = await database.execute(query);
 
 The default lossless policy maps PostgreSQL `bigint` to `bigint`, `numeric` to `string`, temporal
 types to `Date`, JSON to `unknown`, enums to literal unions, arrays recursively, and `bytea` to
-`Uint8Array`. Per-query parsers do not mutate `pg` globals.
+`Uint8Array`. Per-query parsers do not mutate `pg` globals and delegate non-policy OIDs to the
+installed driver's native parser table. See the tested
+[runtime codec matrix](https://github.com/Lojhan/typed-sql/blob/main/docs/CODEC_FIDELITY.md#postgresql-and-pg).
 
 ## Supported SQL
 

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -45,6 +45,14 @@ async function connectionString(value: PgOptions["connectionString"]): Promise<s
   return resolved;
 }
 
+function validatePoolConfig(poolConfig: PgOptions["poolConfig"]): void {
+  if (poolConfig !== undefined && "types" in poolConfig) {
+    throw new TypeError(
+      "@typed-sql/postgres/pg owns poolConfig.types so decoded values match typePolicy; remove that option",
+    );
+  }
+}
+
 function queryConfig(config: PostgresQueryConfig): QueryConfig<unknown[]> {
   return {
     text: config.text,
@@ -84,11 +92,14 @@ export function adaptPgPool(pool: PgPool): PostgresPoolLike {
 }
 
 export async function createPgDatabase(options: PgOptions): Promise<PostgresDatabase> {
-  const { Pool } = await loadPgDriver();
+  validatePoolConfig(options.poolConfig);
+  const driver = await loadPgDriver();
+  const { Pool } = driver;
   const pool = new Pool({ ...options.poolConfig, connectionString: await connectionString(options.connectionString) });
   return createPostgresDatabase({
     pool: adaptPgPool(pool),
     ownsPool: true,
+    fallbackTypeParsers: driver.types,
     ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),
     ...(options.decimal === undefined ? {} : { decimal: options.decimal }),
   });

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,4 +1,5 @@
 import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
+import { defaultPostgresTypePolicy } from "./type-policy.js";
 
 export interface PostgresCodecPolicy {
   readonly bigint: "bigint" | "string" | "number";
@@ -41,14 +42,11 @@ export interface PostgresDatabaseOptions {
   readonly ownsPool?: boolean;
   readonly typePolicy?: PostgresCodecPolicy;
   readonly decimal?: (value: string) => unknown;
+  /** Native driver parsers used for types that typed-sql does not override. */
+  readonly fallbackTypeParsers?: PostgresTypeParserSet;
 }
 
-const defaultPolicy: PostgresCodecPolicy = {
-  bigint: "bigint",
-  numeric: "string",
-  date: "Date",
-  json: "unknown",
-};
+const defaultPolicy: PostgresCodecPolicy = defaultPostgresTypePolicy;
 
 const oids = {
   int8: 20,
@@ -125,6 +123,7 @@ function parsePostgresArray(source: string, transform: (value: string) => unknow
 export function createPostgresTypeParsers(
   policy: PostgresCodecPolicy = defaultPolicy,
   decimal?: (value: string) => unknown,
+  fallback?: PostgresTypeParserSet,
 ): PostgresTypeParserSet {
   const scalar = new Map<number, (value: string) => unknown>();
   scalar.set(oids.int8, policy.bigint === "bigint" ? BigInt : policy.bigint === "number" ? safeIntegerValue : String);
@@ -138,11 +137,12 @@ export function createPostgresTypeParsers(
   for (const oid of [oids.json, oids.jsonb]) scalar.set(oid, policy.json === "string" ? String : JSON.parse);
   return {
     getTypeParser(oid: number, format = "text") {
-      if (format === "binary") return (input: string): string => input;
+      if (format === "binary") return fallback?.getTypeParser(oid, format) ?? ((input: string): string => input);
       const parser = scalar.get(oid);
       if (parser !== undefined) return parser;
       const elementParser = scalar.get(arrayElementOids.get(oid) ?? -1);
-      return elementParser === undefined ? String : (input: string) => parsePostgresArray(input, elementParser);
+      if (elementParser !== undefined) return (input: string) => parsePostgresArray(input, elementParser);
+      return fallback?.getTypeParser(oid, format) ?? String;
     },
   };
 }
@@ -233,7 +233,7 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
   return new PostgresDatabaseImplementation(
     options.pool,
     undefined,
-    createPostgresTypeParsers(options.typePolicy ?? defaultPolicy, options.decimal),
+    createPostgresTypeParsers(options.typePolicy ?? defaultPolicy, options.decimal, options.fallbackTypeParsers),
     options.ownsPool ?? false,
     0,
   );

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -65,6 +65,14 @@ await describe("application-owned pg integration", async () => {
     });
     await database.close();
     await strict.rejects(() => createPgDatabase({ connectionString: "" }), /must not be empty/);
+    await strict.rejects(
+      () =>
+        createPgDatabase({
+          connectionString: "postgresql://unused/app",
+          poolConfig: { types: {} } as never,
+        }),
+      /owns poolConfig\.types/,
+    );
   });
 
   await it("supports injected catalog clients and validates provider options", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -70,6 +70,16 @@ await describe("PostgreSQL runtime adapter", async () => {
     strict.strictEqual(strings.getTypeParser(20, "binary")("raw"), "raw");
     strict.strictEqual(strings.getTypeParser(9999)("custom"), "custom");
 
+    const native = {
+      getTypeParser(oid: number, format = "text") {
+        return (input: string) => ({ format, input, oid });
+      },
+    };
+    const delegated = createPostgresTypeParsers(undefined, undefined, native);
+    strict.deepStrictEqual(delegated.getTypeParser(23)("42"), { format: "text", input: "42", oid: 23 });
+    strict.deepStrictEqual(delegated.getTypeParser(17, "binary")("raw"), { format: "binary", input: "raw", oid: 17 });
+    strict.strictEqual(delegated.getTypeParser(20)("42"), 42n);
+
     const values = createPostgresTypeParsers(
       { bigint: "bigint", numeric: "Decimal", date: "Date", json: "unknown" },
       (value) => ({ decimal: value }),

--- a/packages/schema/test/generator.test.ts
+++ b/packages/schema/test/generator.test.ts
@@ -46,6 +46,10 @@ await describe("schema package generation", async () => {
       strict.strictEqual(drift.drifted, true);
       strict.strictEqual(drift.schemaChanged, true);
       strict.strictEqual(drift.typePolicyChanged, false);
+      const policyDrift = checkSchemaDrift(generated, schema, { bigint: "string" });
+      strict.strictEqual(policyDrift.drifted, true);
+      strict.strictEqual(policyDrift.schemaChanged, false);
+      strict.strictEqual(policyDrift.typePolicyChanged, true);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- publish the PostgreSQL/pg and MySQL/mysql2 codec compatibility matrix
- prove catalog, generated, inferred, rendered, metadata, and decoded contracts against live containers
- preserve pg native parsers for non-policy OIDs and reject conflicting driver decoder settings
- correct MySQL BIT inference from number to Uint8Array
- cover precision edges, dates, JSON, binary, arrays, enums, nullability, aggregates, functions, and policy drift

## Verification

- pnpm verify
- pnpm e2e:postgres
- pnpm e2e:mysql
- git diff --check

Closes #17