### PR TITLE
Enforce structural and editor performance budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ pnpm e2e:packed
 - [Authoring a SQL grammar](./docs/GRAMMAR_AUTHORING.md)
 - [Inference soundness policy and corpus](./docs/SOUNDNESS.md)
 - [PostgreSQL and MySQL runtime codec fidelity](./docs/CODEC_FIDELITY.md)
+- [Performance budgets and methodology](./docs/PERFORMANCE.md)
 - [Compatibility and performance](./docs/COMPATIBILITY.md)
 - [Releasing](./docs/RELEASING.md)
 - [Diagnostic code registry](./packages/core/README.md#diagnostics)

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -27,13 +27,13 @@ the same classification in `typedSql.releaseTrack`. See [Public API](./PUBLIC_AP
 Database-to-TypeScript mappings, supported driver settings, precision behavior, and live runtime
 assertions are defined in [Runtime codec fidelity](./CODEC_FIDELITY.md).
 
-The compiler performance gate transforms 1,000 static query templates in at most 3,000ms on an
-unwarmed CI-compatible Node process. Parser fuzzing runs 2,000 deterministic arbitrary inputs.
-Compiler-critical packages enforce at least 95% statements, lines, and functions plus 90% branches.
-Structural compilation rejects work beyond 64 variants before invoking a grammar and verifies that
-repeated conditions remain correlated. Core additionally budgets construction/rendering of 25,000
-composed queries and 100,000 indexed lookups across a 5,000-table snapshot. Editor analysis bounds
-config, schema, analysis, and inspection caches plus initial workspace scanning.
+The versioned [production performance gate](./PERFORMANCE.md) reports p50, p95, variance, throughput,
+retained heap, and runtime/CPU context for scanner, compiler, structural expansion, core rendering,
+and editor analysis. Protected CI warns near the reviewed ceilings and blocks regressions beyond
+them. Package-local Poku budgets remain fast guards for parser security, resolver indexing,
+structural limits, composition, rendering, and cache bounds. Parser fuzzing runs 2,000 deterministic
+arbitrary inputs. Compiler-critical packages enforce at least 95% statements, lines, and functions
+plus 90% branches.
 
 PostgreSQL and MySQL currently implement grammar contract `1.0.0`. `grammarVersion` describes the
 snapshot/resolution semantics and intentionally does not change for npm-only prerelease or patch

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,79 @@
+# Performance budgets
+
+typed-sql treats responsiveness as a release contract. Package-local Poku tests catch obvious
+algorithmic regressions quickly; the repository production gate then measures built JavaScript with
+real grammar and language-service work.
+
+The thresholds are regression limits, not promises that every application or machine will observe
+the same latency. Every run prints its Node.js version, operating system, architecture, CPU model,
+logical CPU count, total memory, CI status, and budget version beside the measurements.
+
+## Run the gate
+
+```sh
+pnpm performance
+```
+
+`pnpm performance` creates production builds before measuring them. `pnpm verify` also builds and
+runs the gate, so protected CI blocks a pull request that exceeds a failure threshold.
+
+The versioned source of truth is [`performance-budgets.json`](../performance-budgets.json). Changes
+to fixtures, sample counts, or limits are reviewed as code rather than hidden in a benchmark script
+or CI environment.
+
+## Methodology
+
+Latency scenarios receive three warm-up executions followed by 20 measured executions. Cold editor
+scenarios use 10 fresh-service samples. Reports include minimum, mean, standard deviation,
+coefficient of variation, p50, p95, and maximum. CI emits a warning after a metric consumes 75% of
+its budget and fails when p50 or p95 exceeds its configured ceiling.
+
+Measurements use production files under each package's `dist` directory and cover:
+
+- scanning one TypeScript file containing 1,000 static queries;
+- compiling 250 queries with the PostgreSQL parser and resolver;
+- 20 repeated correlated conditions, which must produce exactly two grammar analyses;
+- six independent conditions, which must produce exactly 64 analyses;
+- 20 independent conditions, which must stop before grammar analysis with `TSQ003`;
+- core fragment composition and rendering in batches of 10,000 queries;
+- cold, unchanged, incrementally edited, and schema-reloaded language-service analysis for a file
+  containing 120 queries;
+- cancellation before expensive analysis of a 2,000-query document;
+- retained heap after 128 analyzed documents compete for a 32-entry cache.
+
+The structural fixtures assert their analysis counts in addition to measuring time. A fast but
+incorrect variant implementation therefore cannot pass.
+
+## Version 1 failure budgets
+
+| Scenario | p50 | p95 |
+| --- | ---: | ---: |
+| Scanner, 1,000 queries | 10 ms | 25 ms |
+| Compiler, 250 PostgreSQL queries | 20 ms | 50 ms |
+| 20 correlated conditions | 5 ms | 10 ms |
+| Six independent conditions | 10 ms | 25 ms |
+| Structural limit rejection | 5 ms | 10 ms |
+| Editor cold analysis | 75 ms | 150 ms |
+| Editor incremental analysis | 30 ms | 75 ms |
+| Editor unchanged cache hit | 0.5 ms | 1 ms |
+| Editor schema reload | 30 ms | 75 ms |
+| Editor cancelled request | 0.5 ms | 1 ms |
+
+Core composition and rendering must sustain a p50 of at least 250,000 operations per second. The
+bounded editor cache may retain at most 16 MiB after garbage collection in the memory fixture.
+
+These ceilings deliberately leave room for supported GitHub-hosted runners while remaining close
+enough to measured work to catch order-of-magnitude regressions. Tightening or relaxing them
+requires an updated budget version or a documented fixture/runtime justification.
+
+## Cancellation and event-loop limits
+
+Language-service requests check cancellation before configuration work, after schema loading, and
+after analysis. Workspace discovery checks between directory entries. The performance fixture proves
+that cancellation arriving during asynchronous setup aborts before the 2,000-query compile begins.
+
+Grammar analysis itself is currently synchronous. A cancellation received during that bounded
+section is observed immediately afterward, so the cold and incremental p95 ceilings are also the
+responsiveness guard against monopolizing the editor process. We do not claim mid-parser
+preemption. If valid workloads approach those ceilings, analysis should move behind a worker or
+gain an asynchronous cooperative boundary before increasing the budgets.

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -12,8 +12,8 @@ current public release line is `1.0.0-beta.*` under the npm `next` tag.
 
 The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
 of a complete registry-only consumer test, an unrehearsed stable version transition, and
-insufficient external beta soak time. Reproducible editor installation and performance budgets also
-remain open gates.
+insufficient external beta soak time. Reproducible external editor installation also remains an
+open gate.
 
 ## Definition of ready
 
@@ -127,6 +127,11 @@ tarballs, compiles and renders a query, checks grammar/snapshot compatibility, a
 SQL fails closed. Neutral package scans reject dialect names, driver dependencies, and dialect SQL
 features in core, compiler, config, and schema sources. The public author contract is documented in
 [Authoring a SQL grammar](./GRAMMAR_AUTHORING.md).
+
+Structural and editor performance is enforced against production builds by the versioned
+[performance gate](./PERFORMANCE.md). It reports p50, p95, variance, retained heap, throughput, and
+runtime/CPU context. Correlated and independent condition counts are asserted directly, and
+`TSQ003` must stop over-limit expansion before a grammar is invoked.
 
 Acceptance criteria:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "node scripts/clean-build.mjs && node scripts/require-typescript-7.mjs && tsc -b && pnpm --filter ./packages/vscode build:bundle",
     "changeset": "changeset",
-    "verify": "pnpm quality && pnpm test && pnpm coverage && pnpm build",
+    "verify": "pnpm quality && pnpm test && pnpm coverage && pnpm build && pnpm performance:gate",
     "quality": "biome check .",
     "format": "biome check --write .",
     "clean": "node scripts/clean-build.mjs",
@@ -25,6 +25,8 @@
     "test:contracts": "poku test/contracts --reporter=compact --enforce",
     "test:pack": "poku test/contracts/packed-consumer.test.ts --reporter=compact --enforce",
     "test:soundness": "poku packages/postgres/test/soundness.test.ts packages/mysql/test/soundness.test.ts packages/compiler/test/soundness.test.ts packages/cli/test/soundness.test.ts packages/ts-bridge/test/soundness.test.ts packages/language-server/test/soundness.test.ts --reporter=compact --enforce",
+    "performance": "pnpm build && pnpm performance:gate",
+    "performance:gate": "node --expose-gc scripts/performance-gate.mjs",
     "release:artifacts": "pnpm build && pnpm test:pack",
     "release:assert": "node scripts/assert-release-channel.mjs",
     "release:security": "node scripts/code-scanning-policy.mjs",

--- a/performance-budgets.json
+++ b/performance-budgets.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "methodology": {
+    "warmups": 3,
+    "samples": 20,
+    "coldSamples": 10,
+    "warningRatio": 0.75
+  },
+  "latencyMs": {
+    "scanner.largeFile": { "p50": 10, "p95": 25 },
+    "compiler.manyQueries": { "p50": 20, "p95": 50 },
+    "compiler.correlatedConditions": { "p50": 5, "p95": 10 },
+    "compiler.independentConditions": { "p50": 10, "p95": 25 },
+    "compiler.structuralLimit": { "p50": 5, "p95": 10 },
+    "editor.coldAnalysis": { "p50": 75, "p95": 150 },
+    "editor.incrementalAnalysis": { "p50": 30, "p95": 75 },
+    "editor.unchangedAnalysis": { "p50": 0.5, "p95": 1 },
+    "editor.schemaReload": { "p50": 30, "p95": 75 },
+    "editor.cancelledRequest": { "p50": 0.5, "p95": 1 }
+  },
+  "throughput": {
+    "core.composeAndRender": { "minimumOperationsPerSecond": 250000 }
+  },
+  "memory": {
+    "editor.retainedHeapMiB": { "maximum": 16 }
+  }
+}

--- a/scripts/performance-gate.mjs
+++ b/scripts/performance-gate.mjs
@@ -1,0 +1,329 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { cpus, platform, release, tmpdir, totalmem } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { compileSource, extractStaticQueries } from "../packages/compiler/dist/packages/compiler/src/index.js";
+import { renderQuery, sql } from "../packages/core/dist/packages/core/src/index.js";
+import { TypedSqlLanguageService } from "../packages/language-server/dist/packages/language-server/src/index.js";
+import { postgres } from "../packages/postgres/dist/packages/postgres/src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const budgets = JSON.parse(await readFile(join(workspace, "performance-budgets.json"), "utf8"));
+const methodology = budgets.methodology;
+const results = {};
+const processors = cpus();
+const context = {
+  node: process.version,
+  platform: platform(),
+  platformRelease: release(),
+  architecture: process.arch,
+  cpuModel: processors[0]?.model ?? "unknown",
+  logicalCpuCount: processors.length,
+  totalMemoryMiB: Math.round(totalmem() / 1024 / 1024),
+  ci: process.env.CI === "true",
+  productionBuild: true,
+  budgetVersion: budgets.version,
+};
+console.log(`typed-sql performance context\n${JSON.stringify(context, null, 2)}`);
+
+function percentile(samples, quantile) {
+  const ordered = [...samples].sort((left, right) => left - right);
+  return ordered[Math.max(0, Math.ceil(ordered.length * quantile) - 1)];
+}
+
+function statistics(samples) {
+  const mean = samples.reduce((total, sample) => total + sample, 0) / samples.length;
+  const variance = samples.reduce((total, sample) => total + (sample - mean) ** 2, 0) / samples.length;
+  const standardDeviation = Math.sqrt(variance);
+  return {
+    samples: samples.length,
+    minimum: Math.min(...samples),
+    mean,
+    standardDeviation,
+    coefficientOfVariation: mean === 0 ? 0 : standardDeviation / mean,
+    p50: percentile(samples, 0.5),
+    p95: percentile(samples, 0.95),
+    maximum: Math.max(...samples),
+  };
+}
+
+async function latency(name, operation, options = {}) {
+  const warmups = options.warmups ?? methodology.warmups;
+  const sampleCount = options.samples ?? methodology.samples;
+  for (let index = 0; index < warmups; index += 1) await operation(index);
+  const samples = [];
+  for (let index = 0; index < sampleCount; index += 1) {
+    const start = performance.now();
+    await operation(index);
+    samples.push(performance.now() - start);
+  }
+  const measured = statistics(samples);
+  const budget = budgets.latencyMs[name];
+  assert.ok(budget !== undefined, `Missing latency budget for ${name}`);
+  results[name] = { unit: "ms", ...measured, budget };
+  warnNearBudget(name, measured.p50, budget.p50, "p50");
+  warnNearBudget(name, measured.p95, budget.p95, "p95");
+  assert.ok(measured.p50 <= budget.p50, `${name} p50 ${measured.p50.toFixed(2)}ms exceeded ${budget.p50}ms`);
+  assert.ok(measured.p95 <= budget.p95, `${name} p95 ${measured.p95.toFixed(2)}ms exceeded ${budget.p95}ms`);
+}
+
+function warnNearBudget(name, actual, maximum, statistic) {
+  if (actual <= maximum * methodology.warningRatio) return;
+  const message = `${name} ${statistic} ${actual.toFixed(2)} is above ${Math.round(methodology.warningRatio * 100)}% of ${maximum}`;
+  warn(message);
+}
+
+function warn(message) {
+  if (process.env.GITHUB_ACTIONS === "true") console.warn(`::warning title=typed-sql performance::${message}`);
+  else console.warn(`WARNING ${message}`);
+}
+
+function manyQuerySource(count) {
+  return [
+    'import { sql } from "@typed-sql/postgres";',
+    ...Array.from(
+      { length: count },
+      (_, index) =>
+        `export const query_${index} = sql\`SELECT account.id, account.email FROM users AS account WHERE account.id >= \${${index}n}\`;`,
+    ),
+  ].join("\n");
+}
+
+function structuralSource(conditions) {
+  return [
+    'import { sql } from "@typed-sql/postgres";',
+    `interface Selection { ${[...new Set(conditions)].map((name) => `${name}: boolean`).join("; ")} }`,
+    "export function accounts<const Select extends Selection>(select: Select) {",
+    "  return sql`SELECT account.id, account.email",
+    ...conditions.map(
+      (name, index) => `    \${select.${name} ? sql.fragment\`, ${index + 1} AS value_${index}\` : sql.empty}`,
+    ),
+    "    FROM users AS account`;",
+    "}",
+  ].join("\n");
+}
+
+const snapshot = {
+  formatVersion: 1,
+  dialect: "postgres",
+  dialectVersion: "1.0.0",
+  tables: {
+    users: {
+      name: "users",
+      columns: {
+        id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+        email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
+      },
+    },
+  },
+};
+const dialect = postgres();
+const scannerSource = manyQuerySource(1_000);
+const compilerSource = manyQuerySource(250);
+
+await latency("scanner.largeFile", () => {
+  const extracted = extractStaticQueries(scannerSource, (index) => `$${index}`, ["@typed-sql/postgres"]);
+  assert.equal(extracted.length, 1_000);
+});
+
+await latency("compiler.manyQueries", () => {
+  const compiled = compileSource({ source: compilerSource, schema: snapshot, dialect });
+  assert.equal(compiled.queries.length, 250);
+  assert.deepEqual(compiled.diagnostics, []);
+});
+
+async function structuralMetric(name, conditions, expectedAnalyses, expectedCode) {
+  let analyses = 0;
+  const measuredDialect = {
+    ...dialect,
+    analyze(...args) {
+      analyses += 1;
+      return dialect.analyze(...args);
+    },
+  };
+  await latency(name, () => {
+    analyses = 0;
+    const compiled = compileSource({
+      source: structuralSource(conditions),
+      schema: snapshot,
+      dialect: measuredDialect,
+      maxStructuralVariants: 64,
+    });
+    assert.equal(analyses, expectedAnalyses);
+    if (expectedCode === undefined) {
+      assert.deepEqual(compiled.diagnostics, []);
+      assert.equal(compiled.queries.length, 1);
+    } else {
+      assert.equal(compiled.diagnostics[0]?.code, expectedCode);
+      assert.equal(compiled.queries.length, 0);
+    }
+  });
+}
+
+await structuralMetric(
+  "compiler.correlatedConditions",
+  Array.from({ length: 20 }, () => "details"),
+  2,
+);
+await structuralMetric(
+  "compiler.independentConditions",
+  Array.from({ length: 6 }, (_, index) => `field_${index}`),
+  64,
+);
+await structuralMetric(
+  "compiler.structuralLimit",
+  Array.from({ length: 20 }, (_, index) => `field_${index}`),
+  0,
+  "TSQ003",
+);
+
+const coreIterations = 10_000;
+const coreSamples = [];
+for (let warmup = 0; warmup < methodology.warmups; warmup += 1) {
+  for (let index = 0; index < coreIterations; index += 1) {
+    renderQuery(sql`SELECT ${sql.ident("id")} FROM users WHERE id = ${index}`, dialect);
+  }
+}
+for (let sample = 0; sample < methodology.samples; sample += 1) {
+  const start = performance.now();
+  for (let index = 0; index < coreIterations; index += 1) {
+    const predicate = sql.and([
+      sql.fragment`account.id >= ${index}`,
+      index % 2 === 0 ? sql.fragment`account.email = ${"person@example.com"}` : undefined,
+    ]);
+    renderQuery(sql`SELECT ${sql.ident("id")} FROM users AS account WHERE ${predicate}`, dialect);
+  }
+  coreSamples.push((coreIterations * 1_000) / (performance.now() - start));
+}
+const coreThroughput = statistics(coreSamples);
+const coreBudget = budgets.throughput["core.composeAndRender"];
+results["core.composeAndRender"] = { unit: "operations/second", ...coreThroughput, budget: coreBudget };
+if (coreThroughput.p50 < coreBudget.minimumOperationsPerSecond / methodology.warningRatio) {
+  warn(
+    `core.composeAndRender p50 ${coreThroughput.p50.toFixed(0)} ops/s is approaching ${coreBudget.minimumOperationsPerSecond}`,
+  );
+}
+assert.ok(
+  coreThroughput.p50 >= coreBudget.minimumOperationsPerSecond,
+  `core.composeAndRender p50 ${coreThroughput.p50.toFixed(0)} ops/s fell below ${coreBudget.minimumOperationsPerSecond}`,
+);
+
+const temporary = await mkdtemp(join(tmpdir(), "typed-sql-performance-"));
+try {
+  const schemaPath = join(temporary, "schema.json");
+  const configPath = join(temporary, "typed-sql.config.mjs");
+  const postgresModule = pathToFileURL(join(workspace, "packages/postgres/dist/packages/postgres/src/index.js")).href;
+  await writeFile(schemaPath, `${JSON.stringify(snapshot)}\n`);
+  await writeFile(
+    configPath,
+    `import { postgres } from ${JSON.stringify(postgresModule)};\nexport default { dialect: postgres(), schema: { file: "schema.json" }, outDir: "generated" };\n`,
+  );
+  const editorSource = manyQuerySource(120);
+  const editorDocument = (name, version, text = editorSource) => ({
+    uri: pathToFileURL(join(temporary, name)).href,
+    languageId: "typescript",
+    version,
+    getText: () => text,
+  });
+  const settings = { configPath, schemaPath, nativePreview: false, maxCacheEntries: 32 };
+
+  await latency(
+    "editor.coldAnalysis",
+    async (index) => {
+      const service = new TypedSqlLanguageService(temporary, settings);
+      try {
+        const analysis = await service.analysis(editorDocument(`cold-${index}.ts`, 1));
+        assert.equal(analysis?.queries.length, 120);
+      } finally {
+        await service.close();
+      }
+    },
+    { warmups: 1, samples: methodology.coldSamples },
+  );
+
+  const service = new TypedSqlLanguageService(temporary, settings);
+  try {
+    const uriName = "incremental.ts";
+    await service.analysis(editorDocument(uriName, 1));
+    await latency("editor.unchangedAnalysis", async () => {
+      const analysis = await service.analysis(editorDocument(uriName, 1));
+      assert.equal(analysis?.queries.length, 120);
+    });
+
+    let version = 1;
+    await latency("editor.incrementalAnalysis", async (index) => {
+      version += 1;
+      const analysis = await service.analysis(editorDocument(uriName, version, `${editorSource}\n// edit ${index}`));
+      assert.equal(analysis?.queries.length, 120);
+    });
+
+    await latency(
+      "editor.schemaReload",
+      async (index) => {
+        const modified = new Date(Date.now() + (index + 1) * 1_000);
+        await utimes(schemaPath, modified, modified);
+        const analysis = await service.analysis(editorDocument(uriName, version));
+        assert.equal(analysis?.queries.length, 120);
+      },
+      { warmups: 1, samples: methodology.coldSamples },
+    );
+
+    await latency("editor.cancelledRequest", async () => {
+      let checks = 0;
+      await assert.rejects(
+        () =>
+          service.analysis(editorDocument("cancelled.ts", 1, manyQuerySource(2_000)), {
+            get isCancellationRequested() {
+              checks += 1;
+              return checks > 1;
+            },
+          }),
+        (error) => error instanceof Error && error.name === "AbortError",
+      );
+    });
+
+    service.invalidate();
+    globalThis.gc?.();
+    const heapBefore = process.memoryUsage().heapUsed;
+    for (let index = 0; index < 128; index += 1) {
+      const analysis = await service.analysis(
+        editorDocument(`memory-${index}.ts`, 1, `${manyQuerySource(100)}\n// document ${index}`),
+      );
+      assert.equal(analysis?.queries.length, 100);
+    }
+    globalThis.gc?.();
+    const retainedHeapMiB = Math.max(0, process.memoryUsage().heapUsed - heapBefore) / 1024 / 1024;
+    const memoryBudget = budgets.memory["editor.retainedHeapMiB"];
+    results["editor.retainedHeapMiB"] = {
+      unit: "MiB",
+      value: retainedHeapMiB,
+      budget: memoryBudget,
+      cacheSizes: service.cacheSizes(),
+    };
+    if (retainedHeapMiB > memoryBudget.maximum * methodology.warningRatio) {
+      warn(`editor.retainedHeapMiB ${retainedHeapMiB.toFixed(2)}MiB is approaching ${memoryBudget.maximum}MiB`);
+    }
+    assert.ok(service.cacheSizes().analyses <= 32);
+    assert.ok(
+      retainedHeapMiB <= memoryBudget.maximum,
+      `editor.retainedHeapMiB ${retainedHeapMiB.toFixed(2)}MiB exceeded ${memoryBudget.maximum}MiB`,
+    );
+  } finally {
+    await service.close();
+  }
+} finally {
+  await rm(temporary, { recursive: true, force: true });
+}
+
+console.log(
+  JSON.stringify(
+    {
+      context,
+      results,
+    },
+    null,
+    2,
+  ),
+);

--- a/test/contracts/performance-policy.test.ts
+++ b/test/contracts/performance-policy.test.ts
@@ -1,0 +1,73 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, strict } from "poku";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+interface PerformanceBudgets {
+  readonly version: number;
+  readonly methodology: {
+    readonly warmups: number;
+    readonly samples: number;
+    readonly coldSamples: number;
+    readonly warningRatio: number;
+  };
+  readonly latencyMs: Readonly<Record<string, { readonly p50: number; readonly p95: number }>>;
+  readonly throughput: Readonly<Record<string, { readonly minimumOperationsPerSecond: number }>>;
+  readonly memory: Readonly<Record<string, { readonly maximum: number }>>;
+}
+
+await describe("performance regression policy", async () => {
+  const budgets = JSON.parse(await readFile(join(workspace, "performance-budgets.json"), "utf8")) as PerformanceBudgets;
+
+  await it("uses versioned percentile methodology and complete release metrics", () => {
+    strict.ok(Number.isSafeInteger(budgets.version) && budgets.version > 0);
+    strict.ok(budgets.methodology.warmups >= 1);
+    strict.ok(budgets.methodology.samples >= 20);
+    strict.ok(budgets.methodology.coldSamples >= 10);
+    strict.ok(budgets.methodology.warningRatio > 0 && budgets.methodology.warningRatio < 1);
+    strict.deepStrictEqual(Object.keys(budgets.latencyMs).sort(), [
+      "compiler.correlatedConditions",
+      "compiler.independentConditions",
+      "compiler.manyQueries",
+      "compiler.structuralLimit",
+      "editor.cancelledRequest",
+      "editor.coldAnalysis",
+      "editor.incrementalAnalysis",
+      "editor.schemaReload",
+      "editor.unchangedAnalysis",
+      "scanner.largeFile",
+    ]);
+    for (const [name, budget] of Object.entries(budgets.latencyMs)) {
+      strict.ok(budget.p50 > 0, `${name} has no p50 budget`);
+      strict.ok(budget.p95 >= budget.p50, `${name} p95 is below p50`);
+    }
+    strict.ok((budgets.throughput["core.composeAndRender"]?.minimumOperationsPerSecond ?? 0) > 0);
+    strict.ok((budgets.memory["editor.retainedHeapMiB"]?.maximum ?? 0) > 0);
+  });
+
+  await it("runs the gate after production build and records reproducibility context", async () => {
+    const manifest = JSON.parse(await readFile(join(workspace, "package.json"), "utf8")) as {
+      readonly scripts: Readonly<Record<string, string>>;
+    };
+    const verify = manifest.scripts.verify ?? "";
+    strict.ok(verify.indexOf("pnpm build") < verify.indexOf("pnpm performance:gate"));
+    strict.ok(manifest.scripts.performance?.startsWith("pnpm build &&"));
+
+    const gate = await readFile(join(workspace, "scripts", "performance-gate.mjs"), "utf8");
+    for (const evidence of [
+      "/dist/",
+      "coefficientOfVariation",
+      "cpuModel",
+      "productionBuild: true",
+      "globalThis.gc",
+      '"TSQ003"',
+      "expectedAnalyses",
+      "cacheSizes",
+      "isCancellationRequested",
+    ]) {
+      strict.ok(gate.includes(evidence), `performance gate does not record ${evidence}`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #19

## What changed

- add versioned, reviewable p50/p95 latency, throughput, and retained-memory budgets
- benchmark production builds with the PostgreSQL grammar and language service
- cover scanner scale, many queries, correlated and independent structural conditions, pre-grammar `TSQ003`, core composition/rendering, cold and incremental editor work, unchanged cache hits, schema reloads, cancellation, and cache saturation
- report sample variance and complete Node/runtime/CPU context
- warn at 75% of a ceiling and fail protected verification beyond the budget
- add a Poku policy contract that prevents the performance gate from drifting out of `pnpm verify` or running before production build
- document the methodology, exact fixtures, limitations, and non-guarantee boundary

## Verification

- `pnpm verify` on Node 24.10.0
- `pnpm performance:gate`
- focused Poku compiler/core/language-service performance and policy suites

All local gates pass.