### PR TITLE
Enforce grammar plugin conformance

### DIFF
--- a/.changeset/grammar-conformance.md
+++ b/.changeset/grammar-conformance.md
@@ -1,0 +1,11 @@
+---
+"@typed-sql/core": patch
+"@typed-sql/schema": patch
+"@typed-sql/config": patch
+"@typed-sql/postgres": patch
+"@typed-sql/mysql": patch
+---
+
+Finalize dialect contract version 3 with explicit identifier quoting and grammar-owned capability
+declarations. Accept third-party snapshot dialects, validate grammar versions, and document the
+public grammar-authoring and conformance workflow.

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ pnpm e2e:packed
 
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Public API and stability boundary](./docs/PUBLIC_API.md)
+- [Authoring a SQL grammar](./docs/GRAMMAR_AUTHORING.md)
 - [Inference soundness policy and corpus](./docs/SOUNDNESS.md)
 - [PostgreSQL and MySQL runtime codec fidelity](./docs/CODEC_FIDELITY.md)
 - [Compatibility and performance](./docs/COMPATIBILITY.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,10 +71,14 @@ not require changing the compiler.
 
 The compiler recognizes the `sqlModule` declared by the configured dialect and never branches on
 a package name, dialect id, or concrete driver. This lets first-party and third-party grammars expose
-the same package-root application contract. Contract version 2 requires both resolved result
-columns and resolved parameters. Generated snapshots
-record their dialect, dialect package version, server version, type policy and deterministic hashes.
+the same package-root application contract. Contract version 3 requires resolved result columns,
+ordered parameters, identifier quoting, and grammar-owned capability declarations. Generated
+snapshots record their dialect, dialect package version, server version, type policy and
+deterministic hashes.
 The schema layer treats type policy as opaque data; its shape and defaults belong to the dialect.
+
+Third-party packages implement exactly the same contract. The complete public-only workflow is in
+[Authoring a SQL grammar](./GRAMMAR_AUTHORING.md).
 
 Generated TypeScript is schema metadata for tooling and inspection. Application code imports
 `sql` and the default `typePolicy` from the dialect root, then imports a driver adapter only when it

--- a/docs/GRAMMAR_AUTHORING.md
+++ b/docs/GRAMMAR_AUTHORING.md
@@ -1,0 +1,158 @@
+# Authoring a SQL grammar
+
+typed-sql grammars are ordinary packages that implement the public dialect contract. The compiler,
+schema loader, CLI, and editor tooling do not contain a list of database engines. They discover SQL
+semantics through the dialect selected in `typed-sql.config.ts`.
+
+This guide uses only published package entrypoints. A grammar must not import files from another
+typed-sql package's `src` or `dist` directory.
+
+## Package boundary
+
+A grammar package should:
+
+- depend on `@typed-sql/core` for the query and dialect contracts;
+- depend on `@typed-sql/schema` when it uses the shared snapshot parser;
+- export `sql` from its package root;
+- export a dialect factory and default type policy from the same root;
+- keep database drivers outside normal dependencies;
+- put optional introspection and execution adapters behind explicit subpath exports.
+
+Applications should be able to install the grammar without installing a driver. If an adapter needs
+one, load the application-owned package lazily and return an actionable installation error when it
+is absent.
+
+## Minimal implementation
+
+```ts
+import {
+  DIALECT_CONTRACT_VERSION,
+  assertDialectPlugin,
+  sql,
+  type DialectAnalysis,
+  type DialectPlugin,
+  type SchemaSnapshot,
+} from "@typed-sql/core";
+import { parseSchemaSnapshot } from "@typed-sql/schema";
+
+export { sql };
+
+export interface AcmeTypePolicy {
+  readonly scalar: "number" | "string";
+}
+
+export const typePolicy: AcmeTypePolicy = Object.freeze({ scalar: "number" });
+export const ACME_GRAMMAR_VERSION = "1.0.0";
+
+export type AcmeSnapshot = SchemaSnapshot & { readonly dialect: "acme" };
+
+function validateSnapshot(value: unknown): AcmeSnapshot {
+  const snapshot = parseSchemaSnapshot(value);
+  if (snapshot.dialect !== "acme") {
+    throw new TypeError(`acme cannot use a ${snapshot.dialect} schema snapshot`);
+  }
+  if (snapshot.dialectVersion !== ACME_GRAMMAR_VERSION) {
+    throw new TypeError(
+      `acme grammar ${ACME_GRAMMAR_VERSION} cannot use snapshot ${snapshot.dialectVersion}`,
+    );
+  }
+  return snapshot as AcmeSnapshot;
+}
+
+function analyze(
+  text: string,
+  snapshot: AcmeSnapshot,
+  policy: AcmeTypePolicy,
+): DialectAnalysis {
+  // Tokenize, parse, and resolve with your package's own grammar. Use snapshot for catalog
+  // resolution and return source-mapped columns, ordered parameters, and diagnostics.
+  void text;
+  void snapshot;
+  void policy;
+  return {
+    columns: [],
+    parameters: [],
+    diagnostics: [],
+  };
+}
+
+const plugin = Object.freeze({
+  contractVersion: DIALECT_CONTRACT_VERSION,
+  id: "acme",
+  grammarVersion: ACME_GRAMMAR_VERSION,
+  sqlModule: "@acme/typed-sql",
+  capabilities: Object.freeze({ returning: false, recursiveCtes: true }),
+  defaultTypePolicy: typePolicy,
+  placeholder(index: number) {
+    if (!Number.isInteger(index) || index < 1) throw new RangeError("parameter indexes start at 1");
+    return `?${index}`;
+  },
+  quoteIdentifier(identifier: string) {
+    return `[${identifier.replaceAll("]", "]]")}]`;
+  },
+  analyze(text: string, snapshot: AcmeSnapshot, policy = typePolicy) {
+    return analyze(text, snapshot, policy);
+  },
+  validateSnapshot,
+}) satisfies DialectPlugin<AcmeSnapshot, AcmeTypePolicy>;
+
+assertDialectPlugin(plugin);
+
+export function acme(): DialectPlugin<AcmeSnapshot, AcmeTypePolicy> {
+  return plugin;
+}
+```
+
+The package root named by `sqlModule` must be the exact module from which applications import
+`sql`. The compiler uses that string to find tagged templates without knowing the grammar's package
+name.
+
+## Contract responsibilities
+
+`DialectPlugin` contract version 3 separates neutral compiler mechanics from SQL semantics:
+
+- `placeholder(index)` defines one-based rendered parameter markers and rejects invalid indexes.
+- `quoteIdentifier(identifier)` must match the grammar's runtime renderer exactly.
+- `capabilities` is an immutable, grammar-owned map. Core exposes it but does not interpret its keys.
+- `analyze(text, snapshot, policy)` returns result columns, ordered parameter evidence, and
+  source-mapped diagnostics.
+- `validateSnapshot(value)` owns dialect and grammar-version compatibility.
+- `defaultTypePolicy` defines the grammar's default database-to-TypeScript mapping.
+
+Return parameters in database placeholder order. When evidence is insufficient, use `unknown` for
+that position. Unsupported, ambiguous, invalid, or version-gated SQL must produce a stable error
+diagnostic or a conservative unknown result; it must never receive an optimistic type.
+
+Core exports `ResolverSchemaIndex`, `ParameterCollector`, `unionTypeLiterals`, and `closestName` as
+optional grammar-neutral resolver primitives. A grammar may use them without surrendering control
+of its parser, identifiers, operators, functions, coercions, nullability, or diagnostics.
+
+## Version compatibility
+
+Three versions have different jobs:
+
+- `DIALECT_CONTRACT_VERSION` is the typed-sql plugin protocol. `assertDialectPlugin` rejects a
+  mismatched version before compilation.
+- `grammarVersion` versions the grammar and snapshot semantics. Store it as `dialectVersion` in
+  generated snapshots and reject unsupported snapshots in `validateSnapshot`.
+- `formatVersion` versions the neutral snapshot envelope and is currently `1`.
+
+Changing placeholder behavior, identifier rules, catalog interpretation, or inferred types should
+change the grammar version whenever an old snapshot could be interpreted differently. An npm
+package version is not a substitute for this explicit compatibility check.
+
+## Conformance checklist
+
+Before publishing, test the package through its public entrypoint and assert:
+
+1. `assertDialectPlugin` and `defineConfig` accept the plugin.
+2. Placeholder and identifier rendering match the runtime adapter.
+3. A valid snapshot is accepted; another dialect and an incompatible `dialectVersion` are rejected.
+4. One query proves exact result columns and an ordered parameter tuple.
+5. A type-policy override changes inference and the matching runtime codec together.
+6. Unsupported syntax emits the documented diagnostic and the compiler produces no typed query.
+7. The packed tarball installs in an empty project without workspace imports or a database driver.
+
+typed-sql applies this same harness to PostgreSQL, MySQL, and a synthetic external grammar. See
+[`test/grammar/conformance.ts`](../test/grammar/conformance.ts) and the packed-consumer contract test
+for executable examples.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -82,11 +82,18 @@ a second public compiler framework.
 
 ## Grammar-author contract
 
-`@typed-sql/core` exposes `DialectPlugin`, `SchemaProvider`, snapshot and resolution types,
-`DIALECT_CONTRACT_VERSION`, `ResolverSchemaIndex`, `ParameterCollector`, `unionTypeLiterals`, and
-`closestName`. These are grammar-neutral mechanisms. SQL parsing rules, identifiers, operators,
-built-ins, nullability, catalog behavior, type policies, and unsupported syntax belong to each
-grammar package.
+`@typed-sql/core` exposes `DialectPlugin`, `DialectCapabilities`, `SchemaProvider`, snapshot and
+resolution types, `DIALECT_CONTRACT_VERSION`, `assertDialectPlugin`, `ResolverSchemaIndex`,
+`ParameterCollector`, `unionTypeLiterals`, and `closestName`. These are grammar-neutral mechanisms.
+Contract version 3 requires grammar-owned capabilities, parameter rendering, identifier quoting,
+snapshot validation, and analysis of both result columns and ordered parameters. SQL parsing rules,
+identifiers, operators, built-ins, nullability, catalog behavior, type policies, and unsupported
+syntax belong to each grammar package.
+
+The compiler discovers application tags through the plugin's exact `sqlModule` entrypoint. The
+schema layer accepts any non-empty dialect id; compatibility belongs to the plugin's
+`validateSnapshot` implementation. See [Authoring a SQL grammar](./GRAMMAR_AUTHORING.md) for a
+public-entrypoint-only implementation and conformance checklist.
 
 PostgreSQL and MySQL expose their configured dialect, schema provider/introspection contract,
 default type policy, type mapping, and root `sql` tag. Runtime codecs are isolated under `/runtime`;

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -12,8 +12,8 @@ current public release line is `1.0.0-beta.*` under the npm `next` tag.
 
 The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
 of a complete registry-only consumer test, an unrehearsed stable version transition, and
-insufficient external beta soak time. Reproducible editor installation, grammar conformance, and
-performance budgets also remain open gates.
+insufficient external beta soak time. Reproducible editor installation and performance budgets also
+remain open gates.
 
 ## Definition of ready
 
@@ -94,9 +94,10 @@ Acceptance criteria:
 The parameter direction is implemented: the public contract is `Query<Row, Parameters>`, where
 `Parameters` is an ordered readonly tuple. PostgreSQL and MySQL infer positions from comparisons,
 casts, DML targets, ranges, limits, and catalog functions. Insufficient or conflicting evidence is
-represented as `unknown`. Dialect contract version 2 makes parameter analysis explicit for
-third-party grammars. Typed `SqlFragment<Parameters>` composition supports nullable `AND`/`OR`
-filter tuples while a statically analyzed base query continues to own the result row.
+represented as `unknown`. Dialect contract version 3 makes parameter analysis, identifier quoting,
+and grammar-owned capabilities explicit for third-party grammars. Typed
+`SqlFragment<Parameters>` composition supports nullable `AND`/`OR` filter tuples while a statically
+analyzed base query continues to own the result row.
 
 The 1.0 contract is recorded in [Public API and stability boundary](./PUBLIC_API.md). Stable package
 roots explicitly enumerate their exported types and values. Runtime exports, entrypoints,
@@ -119,6 +120,13 @@ generated types, inferred row/parameter contracts, driver metadata, and decoded 
 together for PostgreSQL/`pg` and MySQL/`mysql2`, including unsafe integers, exact decimals, dates,
 JSON, binary values, arrays, enums, nullability, joins, aggregates, and functions. Decoder-changing
 driver settings are either owned by the adapter or rejected before connecting.
+
+Grammar neutrality is enforced by one public conformance harness shared by PostgreSQL, MySQL, and a
+synthetic third-party grammar. The packed-consumer gate installs that external grammar from package
+tarballs, compiles and renders a query, checks grammar/snapshot compatibility, and proves unsupported
+SQL fails closed. Neutral package scans reject dialect names, driver dependencies, and dialect SQL
+features in core, compiler, config, and schema sources. The public author contract is documented in
+[Authoring a SQL grammar](./GRAMMAR_AUTHORING.md).
 
 Acceptance criteria:
 

--- a/packages/compiler/test/compiler.test.ts
+++ b/packages/compiler/test/compiler.test.ts
@@ -127,8 +127,10 @@ await describe("TypeScript 7 compiler wrapper", async () => {
       id: "inline",
       grammarVersion: "1",
       sqlModule: "@example/inline-sql",
+      capabilities: {},
       defaultTypePolicy: {},
       placeholder: (index) => `$${index}`,
+      quoteIdentifier: (identifier) => `"${identifier}"`,
       validateSnapshot: () => schema,
       analyze: (sql) => ({
         columns: [
@@ -280,8 +282,10 @@ await describe("TypeScript 7 compiler wrapper", async () => {
       id: "test",
       grammarVersion: "1",
       sqlModule: "@example/test-sql",
+      capabilities: {},
       defaultTypePolicy: {},
       placeholder: (index) => `$${index}`,
+      quoteIdentifier: (identifier) => `"${identifier}"`,
       validateSnapshot: () => schema,
       analyze: () => ({
         columns: [],

--- a/packages/compiler/test/performance.test.ts
+++ b/packages/compiler/test/performance.test.ts
@@ -9,8 +9,10 @@ const dialect: DialectPlugin<typeof schema, Record<string, never>> = {
   id: "performance",
   grammarVersion: "1.0.0",
   sqlModule: "@example/typed-sql-performance",
+  capabilities: {},
   defaultTypePolicy: {},
   placeholder: (index) => `$${index}`,
+  quoteIdentifier: (identifier) => `"${identifier}"`,
   validateSnapshot: () => schema,
   analyze: (_sql, _snapshot) => ({
     columns: [

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,7 +2,7 @@ import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { DIALECT_CONTRACT_VERSION, type SchemaSnapshot, type TypedSqlConfig } from "@typed-sql/core";
+import { assertDialectPlugin, type SchemaSnapshot, type TypedSqlConfig } from "@typed-sql/core";
 import { tsImport } from "tsx/esm/api";
 
 const configNames = [
@@ -48,15 +48,13 @@ export async function discoverConfig(start = process.cwd()): Promise<string> {
 function isConfig(value: unknown): value is TypedSqlConfig<SchemaSnapshot, unknown> {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Partial<TypedSqlConfig<SchemaSnapshot, unknown>>;
-  return (
-    candidate.dialect?.contractVersion === DIALECT_CONTRACT_VERSION &&
-    typeof candidate.dialect.id === "string" &&
-    typeof candidate.dialect.sqlModule === "string" &&
-    typeof candidate.dialect.analyze === "function" &&
-    typeof candidate.dialect.validateSnapshot === "function" &&
-    typeof candidate.schema?.file === "string" &&
-    typeof candidate.outDir === "string"
-  );
+  if (typeof candidate.schema?.file !== "string" || typeof candidate.outDir !== "string") return false;
+  try {
+    assertDialectPlugin(candidate.dialect);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function loadConfig(options: LoadConfigOptions = {}): Promise<LoadedConfig> {

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -31,12 +31,14 @@ await describe("typed-sql config", async () => {
     const source = `
       export default {
         dialect: {
-          contractVersion: 2,
+          contractVersion: 3,
           id: "fixture",
           grammarVersion: "1.0.0",
           sqlModule: "@example/typed-sql-fixture",
+          capabilities: { returning: false },
           defaultTypePolicy: {},
           placeholder(index) { return "?" + index; },
+          quoteIdentifier(identifier) { return "[" + identifier + "]"; },
           analyze() { return { columns: [], parameters: [], diagnostics: [] }; },
           validateSnapshot(value) { return value; }
         },
@@ -61,11 +63,11 @@ await describe("typed-sql config", async () => {
       "{}",
       "{ dialect: null }",
       "{ dialect: { contractVersion: 1 } }",
-      "{ dialect: { contractVersion: 2, id: 1 } }",
-      "{ dialect: { contractVersion: 2, id: 'x' } }",
-      "{ dialect: { contractVersion: 2, id: 'x', analyze() {} } }",
-      "{ dialect: { contractVersion: 2, id: 'x', analyze() {}, validateSnapshot() {} }, schema: {} }",
-      "{ dialect: { contractVersion: 2, id: 'x', analyze() {}, validateSnapshot() {} }, schema: { file: 'x' } }",
+      "{ dialect: { contractVersion: 3, id: 1 } }",
+      "{ dialect: { contractVersion: 3, id: 'x' } }",
+      "{ dialect: { contractVersion: 3, id: 'x', analyze() {} } }",
+      "{ dialect: { contractVersion: 3, id: 'x', analyze() {}, validateSnapshot() {} }, schema: {} }",
+      "{ dialect: { contractVersion: 3, id: 'x', analyze() {}, validateSnapshot() {} }, schema: { file: 'x' } }",
     ];
     try {
       for (const [index, candidate] of candidates.entries()) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -99,6 +99,7 @@ string is never promoted to SQL implicitly.
 ```ts
 import {
   DIALECT_CONTRACT_VERSION,
+  assertDialectPlugin,
   createDatabase,
   defineConfig,
   closestName,
@@ -110,6 +111,7 @@ import {
   sql,
   unionTypeLiterals,
   type DialectPlugin,
+  type DialectCapabilities,
   type Query,
   type QueryParameters,
   type QueryRow,
@@ -125,6 +127,7 @@ semantics, built-ins, quoting, type policy, and unsupported syntax inside their 
 
 The package has no database, parser, grammar, driver, TypeScript compiler, or editor dependency.
 See the [architecture contract](https://github.com/Lojhan/typed-sql/blob/main/docs/ARCHITECTURE.md)
+and [grammar authoring guide](https://github.com/Lojhan/typed-sql/blob/main/docs/GRAMMAR_AUTHORING.md)
 and [root documentation](https://github.com/Lojhan/typed-sql#readme).
 
 ## Diagnostics

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export { closestName, ParameterCollector, ResolverSchemaIndex, unionTypeLiterals
 export type {
   ColumnSnapshot,
   DialectAnalysis,
+  DialectCapabilities,
   DialectPlugin,
   DomainSnapshot,
   FunctionSnapshot,
@@ -34,4 +35,10 @@ export type {
   TableSnapshot,
   TypedSqlConfig,
 } from "./types.js";
-export { DIALECT_CONTRACT_VERSION, defineConfig, parameterTypeLiteral, rowTypeLiteral } from "./types.js";
+export {
+  assertDialectPlugin,
+  DIALECT_CONTRACT_VERSION,
+  defineConfig,
+  parameterTypeLiteral,
+  rowTypeLiteral,
+} from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-export const DIALECT_CONTRACT_VERSION = 2 as const;
+export const DIALECT_CONTRACT_VERSION = 3 as const;
 
 export interface SourceRange {
   readonly start: number;
@@ -91,6 +91,12 @@ export interface DialectAnalysis {
   readonly resultKind?: "rows" | "command";
 }
 
+/**
+ * Grammar-owned feature declarations. Core intentionally does not assign meaning to the keys.
+ * Tooling and applications can expose them without teaching neutral packages dialect semantics.
+ */
+export type DialectCapabilities = Readonly<Record<string, boolean>>;
+
 export interface DialectPlugin<Snapshot extends SchemaSnapshot = SchemaSnapshot, Policy = unknown> {
   readonly contractVersion: typeof DIALECT_CONTRACT_VERSION;
   readonly id: string;
@@ -98,8 +104,11 @@ export interface DialectPlugin<Snapshot extends SchemaSnapshot = SchemaSnapshot,
   readonly grammarVersion: string;
   /** Exact package entrypoint from which applications import the dialect's `sql` tag. */
   readonly sqlModule: string;
+  /** Grammar-owned feature names and their support status. */
+  readonly capabilities: DialectCapabilities;
   readonly defaultTypePolicy: Policy;
   placeholder(index: number): string;
+  quoteIdentifier(identifier: string): string;
   analyze(sql: string, snapshot: Snapshot, policy?: Policy): DialectAnalysis;
   validateSnapshot(value: unknown): Snapshot;
 }
@@ -122,12 +131,36 @@ export interface TypedSqlConfig<Snapshot extends SchemaSnapshot = SchemaSnapshot
   };
 }
 
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function assertDialectPlugin(value: unknown): asserts value is DialectPlugin {
+  if (!record(value)) throw new TypeError("typed-sql dialect must be an object");
+  if (value.contractVersion !== DIALECT_CONTRACT_VERSION) {
+    throw new TypeError(`Unsupported typed-sql dialect contract ${String(value.contractVersion)}`);
+  }
+  for (const property of ["id", "grammarVersion", "sqlModule"] as const) {
+    if (typeof value[property] !== "string" || value[property].length === 0) {
+      throw new TypeError(`typed-sql dialect.${property} must be a non-empty string`);
+    }
+  }
+  if (!("defaultTypePolicy" in value)) throw new TypeError("typed-sql dialect.defaultTypePolicy is required");
+  if (
+    !record(value.capabilities) ||
+    Object.values(value.capabilities).some((supported) => typeof supported !== "boolean")
+  ) {
+    throw new TypeError("typed-sql dialect.capabilities must contain only boolean feature declarations");
+  }
+  for (const method of ["placeholder", "quoteIdentifier", "analyze", "validateSnapshot"] as const) {
+    if (typeof value[method] !== "function") throw new TypeError(`typed-sql dialect.${method} must be a function`);
+  }
+}
+
 export function defineConfig<Snapshot extends SchemaSnapshot, Policy>(
   config: TypedSqlConfig<Snapshot, Policy>,
 ): TypedSqlConfig<Snapshot, Policy> {
-  if (config.dialect.contractVersion !== DIALECT_CONTRACT_VERSION) {
-    throw new TypeError(`Unsupported typed-sql dialect contract ${config.dialect.contractVersion}`);
-  }
+  assertDialectPlugin(config.dialect);
   const maximum = config.compiler?.maxStructuralVariants;
   if (maximum !== undefined && (!Number.isSafeInteger(maximum) || maximum < 1)) {
     throw new TypeError("compiler.maxStructuralVariants must be a positive safe integer");

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, strict } from "poku";
 import {
+  assertDialectPlugin,
   closestName,
   createDatabase,
   DIALECT_CONTRACT_VERSION,
@@ -241,8 +242,10 @@ await describe("core contracts", async () => {
     id: "test",
     grammarVersion: "1.0.0",
     sqlModule: "@example/typed-sql-test",
+    capabilities: {},
     defaultTypePolicy: {},
     placeholder: (index) => `?${index}`,
+    quoteIdentifier: (identifier) => `"${identifier}"`,
     analyze: () => ({ columns: [], parameters: [], diagnostics: [] }),
     validateSnapshot: () => schema,
   };
@@ -260,7 +263,7 @@ await describe("core contracts", async () => {
     strict.throws(
       () =>
         defineConfig({
-          dialect: { ...dialect, contractVersion: 3 as never },
+          dialect: { ...dialect, contractVersion: 4 as never },
           schema: { file: "schema.json" },
           outDir: "generated",
         }),
@@ -277,6 +280,27 @@ await describe("core contracts", async () => {
           }),
         /positive safe integer/,
       );
+    }
+  });
+
+  await it("validates every public dialect contract boundary", () => {
+    strict.doesNotThrow(() => assertDialectPlugin(dialect));
+    const withoutPolicy = Object.fromEntries(Object.entries(dialect).filter(([key]) => key !== "defaultTypePolicy"));
+    for (const invalid of [
+      null,
+      { ...dialect, contractVersion: 2 },
+      { ...dialect, id: "" },
+      { ...dialect, grammarVersion: "" },
+      { ...dialect, sqlModule: "" },
+      withoutPolicy,
+      { ...dialect, capabilities: [] },
+      { ...dialect, capabilities: { returning: "yes" } },
+      { ...dialect, placeholder: undefined },
+      { ...dialect, quoteIdentifier: undefined },
+      { ...dialect, analyze: undefined },
+      { ...dialect, validateSnapshot: undefined },
+    ]) {
+      strict.throws(() => assertDialectPlugin(invalid));
     }
   });
 

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -11,10 +11,25 @@ export interface MySqlDialectOptions {
   readonly typePolicy?: MySqlTypePolicy;
 }
 
+const capabilities = Object.freeze({
+  aggregateFilter: false,
+  arrays: false,
+  distinctOn: false,
+  fullJoins: false,
+  recursiveCtes: false,
+  returning: false,
+  setOperations: false,
+});
+
 function validateMySqlSnapshot(value: unknown): MySqlSchemaSnapshot {
   const snapshot = parseSchemaSnapshot(value);
   if (snapshot.dialect !== "mysql")
     throw new TypeError(`@typed-sql/mysql cannot use a ${snapshot.dialect} schema snapshot`);
+  if (snapshot.dialectVersion !== undefined && snapshot.dialectVersion !== MYSQL_DIALECT_VERSION) {
+    throw new TypeError(
+      `@typed-sql/mysql grammar ${MYSQL_DIALECT_VERSION} cannot use snapshot dialectVersion ${snapshot.dialectVersion}`,
+    );
+  }
   return snapshot as MySqlSchemaSnapshot;
 }
 
@@ -25,10 +40,14 @@ export function mysql(options: MySqlDialectOptions = {}): DialectPlugin<MySqlSch
     id: "mysql",
     grammarVersion: MYSQL_DIALECT_VERSION,
     sqlModule: "@typed-sql/mysql",
+    capabilities,
     defaultTypePolicy,
     placeholder(index: number): string {
       if (!Number.isInteger(index) || index < 1) throw new RangeError("MySQL parameter indexes start at 1");
       return "?";
+    },
+    quoteIdentifier(identifier: string): string {
+      return `\`${identifier.replaceAll("`", "``")}\``;
     },
     analyze(sql: string, snapshot: MySqlSchemaSnapshot, policy = defaultTypePolicy) {
       try {

--- a/packages/mysql/test/mysql.test.ts
+++ b/packages/mysql/test/mysql.test.ts
@@ -54,9 +54,12 @@ await describe("MySQL dialect", async () => {
     const dialect = mysql();
     strict.strictEqual(dialect.id, "mysql");
     strict.strictEqual(dialect.sqlModule, "@typed-sql/mysql");
+    strict.strictEqual(dialect.capabilities.returning, false);
     strict.strictEqual(dialect.placeholder(2), "?");
+    strict.strictEqual(dialect.quoteIdentifier("account`status"), "`account``status`");
     strict.throws(() => dialect.placeholder(0), /start at 1/);
     strict.throws(() => dialect.validateSnapshot({ ...schema, dialect: "postgres" }), /cannot use a postgres/);
+    strict.throws(() => dialect.validateSnapshot({ ...schema, dialectVersion: "999" }), /dialectVersion 999/);
     const result = dialect.analyze(
       "SELECT `id`, `status` FROM `users` WHERE `id` = ?",
       schema as typeof schema & { readonly dialect: "mysql" },

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -11,10 +11,25 @@ export interface PostgresDialectOptions {
   readonly typePolicy?: PostgresTypePolicy;
 }
 
+const capabilities = Object.freeze({
+  aggregateFilter: true,
+  arrays: true,
+  distinctOn: true,
+  fullJoins: true,
+  recursiveCtes: true,
+  returning: true,
+  setOperations: false,
+});
+
 function validatePostgresSnapshot(value: unknown): PostgresSchemaSnapshot {
   const snapshot = parseSchemaSnapshot(value);
   if (snapshot.dialect !== "postgres") {
     throw new TypeError(`@typed-sql/postgres cannot use a ${snapshot.dialect} schema snapshot`);
+  }
+  if (snapshot.dialectVersion !== undefined && snapshot.dialectVersion !== POSTGRES_DIALECT_VERSION) {
+    throw new TypeError(
+      `@typed-sql/postgres grammar ${POSTGRES_DIALECT_VERSION} cannot use snapshot dialectVersion ${snapshot.dialectVersion}`,
+    );
   }
   return snapshot as PostgresSchemaSnapshot;
 }
@@ -28,10 +43,14 @@ export function postgres(
     id: "postgres",
     grammarVersion: POSTGRES_DIALECT_VERSION,
     sqlModule: "@typed-sql/postgres",
+    capabilities,
     defaultTypePolicy,
     placeholder(index: number): string {
       if (!Number.isInteger(index) || index < 1) throw new RangeError("PostgreSQL parameter indexes start at 1");
       return `$${index}`;
+    },
+    quoteIdentifier(identifier: string): string {
+      return `"${identifier.replaceAll('"', '""')}"`;
     },
     analyze(sql: string, snapshot: PostgresSchemaSnapshot, policy = defaultTypePolicy) {
       try {

--- a/packages/postgres/test/plugin.test.ts
+++ b/packages/postgres/test/plugin.test.ts
@@ -17,7 +17,9 @@ await describe("PostgreSQL dialect plugin", async () => {
     const dialect = postgres();
     strict.strictEqual(dialect.id, "postgres");
     strict.strictEqual(dialect.sqlModule, "@typed-sql/postgres");
+    strict.strictEqual(dialect.capabilities.returning, true);
     strict.strictEqual(dialect.placeholder(2), "$2");
+    strict.strictEqual(dialect.quoteIdentifier('account"status'), '"account""status"');
     strict.strictEqual(dialect.validateSnapshot(schema).dialect, "postgres");
     strict.strictEqual(dialect.analyze("SELECT id FROM users", schema).columns[0]?.tsType, "number");
     strict.strictEqual(dialect.analyze("SELECT", schema).diagnostics[0]?.code, "TSQ001");
@@ -26,6 +28,10 @@ await describe("PostgreSQL dialect plugin", async () => {
     strict.throws(
       () => dialect.validateSnapshot({ formatVersion: 1, dialect: "mysql", tables: {} }),
       /cannot use a mysql/,
+    );
+    strict.throws(
+      () => dialect.validateSnapshot({ ...schema, dialectVersion: "999" }),
+      /cannot use snapshot dialectVersion 999/,
     );
   });
 

--- a/packages/schema/src/loader.ts
+++ b/packages/schema/src/loader.ts
@@ -109,9 +109,13 @@ function parseObjectMap<T>(
 
 export function parseSchemaSnapshot(value: unknown): SchemaSnapshot {
   if (!isRecord(value)) throw new TypeError("Schema snapshot must be an object");
-  if (value.dialect !== "postgres" && value.dialect !== "mysql" && value.dialect !== "sqlite") {
-    throw new TypeError("schema.dialect must be postgres, mysql, or sqlite");
-  }
+  if (typeof value.dialect !== "string" || value.dialect.length === 0)
+    throw new TypeError("schema.dialect must be a non-empty string");
+  if (
+    value.dialectVersion !== undefined &&
+    (typeof value.dialectVersion !== "string" || value.dialectVersion.length === 0)
+  )
+    throw new TypeError("schema.dialectVersion must be a non-empty string");
   if (!isRecord(value.tables)) throw new TypeError("schema.tables must be an object");
   const tables: Record<string, TableSnapshot> = {};
   for (const [name, table] of Object.entries(value.tables)) tables[name] = parseTable(table, `schema.tables.${name}`);
@@ -127,7 +131,7 @@ export function parseSchemaSnapshot(value: unknown): SchemaSnapshot {
               );
             })(),
     dialect: value.dialect,
-    ...(typeof value.dialectVersion === "string" ? { dialectVersion: value.dialectVersion } : {}),
+    ...(value.dialectVersion === undefined ? {} : { dialectVersion: value.dialectVersion }),
     tables,
     ...(typeof value.version === "string" ? { version: value.version } : {}),
     ...(value.enums === undefined ? {} : { enums: parseStringArrays(value.enums, "schema.enums") }),

--- a/packages/schema/test/loader.test.ts
+++ b/packages/schema/test/loader.test.ts
@@ -62,6 +62,16 @@ await describe("schema snapshot loader", async () => {
     strict.deepStrictEqual(migrateSchemaSnapshot(legacy), fullSnapshot);
     strict.strictEqual(parseSchemaSnapshot(legacy).formatVersion, 1);
   });
+  await it("accepts dialect identifiers owned by third-party grammar packages", () => {
+    const snapshot = parseSchemaSnapshot({
+      formatVersion: 1,
+      dialect: "acme-warehouse",
+      dialectVersion: "2.4.0",
+      tables: {},
+    });
+    strict.strictEqual(snapshot.dialect, "acme-warehouse");
+    strict.strictEqual(snapshot.dialectVersion, "2.4.0");
+  });
   await it("loads complete snapshots, generated metadata, and policies", async () => {
     const directory = await mkdtemp(join(tmpdir(), "typed-sql-loader-"));
     try {
@@ -88,7 +98,8 @@ await describe("schema snapshot loader", async () => {
   await it("validates every nested snapshot shape", () => {
     const failures: readonly [unknown, RegExp][] = [
       [null, /snapshot must be an object/],
-      [{ dialect: "oracle", tables: {} }, /schema.dialect/],
+      [{ dialect: "", tables: {} }, /schema.dialect/],
+      [{ dialect: "oracle", dialectVersion: 1, tables: {} }, /schema.dialectVersion/],
       [{ dialect: "postgres", tables: [] }, /schema.tables/],
       [{ dialect: "postgres", tables: {}, formatVersion: 2 }, /formatVersion/],
       [{ dialect: "postgres", tables: { users: null } }, /users must be an object/],

--- a/test/contracts/grammar-conformance.test.ts
+++ b/test/contracts/grammar-conformance.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "poku";
+import {
+  DIALECT_CONTRACT_VERSION,
+  type DialectPlugin,
+  type SchemaSnapshot,
+  type SqlDiagnostic,
+} from "../../packages/core/src/index.js";
+import { mysql, typePolicy as mysqlTypePolicy } from "../../packages/mysql/src/index.js";
+import { mysqlRenderer } from "../../packages/mysql/src/runtime.js";
+import { postgres, typePolicy as postgresTypePolicy } from "../../packages/postgres/src/index.js";
+import { postgresRenderer } from "../../packages/postgres/src/runtime.js";
+import { parseSchemaSnapshot } from "../../packages/schema/src/index.js";
+import { assertDialectConformance } from "../grammar/conformance.js";
+
+const range = { start: 0, end: 1, line: 1, column: 1 } as const;
+const capabilities = {
+  aggregateFilter: false,
+  arrays: false,
+  distinctOn: false,
+  fullJoins: false,
+  recursiveCtes: false,
+  returning: false,
+  setOperations: false,
+} as const;
+
+const postgresSnapshot = {
+  formatVersion: 1,
+  dialect: "postgres",
+  dialectVersion: "1.0.0",
+  tables: {
+    widgets: {
+      name: "widgets",
+      columns: { value: { name: "value", databaseType: "bigint", tsType: "bigint", nullable: false } },
+    },
+  },
+} as const;
+
+const mysqlSnapshot = {
+  ...postgresSnapshot,
+  dialect: "mysql",
+} as const;
+
+interface SyntheticPolicy {
+  readonly scalar: "number" | "string";
+}
+
+const syntheticTypePolicy: SyntheticPolicy = Object.freeze({ scalar: "number" });
+
+const syntheticSnapshot = {
+  formatVersion: 1,
+  dialect: "synthetic",
+  dialectVersion: "1.0.0",
+  tables: {
+    widgets: {
+      name: "widgets",
+      columns: { value: { name: "value", databaseType: "scalar", tsType: "number", nullable: false } },
+    },
+  },
+} as const satisfies SchemaSnapshot;
+
+function validateSynthetic(value: unknown): typeof syntheticSnapshot {
+  const snapshot = parseSchemaSnapshot(value);
+  if (snapshot.dialect !== "synthetic") throw new TypeError(`synthetic cannot use ${snapshot.dialect}`);
+  if (snapshot.dialectVersion !== "1.0.0") throw new TypeError(`synthetic cannot use ${snapshot.dialectVersion}`);
+  return snapshot as typeof syntheticSnapshot;
+}
+
+const synthetic: DialectPlugin<typeof syntheticSnapshot, SyntheticPolicy> = Object.freeze({
+  contractVersion: DIALECT_CONTRACT_VERSION,
+  id: "synthetic",
+  grammarVersion: "1.0.0",
+  sqlModule: "@acme/typed-sql-synthetic",
+  capabilities,
+  defaultTypePolicy: syntheticTypePolicy,
+  placeholder(index: number): string {
+    if (!Number.isInteger(index) || index < 1) throw new RangeError("synthetic parameters start at 1");
+    return `?${index}`;
+  },
+  quoteIdentifier(identifier: string): string {
+    return `[${identifier.replaceAll("]", "]]")}]`;
+  },
+  analyze(sql: string, _snapshot: typeof syntheticSnapshot, policy: SyntheticPolicy = syntheticTypePolicy) {
+    if (sql === "SELECT value FROM widgets WHERE value = ?1") {
+      return {
+        columns: [{ name: "value", tsType: policy.scalar, nullable: false, databaseType: "scalar", range }],
+        parameters: [{ index: 1, tsType: policy.scalar, nullable: false, databaseType: "scalar" }],
+        diagnostics: [],
+      };
+    }
+    const diagnostic: SqlDiagnostic = {
+      code: "SYN001",
+      message: "Synthetic grammar does not support this statement",
+      severity: "error",
+      range: { ...range, end: sql.length },
+    };
+    return { columns: [], parameters: [], diagnostics: [diagnostic] };
+  },
+  validateSnapshot: validateSynthetic,
+});
+
+const syntheticRenderer = {
+  placeholder: (index: number) => synthetic.placeholder(index),
+  quoteIdentifier: (identifier: string) => synthetic.quoteIdentifier(identifier),
+};
+
+await describe("public dialect-plugin conformance", async () => {
+  await it("holds PostgreSQL to the public grammar contract", () => {
+    assertDialectConformance({
+      name: "postgres",
+      dialect: postgres(),
+      renderer: postgresRenderer,
+      snapshot: postgresSnapshot,
+      placeholderTwo: "$2",
+      identifier: 'account"status',
+      quotedIdentifier: '"account""status"',
+      expectedCapabilities: {
+        ...capabilities,
+        aggregateFilter: true,
+        arrays: true,
+        distinctOn: true,
+        fullJoins: true,
+        recursiveCtes: true,
+        returning: true,
+      },
+      query: "SELECT value FROM widgets WHERE value = $1",
+      expectedRowType: '{ "value": bigint; }',
+      expectedParameterType: "readonly [bigint]",
+      unsupportedQuery: "SELECT value FROM widgets UNION SELECT value FROM widgets",
+      unsupportedCode: "TSQ001",
+      policyProbe: {
+        query: "SELECT CAST(1 AS bigint) AS value",
+        policy: { ...postgresTypePolicy, bigint: "string" },
+        expectedRowType: '{ "value": string; }',
+      },
+    });
+  });
+
+  await it("holds MySQL to the same public grammar contract", () => {
+    assertDialectConformance({
+      name: "mysql",
+      dialect: mysql(),
+      renderer: mysqlRenderer,
+      snapshot: mysqlSnapshot,
+      placeholderTwo: "?",
+      identifier: "account`status",
+      quotedIdentifier: "`account``status`",
+      expectedCapabilities: capabilities,
+      query: "SELECT value FROM widgets WHERE value = ?",
+      expectedRowType: '{ "value": bigint; }',
+      expectedParameterType: "readonly [bigint]",
+      unsupportedQuery: "SELECT * FROM widgets FULL JOIN widgets AS other ON widgets.value = other.value",
+      unsupportedCode: "TSQ401",
+      policyProbe: {
+        query: "SELECT CAST(1 AS DECIMAL) AS value",
+        policy: { ...mysqlTypePolicy, decimal: "number" },
+        expectedRowType: '{ "value": number; }',
+      },
+    });
+  });
+
+  await it("accepts a synthetic third-party grammar with no internal imports", () => {
+    assertDialectConformance({
+      name: "synthetic",
+      dialect: synthetic,
+      renderer: syntheticRenderer,
+      snapshot: syntheticSnapshot,
+      placeholderTwo: "?2",
+      identifier: "account]status",
+      quotedIdentifier: "[account]]status]",
+      expectedCapabilities: capabilities,
+      query: "SELECT value FROM widgets WHERE value = ?1",
+      expectedRowType: '{ "value": number; }',
+      expectedParameterType: "readonly [number]",
+      unsupportedQuery: "UNSUPPORTED",
+      unsupportedCode: "SYN001",
+      policyProbe: {
+        query: "SELECT value FROM widgets WHERE value = ?1",
+        policy: { scalar: "string" },
+        expectedRowType: '{ "value": string; }',
+      },
+    });
+  });
+});

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -59,8 +59,17 @@ async function manifest(packageName: string): Promise<PackageManifest> {
 
 async function source(packageName: string): Promise<string> {
   const directoryPath = join(workspace, "packages", packageName, "src");
-  const files = (await readdir(directoryPath)).filter((file) => file.endsWith(".ts"));
-  return (await Promise.all(files.map((file) => readFile(join(directoryPath, file), "utf8")))).join("\n");
+  const files: string[] = [];
+  const visit = async (path: string): Promise<void> => {
+    for (const entry of await readdir(path, { withFileTypes: true })) {
+      const item = join(path, entry.name);
+      if (entry.isDirectory()) await visit(item);
+      else if (entry.name.endsWith(".ts")) files.push(item);
+    }
+  };
+  await visit(directoryPath);
+  files.sort();
+  return (await Promise.all(files.map((file) => readFile(file, "utf8")))).join("\n");
 }
 
 await describe("public package graph", async () => {
@@ -113,6 +122,33 @@ await describe("public package graph", async () => {
     strict.ok(!compiler.includes("@typed-sql/postgres"));
     strict.ok(!compiler.includes('=== "postgres"'));
     strict.deepStrictEqual(Object.keys((await manifest("compiler")).dependencies ?? {}), ["@typed-sql/core"]);
+  });
+
+  await it("keeps every neutral package free of dialect, driver, and SQL-feature decisions", async () => {
+    const neutralPackages = ["core", "compiler", "config", "schema"] as const;
+    const forbiddenSource = [
+      { label: "first-party dialect name", pattern: /\b(?:postgres(?:ql)?|mysql2?)\b/iu },
+      { label: "dialect-specific RETURNING", pattern: /\bRETURNING\b/u },
+      { label: "dialect-specific DISTINCT ON", pattern: /\bDISTINCT\s+ON\b/u },
+      { label: "dialect-specific FULL JOIN", pattern: /\bFULL\s+JOIN\b/u },
+      { label: "dialect-specific JSON_EXTRACT", pattern: /\bJSON_EXTRACT\b/u },
+      { label: "dialect-specific TIMESTAMPTZ", pattern: /\bTIMESTAMPTZ\b/u },
+    ] as const;
+    for (const packageName of neutralPackages) {
+      const packageSource = await source(packageName);
+      for (const forbidden of forbiddenSource) {
+        strict.ok(!forbidden.pattern.test(packageSource), `${packageName} contains ${forbidden.label}`);
+      }
+      const dependencies = Object.keys((await manifest(packageName)).dependencies ?? {});
+      for (const dependency of dependencies) {
+        strict.ok(
+          dependency !== "@typed-sql/postgres" &&
+            dependency !== "@typed-sql/mysql" &&
+            !forbiddenDrivers.has(dependency),
+          `${packageName} depends on dialect or driver ${dependency}`,
+        );
+      }
+    }
   });
 
   await it("loads editor grammars through config instead of a PostgreSQL dependency", async () => {

--- a/test/contracts/packed-consumer.test.ts
+++ b/test/contracts/packed-consumer.test.ts
@@ -27,8 +27,10 @@ await describe("packed public packages", async () => {
   await it("installs every tarball in isolation without a database driver", async () => {
     const temporary = await mkdtemp(join(tmpdir(), "typed-sql-packed-"));
     const tarballs = join(temporary, "tarballs");
+    const grammar = join(temporary, "grammar");
     const consumer = join(temporary, "consumer");
     await mkdir(tarballs);
+    await mkdir(grammar);
     await mkdir(consumer);
     try {
       const dependencies: Record<string, string> = {};
@@ -88,12 +90,105 @@ await describe("packed public packages", async () => {
       }
 
       await writeFile(
+        join(grammar, "package.json"),
+        `${JSON.stringify(
+          {
+            name: "@acme/typed-sql-synthetic",
+            version: "1.0.0",
+            type: "module",
+            exports: { ".": "./index.mjs" },
+            dependencies: {
+              "@typed-sql/core": dependencies["@typed-sql/core"],
+              "@typed-sql/schema": dependencies["@typed-sql/schema"],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await writeFile(
+        join(grammar, "index.mjs"),
+        `
+          import {
+            DIALECT_CONTRACT_VERSION,
+            assertDialectPlugin,
+            sql,
+          } from "@typed-sql/core";
+          import { parseSchemaSnapshot } from "@typed-sql/schema";
+
+          export { sql };
+          export const typePolicy = Object.freeze({ scalar: "number" });
+          export const SYNTHETIC_DIALECT_VERSION = "1.0.0";
+
+          const capabilities = Object.freeze({ returning: false });
+          const range = Object.freeze({ start: 0, end: 1, line: 1, column: 1 });
+
+          function validateSnapshot(value) {
+            const snapshot = parseSchemaSnapshot(value);
+            if (snapshot.dialect !== "synthetic") {
+              throw new TypeError(\`synthetic cannot use a \${snapshot.dialect} schema snapshot\`);
+            }
+            if (snapshot.dialectVersion !== SYNTHETIC_DIALECT_VERSION) {
+              throw new TypeError(
+                \`synthetic grammar \${SYNTHETIC_DIALECT_VERSION} cannot use snapshot dialectVersion \${snapshot.dialectVersion}\`,
+              );
+            }
+            return snapshot;
+          }
+
+          const plugin = Object.freeze({
+            contractVersion: DIALECT_CONTRACT_VERSION,
+            id: "synthetic",
+            grammarVersion: SYNTHETIC_DIALECT_VERSION,
+            sqlModule: "@acme/typed-sql-synthetic",
+            capabilities,
+            defaultTypePolicy: typePolicy,
+            placeholder(index) {
+              if (!Number.isInteger(index) || index < 1) throw new RangeError("synthetic parameters start at 1");
+              return \`?\${index}\`;
+            },
+            quoteIdentifier(identifier) {
+              return "[" + identifier.replaceAll("]", "]]") + "]";
+            },
+            analyze(text, _snapshot, policy = typePolicy) {
+              if (text === "SELECT value FROM widgets WHERE value = ?1") {
+                return {
+                  columns: [{ name: "value", tsType: policy.scalar, nullable: false, databaseType: "scalar", range }],
+                  parameters: [{ index: 1, tsType: policy.scalar, nullable: false, databaseType: "scalar" }],
+                  diagnostics: [],
+                };
+              }
+              return {
+                columns: [],
+                parameters: [],
+                diagnostics: [{
+                  code: "SYN001",
+                  message: "Synthetic grammar does not support this statement",
+                  severity: "error",
+                  range: { ...range, end: text.length },
+                }],
+              };
+            },
+            validateSnapshot,
+          });
+
+          assertDialectPlugin(plugin);
+          export function synthetic() {
+            return plugin;
+          }
+        `,
+      );
+
+      await writeFile(
         join(consumer, "package.json"),
         `${JSON.stringify(
           {
             private: true,
             type: "module",
-            dependencies,
+            dependencies: {
+              ...dependencies,
+              "@acme/typed-sql-synthetic": "file:../grammar",
+            },
             pnpm: {
               overrides: {
                 ...dependencies,
@@ -119,6 +214,8 @@ await describe("packed public packages", async () => {
         join(consumer, "verify.mjs"),
         `
         import { createRequire } from "node:module";
+        import { synthetic, sql as syntheticSql, typePolicy as syntheticTypePolicy } from "@acme/typed-sql-synthetic";
+        import { assertDialectPlugin, defineConfig, renderQuery } from "@typed-sql/core";
         import { postgres, sql as postgresSql, typePolicy as postgresTypePolicy } from "@typed-sql/postgres";
         import { postgresRenderer } from "@typed-sql/postgres/runtime";
         import { loadPgDriver } from "@typed-sql/postgres/pg";
@@ -126,9 +223,9 @@ await describe("packed public packages", async () => {
         import { mysqlRenderer } from "@typed-sql/mysql/runtime";
         import { loadMySql2Driver } from "@typed-sql/mysql/mysql2";
         import { compileSource } from "@typed-sql/compiler";
+        import { parseSchemaSnapshot } from "@typed-sql/schema";
         import "@typed-sql/ast";
         import "@typed-sql/config";
-        import "@typed-sql/schema";
         import "@typed-sql/ts-bridge";
         import "@typed-sql/language-server";
 
@@ -152,6 +249,47 @@ await describe("packed public packages", async () => {
           schema: { formatVersion: 1, dialect: "postgres", tables: {} },
         });
         if (compiled.queries.length !== 1 || !compiled.transformedSource.includes("sql<{")) throw new Error("packed package-root inference failed");
+
+        const externalDialect = synthetic();
+        assertDialectPlugin(externalDialect);
+        defineConfig({ dialect: externalDialect, schema: { file: "schema.json" }, outDir: "generated" });
+        const externalSnapshot = externalDialect.validateSnapshot(parseSchemaSnapshot({
+          formatVersion: 1,
+          dialect: "synthetic",
+          dialectVersion: "1.0.0",
+          tables: {
+            widgets: {
+              name: "widgets",
+              columns: {
+                value: { name: "value", databaseType: "scalar", tsType: "number", nullable: false },
+              },
+            },
+          },
+        }));
+        const externalCompiled = compileSource({
+          source: 'import { sql } from "@acme/typed-sql-synthetic"; const query = sql\`SELECT value FROM widgets WHERE value = \${1}\`;',
+          dialect: externalDialect,
+          schema: externalSnapshot,
+          typePolicy: syntheticTypePolicy,
+        });
+        if (externalCompiled.diagnostics.length !== 0 || externalCompiled.queries.length !== 1) {
+          throw new Error("external grammar could not compile from packed public packages");
+        }
+        if (!externalCompiled.transformedSource.includes('sql<{ "value": number; }, readonly [number]>')) {
+          throw new Error("external grammar inference contract failed");
+        }
+        const rendered = renderQuery(syntheticSql\`SELECT value FROM widgets WHERE value = \${42}\`, externalDialect);
+        if (rendered.text !== "SELECT value FROM widgets WHERE value = ?1" || rendered.values[0] !== 42) {
+          throw new Error("external grammar runtime contract failed");
+        }
+        const unsupported = compileSource({
+          source: 'import { sql } from "@acme/typed-sql-synthetic"; const query = sql\`UNSUPPORTED\`;',
+          dialect: externalDialect,
+          schema: externalSnapshot,
+        });
+        if (unsupported.queries.length !== 0 || !unsupported.diagnostics.some(({ code }) => code === "SYN001")) {
+          throw new Error("external grammar did not fail closed for unsupported SQL");
+        }
         try { await loadPgDriver(); throw new Error("missing pg did not fail"); }
         catch (error) { if (!String(error.message).includes("pnpm add pg")) throw error; }
         try { await loadMySql2Driver(); throw new Error("missing mysql2 did not fail"); }

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -16,6 +16,7 @@ import * as compilerApi from "../../packages/compiler/src/index.js";
 import * as configApi from "../../packages/config/src/index.js";
 import type {
   Database,
+  DialectCapabilities,
   DialectPlugin,
   OptionalSqlFragment,
   Query,
@@ -85,6 +86,7 @@ type ReferencedStableTypes =
   | ExtractedInterpolation
   | ExtractedQuery
   | TypeScriptCheckResult
+  | DialectCapabilities
   | DialectPlugin
   | OptionalSqlFragment
   | QueryExecutor
@@ -121,6 +123,7 @@ const expectedRuntimeExports = {
   compiler: ["checkFile", "compileSource", "extractStaticQueries", "mapSqlRange"],
   config: ["discoverConfig", "fromConfig", "loadConfig"],
   core: [
+    "assertDialectPlugin",
     "DIALECT_CONTRACT_VERSION",
     "ParameterCollector",
     "ResolverSchemaIndex",

--- a/test/grammar/conformance.ts
+++ b/test/grammar/conformance.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from "node:assert";
+import { compileSource } from "../../packages/compiler/src/index.js";
+import {
+  assertDialectPlugin,
+  type DialectPlugin,
+  defineConfig,
+  parameterTypeLiteral,
+  rowTypeLiteral,
+  type SchemaSnapshot,
+  type SqlRenderer,
+} from "../../packages/core/src/index.js";
+
+export interface DialectConformanceFixture<Snapshot extends SchemaSnapshot, Policy> {
+  readonly name: string;
+  readonly dialect: DialectPlugin<Snapshot, Policy>;
+  readonly renderer: SqlRenderer;
+  readonly snapshot: Snapshot;
+  readonly placeholderTwo: string;
+  readonly identifier: string;
+  readonly quotedIdentifier: string;
+  readonly expectedCapabilities: Readonly<Record<string, boolean>>;
+  readonly query: string;
+  readonly expectedRowType: string;
+  readonly expectedParameterType: string;
+  readonly unsupportedQuery: string;
+  readonly unsupportedCode: string;
+  readonly policyProbe?: {
+    readonly query: string;
+    readonly policy: Policy;
+    readonly expectedRowType: string;
+  };
+}
+
+export function assertDialectConformance<Snapshot extends SchemaSnapshot, Policy>(
+  fixture: DialectConformanceFixture<Snapshot, Policy>,
+): void {
+  const { dialect, snapshot } = fixture;
+  assertDialectPlugin(dialect);
+  assert.doesNotThrow(() =>
+    defineConfig({
+      dialect,
+      schema: { file: "schema.json" },
+      outDir: "generated",
+      typePolicy: dialect.defaultTypePolicy,
+    }),
+  );
+  assert.deepStrictEqual(dialect.capabilities, fixture.expectedCapabilities);
+  assert.ok(Object.values(dialect.capabilities).every((supported) => typeof supported === "boolean"));
+  assert.strictEqual(dialect.placeholder(2), fixture.placeholderTwo);
+  assert.strictEqual(dialect.placeholder(2), fixture.renderer.placeholder(2));
+  assert.throws(() => dialect.placeholder(0));
+  assert.strictEqual(dialect.quoteIdentifier(fixture.identifier), fixture.quotedIdentifier);
+  assert.strictEqual(dialect.quoteIdentifier(fixture.identifier), fixture.renderer.quoteIdentifier(fixture.identifier));
+  assert.strictEqual(dialect.validateSnapshot(snapshot).dialect, dialect.id);
+  assert.throws(() => dialect.validateSnapshot({ ...snapshot, dialect: `${dialect.id}-other` }));
+  assert.throws(() => dialect.validateSnapshot({ ...snapshot, dialectVersion: "incompatible" }));
+
+  const resolved = dialect.analyze(fixture.query, snapshot);
+  assert.deepStrictEqual(
+    resolved.diagnostics.filter((diagnostic) => diagnostic.severity === "error"),
+    [],
+    `${fixture.name} rejected its conformance query`,
+  );
+  assert.strictEqual(rowTypeLiteral(resolved.columns), fixture.expectedRowType);
+  assert.strictEqual(parameterTypeLiteral(1, resolved.parameters), fixture.expectedParameterType);
+
+  if (fixture.policyProbe !== undefined) {
+    const policyResult = dialect.analyze(fixture.policyProbe.query, snapshot, fixture.policyProbe.policy);
+    assert.deepStrictEqual(policyResult.diagnostics, []);
+    assert.strictEqual(rowTypeLiteral(policyResult.columns), fixture.policyProbe.expectedRowType);
+  }
+
+  const unsupported = dialect.analyze(fixture.unsupportedQuery, snapshot);
+  assert.ok(
+    unsupported.diagnostics.some(({ code, severity }) => code === fixture.unsupportedCode && severity === "error"),
+  );
+  const source = [
+    `import { sql } from ${JSON.stringify(dialect.sqlModule)};`,
+    "const query = sql`",
+    fixture.unsupportedQuery,
+    "`;",
+  ].join("\n");
+  const compiled = compileSource({ source, dialect, schema: snapshot });
+  assert.strictEqual(compiled.queries.length, 0, `${fixture.name} optimistically typed unsupported SQL`);
+  assert.ok(compiled.diagnostics.some(({ code }) => code === fixture.unsupportedCode));
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "rootDir": ".."
   },
-  "include": ["../packages/*/test/**/*.test.ts", "contracts/**/*.test.ts", "soundness/**/*.ts"],
+  "include": ["../packages/*/test/**/*.test.ts", "contracts/**/*.test.ts", "grammar/**/*.ts", "soundness/**/*.ts"],
   "exclude": ["fixtures"],
   "references": [
     { "path": "../packages/core" },


### PR DESCRIPTION
Closes #18

## What changed

- finalize dialect contract version 3 with identifier quoting and grammar-owned capability declarations
- validate dialect plugins consistently across core and config
- allow third-party dialect identifiers in neutral schema snapshots
- run PostgreSQL, MySQL, and a synthetic grammar through one public conformance harness
- install and execute an external synthetic grammar using only packed public packages
- add dependency/source guards against dialect and driver leakage in neutral packages
- document the public grammar-authoring and compatibility contract

## Verification

- `pnpm verify`
- focused Poku grammar, package-graph, schema, core, config, PostgreSQL, and MySQL suites
- packed external grammar consumer test

All checks pass locally. The shell reports Node 22.5.1 as below the declared >=22.11 engine, but the complete gate itself passes; protected CI runs the supported Node version.