### PR TITLE
feat(editor): harden external installation reliability

### DIFF
--- a/.changeset/editor-reliability.md
+++ b/.changeset/editor-reliability.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Make external editor startup reproducible from the installed package. Route multi-root workspaces
+through independent grammar/config/schema services, keep generated schema reloads synchronized with
+the TypeScript overlay, guard preview process failures with actionable errors, and launch the packed
+language-server executable in PostgreSQL and MySQL editor smoke tests.

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ query overlay in memory, asks the native TypeScript checker for the real program
 hover/diagnostic positions back to the unchanged source.
 
 - **Zed:** the repository includes a native extension and a project-local configuration. The
-  typed-sql server replaces the ordinary TypeScript server so Zed does not show a competing
-  `Query<unknown>`. See the [Zed guide](./editors/zed/README.md).
+  extension automatically resolves `@typed-sql/language-server@next` from the application, with no
+  absolute binary path. The typed-sql server replaces the ordinary TypeScript server so Zed does
+  not show a competing `Query<unknown>`. See the [Zed guide](./editors/zed/README.md).
 - **VS Code:** the experimental extension provides inferred hovers, SQL diagnostics, completion,
   definitions, quick fixes, cancellation, and bounded caches. See the
   [VS Code guide](./packages/vscode/README.md).
@@ -276,7 +277,7 @@ hover/diagnostic positions back to the unchanged source.
 
 TypeScript `7.0.2` is the correctness compiler. A separately pinned `7.1` preview lives behind an
 isolated process boundary for the editor bridge, so upstream API churn cannot leak into the grammar
-or query contract.
+or query contract. The bridge does not require `tsserver.js` from the workspace TypeScript package.
 
 ## Packages
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | Stable | `core`, `ast`, `schema`, `config`, `compiler`, `postgres`, `mysql`, `cli` | Move to `1.0.0` under `latest` after all release gates pass |
 | Experimental | `ts-bridge`, `language-server` | Remain prerelease under `next` while they depend on TypeScript preview APIs |
-| Experimental/private | VS Code and Zed integrations | No stable distribution promise until external installation tests pass |
+| Experimental/private | VS Code and Zed integrations (`0.1.x`) | Source/VSIX development distribution only; no Marketplace or Zed registry stability promise |
 
 The release workflow validates this split from `release-manifest.json`; every public package records
 the same classification in `typedSql.releaseTrack`. See [Public API](./PUBLIC_API.md).
@@ -42,3 +42,9 @@ publishes; incompatible grammar semantics require an explicit grammar-version ch
 TypeScript 7.0 intentionally has no stable embeddable API. Therefore CLI checks and source
 transforms are authoritative, while the preview bridge is isolated behind a process boundary and
 can be replaced without changing the grammar or generated-query contract.
+
+The language server installs its exact TypeScript 7.1 preview as an internal dependency and never
+looks for a workspace `tsserver.js`. Its beta version and npm `next` tag identify that preview-backed
+contract; stable grammar packages do not acquire a preview dependency. Clean packed-consumer tests
+launch the installed executable for PostgreSQL and MySQL, while the private editor integrations stay
+on `0.1.x` until their editor-store distribution paths are supported.

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -12,8 +12,8 @@ current public release line is `1.0.0-beta.*` under the npm `next` tag.
 
 The project is not ready to publish under `latest` yet. Stable promotion is blocked by the absence
 of a complete registry-only consumer test, an unrehearsed stable version transition, and
-insufficient external beta soak time. Reproducible external editor installation also remains an
-open gate.
+insufficient external beta soak time. Packed external editor startup, schema reload, restart, and
+multi-root behavior are now enforced; registry-only verification remains part of the consumer gate.
 
 ## Definition of ready
 
@@ -78,9 +78,10 @@ Decision:
 - encode the split in `release-manifest.json`, each packed package manifest, stable release
   assertions, entrypoint contract tests, and [the public API contract](./PUBLIC_API.md).
 
-The package boundary is frozen. Reproducible external editor installation remains a separate 1.0
-gate tracked by [issue #20](https://github.com/Lojhan/typed-sql/issues/20); it does not promote the
-preview-backed packages to the stable train.
+The package boundary is frozen. External editor installation is exercised from packed PostgreSQL
+and MySQL consumers without repository-relative binary paths. The preview-backed packages remain on
+the experimental prerelease train; the private VS Code and Zed integrations remain `0.1.x` until
+their editor-store distribution paths are supported.
 
 Acceptance criteria:
 

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -552,7 +552,7 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "typed-sql-zed"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-sql-zed"
-version = "1.0.0"
+version = "0.1.0"
 edition = "2024"
 
 [lib]

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,20 +1,65 @@
-# typed-sql for Zed
+# typed-sql for Zed (experimental)
 
-This development extension runs the workspace build of `@typed-sql/language-server`. That server
-proxies the pinned TypeScript 7.1 preview after applying typed-sql's in-memory source transform, so it
-replaces Zed's normal TypeScript server for TypeScript and TSX in this worktree.
+The Zed extension runs the project-local `@typed-sql/language-server`. It applies typed-sql's
+in-memory query overlay before the pinned TypeScript 7.1 preview checks the program, so hovers on the
+query and every downstream value contain the exact row type.
 
-1. Run `pnpm build` at the repository root.
-2. In Zed, run `zed: install dev extension` from the command palette.
-3. Select this `editors/zed` directory.
-4. Run `pnpm --filter @typed-sql/e2e-postgres generate:snapshot` to reproducibly rebuild the example
-   from the committed catalog snapshot (or `pnpm e2e:postgres` with PostgreSQL running).
-5. Open `e2e/postgres/src/query.ts` and hover `query`, `rows`, and `Actual`.
+## Install in an application
 
-The repository's `.zed/settings.json` lists only `typed-sql` for TypeScript and TSX and points it at
-the E2E config/schema. The config imports the installed PostgreSQL grammar; the language server does
-not hard-code it. Do not add `"..."`, `vtsls`, or `typescript-language-server` to those arrays: those
-servers see the original tag signature and will report `Query<unknown>` alongside the transformed
-result. For another worktree, configure `configPath` under `lsp.typed-sql.settings` (and use
-`schemaPath` only as an override) and set
-`lsp.typed-sql.binary.path` to an installed `typed-sql-language-server` executable.
+From the application root:
+
+```sh
+pnpm add -D @typed-sql/language-server@next
+```
+
+Install this `editors/zed` directory with **zed: install dev extension**, then add:
+
+```json
+{
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["typed-sql", "!vtsls", "!typescript-language-server"]
+    },
+    "TSX": {
+      "language_servers": ["typed-sql", "!vtsls", "!typescript-language-server"]
+    }
+  },
+  "lsp": {
+    "typed-sql": {
+      "settings": {
+        "configPath": "typed-sql.config.ts",
+        "projectFile": "tsconfig.json",
+        "nativePreview": true
+      }
+    }
+  }
+}
+```
+
+No binary path is required. Resolution is deterministic: an explicit Zed binary setting wins, then
+the extension uses the application package at
+`node_modules/@typed-sql/language-server`, then a `typed-sql-language-server` on the worktree PATH,
+and finally a typed-sql monorepo development build. If none exists, Zed reports the exact `pnpm add`
+command instead of attempting an absolute development path.
+
+`schemaPath` is optional; leaving it unset uses `schema.file` from the discovered config. In a
+multi-root workspace, Zed starts per-worktree servers and the language server also routes every
+workspace folder through its own config, installed grammar, schema, and TypeScript project.
+
+## TypeScript server warning
+
+typed-sql does not load the workspace's `tsserver.js`. TypeScript 7.0 may intentionally ship without
+that legacy entrypoint, while typed-sql owns an isolated, pinned TypeScript 7.1 preview process. A
+Zed warning that its built-in TypeScript integration fell back to a bundled TypeScript does not
+describe typed-sql's process. Keeping only `typed-sql` in the language-server list removes the
+competing `Query<unknown>` hover.
+
+## Develop this repository
+
+Run `pnpm build`, install this directory as a dev extension, and open
+`e2e/postgres/src/query.ts`. The repository `.zed/settings.json` uses the monorepo fallback and the
+PostgreSQL E2E config. Rebuild its committed snapshot with:
+
+```sh
+pnpm --filter @typed-sql/e2e-postgres generate:snapshot
+```

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "typed-sql"
 name = "typed-sql"
 description = "TypeScript 7-native SQL inference, hover information, and diagnostics."
-version = "1.0.0"
+version = "0.1.0"
 schema_version = 1
 authors = ["typed-sql contributors"]
 repository = "https://github.com/Lojhan/typed-sql"

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -4,6 +4,8 @@ use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree, setting
 
 const DEVELOPMENT_SERVER: &str =
     "packages/language-server/dist/packages/language-server/src/server.js";
+const INSTALLED_SERVER: &str =
+    "node_modules/@typed-sql/language-server/dist/packages/language-server/src/server.js";
 
 struct TypedSqlExtension;
 
@@ -40,11 +42,31 @@ impl zed::Extension for TypedSqlExtension {
         }
 
         if worktree
+            .read_text_file("node_modules/@typed-sql/language-server/package.json")
+            .is_ok()
+        {
+            let server = PathBuf::from(worktree.root_path()).join(INSTALLED_SERVER);
+            return Ok(zed::Command {
+                command: zed::node_binary_path()?,
+                args: vec![server.to_string_lossy().into_owned(), "--stdio".to_string()],
+                env,
+            });
+        }
+
+        if let Some(command) = worktree.which("typed-sql-language-server") {
+            return Ok(zed::Command {
+                command,
+                args: vec!["--stdio".to_string()],
+                env,
+            });
+        }
+
+        if worktree
             .read_text_file("packages/language-server/package.json")
             .is_err()
         {
             return Err(
-                "typed-sql development server was not found in this worktree; configure lsp.typed-sql.binary.path"
+                "typed-sql language server was not found; run `pnpm add -D @typed-sql/language-server@next`, or configure lsp.typed-sql.binary.path"
                     .to_string(),
             );
         }

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -16,6 +16,11 @@ The server discovers `typed-sql.config.ts`, loads the project's installed dialec
 queries against the generated schema, applies the inferred type overlay in memory, and proxies the
 native TypeScript 7.1 preview semantic program. Source files are never rewritten.
 
+The executable and its pinned preview are self-contained in the project installation. It does not
+load the workspace TypeScript package or require `tsserver.js`; a TypeScript 7.0 package without that
+legacy file is supported. Failure to start the pinned preview returns an initialization error with
+the preview version, underlying cause, and reinstall command instead of leaving the editor hanging.
+
 Initialization options and `workspace/didChangeConfiguration` accept:
 
 ```json
@@ -32,9 +37,16 @@ Initialization options and `workspace/didChangeConfiguration` accept:
 `configPath` is optional and discovered upward from the workspace. `schemaPath` and `projectFile`
 are overrides; relative paths resolve from the LSP workspace root.
 
+Every entry in LSP `workspaceFolders` gets a separate config, grammar, schema, project, and bounded
+cache. Watched typed-sql config/schema changes are reanalyzed before the next request and the updated
+overlay is kept open in TypeScript; unrelated watch events continue to the native preview. This is
+the contract used by the packed PostgreSQL/MySQL editor smoke test, including restart behavior.
+
 ## Zed
 
-Use typed-sql as the sole TypeScript and TSX server:
+Install the native extension from `editors/zed` and use typed-sql as the sole TypeScript and TSX
+server. The extension resolves the project-local package automatically, so no binary path or
+machine-specific directory is required:
 
 ```json
 {
@@ -48,13 +60,6 @@ Use typed-sql as the sole TypeScript and TSX server:
   },
   "lsp": {
     "typed-sql": {
-      "binary": {
-        "path": "node",
-        "arguments": [
-          "node_modules/@typed-sql/language-server/dist/packages/language-server/src/server.js",
-          "--stdio"
-        ]
-      },
       "settings": {
         "configPath": "typed-sql.config.ts",
         "schemaPath": "generated/db/schema.json",

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -355,6 +355,17 @@ export class TypedSqlLanguageService {
     return files;
   }
 
+  async handlesWatchedFile(uri: string): Promise<boolean> {
+    if (!uri.startsWith("file:")) return false;
+    const fileName = resolve(fileURLToPath(uri));
+    const loaded = await this.#config();
+    const schemaPath =
+      this.#settings.schemaPath === undefined
+        ? fromConfig(loaded.directory, loaded.config.schema.file)
+        : this.#configuredPath(this.#settings.schemaPath);
+    return fileName === resolve(loaded.file) || fileName === resolve(schemaPath);
+  }
+
   async close(): Promise<void> {
     const bridge = await this.#nativeBridgePromise;
     this.#nativeBridgePromise = undefined;

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
 import { cwd, stderr, stdin, stdout } from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { BridgeAnalysis } from "@typed-sql/ts-bridge";
@@ -50,9 +51,50 @@ interface DocumentState {
 type JsonObject = Record<string, unknown>;
 type MappingDirection = "source-to-virtual" | "virtual-to-source";
 
-const preview = spawn(process.execPath, [typescriptPreviewCliPath(), "--lsp", "--stdio"], {
+interface WatchedFileChange {
+  readonly uri: string;
+  readonly type: number;
+}
+
+const previewCli = process.env.TYPED_SQL_TYPESCRIPT_PREVIEW_CLI ?? typescriptPreviewCliPath();
+const preview = spawn(process.execPath, [previewCli, "--lsp", "--stdio"], {
   cwd: cwd(),
   stdio: ["pipe", "pipe", "pipe"],
+});
+let previewFailure: Error | undefined;
+let previewStderr = "";
+let stopping = false;
+const previewFailureWaiters = new Set<(error: Error) => void>();
+
+function previewError(cause: string): Error {
+  return new Error(
+    [
+      "typed-sql could not start or communicate with its pinned TypeScript preview process.",
+      `Preview: TypeScript ${TYPESCRIPT_PREVIEW_VERSION}`,
+      `CLI: ${previewCli}`,
+      `Cause: ${cause}`,
+      previewStderr.length === 0 ? "" : `Preview stderr: ${previewStderr.trim()}`,
+      "Reinstall @typed-sql/language-server@next in the workspace and restart the editor.",
+    ]
+      .filter((part) => part.length > 0)
+      .join(" "),
+  );
+}
+
+function failPreview(error: Error): void {
+  previewFailure ??= error;
+  for (const reject of previewFailureWaiters) reject(previewFailure);
+  previewFailureWaiters.clear();
+  stderr.write(`${previewFailure.message}\n`);
+}
+
+const previewReady = new Promise<void>((resolvePreview, rejectPreview) => {
+  preview.once("spawn", resolvePreview);
+  preview.once("error", (error) => {
+    const failure = previewError(error.message);
+    failPreview(failure);
+    rejectPreview(failure);
+  });
 });
 const client = createMessageConnection(stdin, stdout, NullLogger);
 const typescript: MessageConnection = createMessageConnection(preview.stdout, preview.stdin, NullLogger);
@@ -60,21 +102,66 @@ const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
 const pendingDocuments = new Map<string, Promise<void>>();
-let workspaceRoot = cwd();
 let workspaceReady: Promise<void> = Promise.resolve();
-const service = new TypedSqlLanguageService(workspaceRoot);
+let workspaceRoots: readonly string[] = [resolve(cwd())];
+let services = new Map([[workspaceRoots[0]!, new TypedSqlLanguageService(workspaceRoots[0]!)]]);
 
 preview.stderr.on("data", (chunk: Buffer | string) => {
-  stderr.write(`[typed-sql/typescript-${TYPESCRIPT_PREVIEW_VERSION}] ${chunk.toString()}`);
+  const message = chunk.toString();
+  previewStderr = `${previewStderr}${message}`.slice(-8_000);
+  stderr.write(`[typed-sql/typescript-${TYPESCRIPT_PREVIEW_VERSION}] ${message}`);
 });
+
+async function nativeRequest<T = unknown>(method: string, ...params: [] | [unknown]): Promise<T> {
+  if (previewFailure !== undefined) throw previewFailure;
+  let rejectFailure!: (error: Error) => void;
+  const failure = new Promise<never>((_resolveFailure, reject) => {
+    rejectFailure = reject;
+    previewFailureWaiters.add(reject);
+  });
+  try {
+    const request =
+      params.length === 0 ? typescript.sendRequest<T>(method) : typescript.sendRequest<T>(method, params[0]);
+    return await Promise.race([request, failure]);
+  } finally {
+    previewFailureWaiters.delete(rejectFailure);
+  }
+}
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function rootDirectory(params: InitializeParams): string {
-  const uri = params.workspaceFolders?.[0]?.uri ?? params.rootUri;
-  return typeof uri === "string" && uri.startsWith("file:") ? fileURLToPath(uri) : cwd();
+function workspaceDirectories(params: InitializeParams): readonly string[] {
+  const folderUris = params.workspaceFolders?.map((folder) => folder.uri);
+  const uris = folderUris !== undefined && folderUris.length > 0 ? folderUris : [params.rootUri];
+  const directories = uris.flatMap((uri) =>
+    typeof uri === "string" && uri.startsWith("file:") ? [resolve(fileURLToPath(uri))] : [],
+  );
+  return directories.length === 0 ? [resolve(cwd())] : [...new Set(directories)];
+}
+
+function contains(root: string, fileName: string): boolean {
+  const path = relative(root, fileName);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function serviceForUri(uri?: string): TypedSqlLanguageService {
+  const fileName = uri?.startsWith("file:") === true ? fileURLToPath(uri) : undefined;
+  const root =
+    fileName === undefined
+      ? workspaceRoots[0]
+      : workspaceRoots
+          .filter((candidate) => contains(candidate, fileName))
+          .sort((left, right) => right.length - left.length)[0];
+  return services.get(root ?? workspaceRoots[0]!)!;
+}
+
+async function configureServices(roots: readonly string[], settings: ReturnType<typeof settingsFrom>): Promise<void> {
+  const previous = services;
+  workspaceRoots = roots;
+  services = new Map(roots.map((root) => [root, new TypedSqlLanguageService(root, settings)]));
+  await Promise.all([...previous.values()].map(async (service) => service.close()));
 }
 
 function sourceOffsetToVirtual(state: DocumentState, offset: number): number {
@@ -125,6 +212,14 @@ function documentUri(value: unknown): string | undefined {
     : undefined;
 }
 
+function watchedFileChanges(value: unknown): readonly WatchedFileChange[] | undefined {
+  if (!isObject(value) || !Array.isArray(value.changes)) return undefined;
+  return value.changes.filter(
+    (change): change is WatchedFileChange =>
+      isObject(change) && typeof change.uri === "string" && typeof change.type === "number",
+  );
+}
+
 function queueDocument(uri: string, operation: () => Promise<void>): Promise<void> {
   const previous = pendingDocuments.get(uri) ?? Promise.resolve();
   const pending = previous.then(operation);
@@ -147,7 +242,7 @@ function mapProtocolValue(value: unknown, direction: MappingDirection, fallback?
 }
 
 async function createState(original: TextDocument, previous?: DocumentState): Promise<DocumentState> {
-  const analysis = await service.analysis(original);
+  const analysis = await serviceForUri(original.uri).analysis(original);
   const virtualVersion = previous === undefined ? original.version : previous.virtualVersion + 1;
   const transformed = TextDocument.create(
     original.uri,
@@ -164,7 +259,10 @@ async function createState(original: TextDocument, previous?: DocumentState): Pr
 }
 
 async function combinedDiagnostics(state: DocumentState): Promise<readonly unknown[]> {
-  return [...(nativeDiagnostics.get(state.original.uri) ?? []), ...(await service.diagnostics(state.original))];
+  return [
+    ...(nativeDiagnostics.get(state.original.uri) ?? []),
+    ...(await serviceForUri(state.original.uri).diagnostics(state.original)),
+  ];
 }
 
 async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
@@ -177,7 +275,7 @@ async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
 
 async function refreshOpenDocuments(): Promise<void> {
   for (const [uri, previous] of documents) {
-    service.forget(uri);
+    serviceForUri(uri).forget(uri);
     const state = await createState(previous.original, previous);
     documents.set(uri, state);
     await typescript.sendNotification("textDocument/didChange", {
@@ -189,29 +287,36 @@ async function refreshOpenDocuments(): Promise<void> {
 }
 
 async function preloadWorkspaceDocuments(): Promise<void> {
-  for (const fileName of await service.workspaceFiles()) {
-    const uri = pathToFileURL(fileName).href;
-    if (documents.has(uri) || virtualDocuments.has(uri)) continue;
-    const text = await readFile(fileName, "utf8");
-    const original = TextDocument.create(uri, /\.tsx$/u.test(fileName) ? "typescriptreact" : "typescript", 0, text);
-    const state = await createState(original);
-    if (state.analysis?.queries.length === 0 || state.analysis === undefined) continue;
-    virtualDocuments.set(uri, state);
-    await typescript.sendNotification("textDocument/didOpen", {
-      textDocument: {
-        uri,
-        languageId: original.languageId,
-        version: state.virtualVersion,
-        text: state.transformed.getText(),
-      },
-    });
+  for (const service of services.values()) {
+    for (const fileName of await service.workspaceFiles()) {
+      const uri = pathToFileURL(fileName).href;
+      if (documents.has(uri) || virtualDocuments.has(uri)) continue;
+      const text = await readFile(fileName, "utf8");
+      const original = TextDocument.create(uri, /\.tsx$/u.test(fileName) ? "typescriptreact" : "typescript", 0, text);
+      const state = await createState(original);
+      if (documents.has(uri) || virtualDocuments.has(uri)) continue;
+      if (state.analysis?.queries.length === 0 || state.analysis === undefined) continue;
+      virtualDocuments.set(uri, state);
+      await typescript.sendNotification("textDocument/didOpen", {
+        textDocument: {
+          uri,
+          languageId: original.languageId,
+          version: state.virtualVersion,
+          text: state.transformed.getText(),
+        },
+      });
+    }
   }
 }
 
 async function resetVirtualDocuments(): Promise<void> {
   for (const uri of virtualDocuments.keys()) {
+    if (documents.has(uri)) {
+      virtualDocuments.delete(uri);
+      continue;
+    }
     await typescript.sendNotification("textDocument/didClose", { textDocument: { uri } });
-    service.forget(uri);
+    serviceForUri(uri).forget(uri);
   }
   virtualDocuments.clear();
   await preloadWorkspaceDocuments();
@@ -219,9 +324,10 @@ async function resetVirtualDocuments(): Promise<void> {
 
 client.onRequest("initialize", async (rawParams) => {
   const params = rawParams as InitializeParams;
-  workspaceRoot = rootDirectory(params);
-  service.configure(workspaceRoot, settingsFrom(params.initializationOptions));
-  const result = await typescript.sendRequest<JsonObject>("initialize", params);
+  await previewReady;
+  const roots = workspaceDirectories(params);
+  await configureServices(roots, settingsFrom(params.initializationOptions));
+  const result = await nativeRequest<JsonObject>("initialize", params);
   return {
     ...result,
     capabilities: {
@@ -238,8 +344,8 @@ client.onRequest("initialize", async (rawParams) => {
 });
 
 client.onRequest("shutdown", async () => {
-  const result = await typescript.sendRequest("shutdown");
-  await service.close();
+  const result = await nativeRequest("shutdown");
+  await Promise.all([...services.values()].map(async (service) => service.close()));
   return result;
 });
 
@@ -258,11 +364,15 @@ client.onRequest("textDocument/completion", async (rawParams, token) => {
   if (uri !== undefined) await pendingDocuments.get(uri);
   const state = stateFor(params);
   if (state !== undefined && isObject(params.position)) {
-    const items = await service.completions(state.original, params.position as unknown as Position, token);
+    const items = await serviceForUri(state.original.uri).completions(
+      state.original,
+      params.position as unknown as Position,
+      token,
+    );
     if (items.length > 0) return { isIncomplete: false, items };
   }
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  return mapProtocolValue(await typescript.sendRequest("textDocument/completion", mapped), "virtual-to-source", state);
+  return mapProtocolValue(await nativeRequest("textDocument/completion", mapped), "virtual-to-source", state);
 });
 
 client.onRequest("textDocument/definition", async (rawParams, token) => {
@@ -272,11 +382,15 @@ client.onRequest("textDocument/definition", async (rawParams, token) => {
   if (uri !== undefined) await pendingDocuments.get(uri);
   const state = stateFor(params);
   if (state !== undefined && isObject(params.position)) {
-    const definition = await service.definition(state.original, params.position as unknown as Position, token);
+    const definition = await serviceForUri(state.original.uri).definition(
+      state.original,
+      params.position as unknown as Position,
+      token,
+    );
     if (definition !== undefined) return definition;
   }
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  return mapProtocolValue(await typescript.sendRequest("textDocument/definition", mapped), "virtual-to-source", state);
+  return mapProtocolValue(await nativeRequest("textDocument/definition", mapped), "virtual-to-source", state);
 });
 
 client.onRequest("textDocument/codeAction", async (rawParams, token) => {
@@ -287,9 +401,10 @@ client.onRequest("textDocument/codeAction", async (rawParams, token) => {
   const state = stateFor(params);
   const context = isObject(params.context) ? params.context : undefined;
   const diagnostics = Array.isArray(context?.diagnostics) ? context.diagnostics : [];
-  const typedActions = state === undefined ? [] : await service.codeActions(state.original, diagnostics, token);
+  const typedActions =
+    state === undefined ? [] : await serviceForUri(state.original.uri).codeActions(state.original, diagnostics, token);
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  const native = await typescript.sendRequest<unknown>("textDocument/codeAction", mapped);
+  const native = await nativeRequest("textDocument/codeAction", mapped);
   const nativeActions = Array.isArray(native)
     ? (mapProtocolValue(native, "virtual-to-source", state) as readonly unknown[])
     : [];
@@ -302,7 +417,7 @@ client.onRequest(async (method, params) => {
   if (uri !== undefined) await pendingDocuments.get(uri);
   const state = isObject(params) ? stateFor(params) : undefined;
   const mappedParams = mapProtocolValue(params, "source-to-virtual", state);
-  const result = await typescript.sendRequest<unknown>(method, mappedParams);
+  const result = await nativeRequest(method, mappedParams);
   const mappedResult = mapProtocolValue(result, "virtual-to-source", state);
   if (method !== "textDocument/diagnostic" || state === undefined || !isObject(mappedResult)) {
     return mappedResult;
@@ -310,7 +425,7 @@ client.onRequest(async (method, params) => {
   const items = Array.isArray(mappedResult.items) ? mappedResult.items : [];
   return {
     ...mappedResult,
-    items: [...items, ...(await service.diagnostics(state.original))],
+    items: [...items, ...(await serviceForUri(state.original.uri).diagnostics(state.original))],
   };
 });
 
@@ -318,6 +433,7 @@ client.onNotification("textDocument/didOpen", (rawParams) => {
   const params = rawParams as DidOpenParams;
   const item = params.textDocument;
   return queueDocument(item.uri, async () => {
+    await workspaceReady;
     const original = TextDocument.create(item.uri, item.languageId, item.version, item.text);
     const virtual = virtualDocuments.get(item.uri);
     const state = await createState(original, virtual);
@@ -339,13 +455,14 @@ client.onNotification("textDocument/didOpen", (rawParams) => {
 client.onNotification("textDocument/didChange", (rawParams) => {
   const params = rawParams as DidChangeParams;
   return queueDocument(params.textDocument.uri, async () => {
+    await workspaceReady;
     const previous = documents.get(params.textDocument.uri);
     if (previous === undefined) {
       await typescript.sendNotification("textDocument/didChange", params);
       return;
     }
     const original = TextDocument.update(previous.original, [...params.contentChanges], params.textDocument.version);
-    service.forget(original.uri);
+    serviceForUri(original.uri).forget(original.uri);
     const state = await createState(original, previous);
     documents.set(original.uri, state);
     await typescript.sendNotification("textDocument/didChange", {
@@ -359,10 +476,11 @@ client.onNotification("textDocument/didChange", (rawParams) => {
 client.onNotification("textDocument/didClose", (rawParams) => {
   const params = rawParams as DidCloseParams;
   return queueDocument(params.textDocument.uri, async () => {
+    await workspaceReady;
     const previous = documents.get(params.textDocument.uri);
     documents.delete(params.textDocument.uri);
     nativeDiagnostics.delete(params.textDocument.uri);
-    service.forget(params.textDocument.uri);
+    serviceForUri(params.textDocument.uri).forget(params.textDocument.uri);
     try {
       const fileName = fileURLToPath(params.textDocument.uri);
       const text = await readFile(fileName, "utf8");
@@ -391,22 +509,46 @@ client.onNotification("textDocument/didClose", (rawParams) => {
   });
 });
 
-client.onNotification("workspace/didChangeConfiguration", async (params) => {
-  const value = isObject(params) ? params.settings : undefined;
-  service.configure(workspaceRoot, settingsFrom(value));
-  await typescript.sendNotification("workspace/didChangeConfiguration", params);
-  await refreshOpenDocuments();
-  await resetVirtualDocuments();
+client.onNotification("workspace/didChangeConfiguration", (params) => {
+  workspaceReady = (async () => {
+    const value = isObject(params) ? params.settings : undefined;
+    const settings = settingsFrom(value);
+    for (const [root, service] of services) service.configure(root, settings);
+    await typescript.sendNotification("workspace/didChangeConfiguration", params);
+    await refreshOpenDocuments();
+    await resetVirtualDocuments();
+  })();
+  return workspaceReady;
 });
 
-client.onNotification("workspace/didChangeWatchedFiles", async (params) => {
-  service.invalidate();
-  await typescript.sendNotification("workspace/didChangeWatchedFiles", params);
-  await refreshOpenDocuments();
-  await resetVirtualDocuments();
+client.onNotification("workspace/didChangeWatchedFiles", (params) => {
+  workspaceReady = (async () => {
+    const changes = watchedFileChanges(params);
+    const nativeChanges =
+      changes === undefined
+        ? undefined
+        : (
+            await Promise.all(
+              changes.map(async (change) =>
+                (await serviceForUri(change.uri).handlesWatchedFile(change.uri)) ? undefined : change,
+              ),
+            )
+          ).filter((change): change is WatchedFileChange => change !== undefined);
+    for (const service of services.values()) service.invalidate();
+    if (nativeChanges === undefined || nativeChanges.length > 0) {
+      await typescript.sendNotification(
+        "workspace/didChangeWatchedFiles",
+        nativeChanges === undefined ? params : { ...(isObject(params) ? params : {}), changes: nativeChanges },
+      );
+    }
+    await refreshOpenDocuments();
+    await resetVirtualDocuments();
+  })();
+  return workspaceReady;
 });
 
 client.onNotification("exit", async () => {
+  stopping = true;
   await typescript.sendNotification("exit");
   typescript.dispose();
   client.dispose();
@@ -447,9 +589,8 @@ typescript.onNotification(async (method, params) => {
 });
 
 preview.on("exit", (code, signal) => {
-  if (code !== 0 && code !== null) {
-    stderr.write(`typed-sql: TypeScript preview exited with code ${code}${signal === null ? "" : ` (${signal})`}\n`);
-  }
+  if (stopping && (code === 0 || code === null)) return;
+  failPreview(previewError(`process exited with code ${code ?? "null"}${signal === null ? "" : ` (${signal})`}`));
 });
 
 typescript.listen();

--- a/packages/language-server/test/language-server.test.ts
+++ b/packages/language-server/test/language-server.test.ts
@@ -1,159 +1,8 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, it, strict } from "poku";
-
-interface JsonRpcMessage {
-  readonly jsonrpc: "2.0";
-  readonly id?: number;
-  readonly method?: string;
-  readonly params?: unknown;
-  readonly result?: unknown;
-  readonly error?: { readonly code: number; readonly message: string };
-}
-
-interface PendingRequest {
-  readonly resolve: (value: unknown) => void;
-  readonly reject: (error: Error) => void;
-}
-
-interface NotificationWaiter {
-  readonly method: string;
-  readonly predicate: (params: unknown) => boolean;
-  readonly resolve: (params: unknown) => void;
-}
-
-class ProtocolClient {
-  readonly #process: ChildProcessWithoutNullStreams;
-  readonly #pending = new Map<number, PendingRequest>();
-  readonly #waiters: NotificationWaiter[] = [];
-  #buffer = Buffer.alloc(0);
-  #nextId = 1;
-  #stderr = "";
-
-  constructor(serverFile: string, workingDirectory: string) {
-    this.#process = spawn(process.execPath, [serverFile, "--stdio"], {
-      cwd: workingDirectory,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    this.#process.stdout.on("data", (chunk: Buffer) => {
-      this.#buffer = Buffer.concat([this.#buffer, chunk]);
-      this.#drain();
-    });
-    this.#process.stderr.on("data", (chunk: Buffer) => {
-      this.#stderr += chunk.toString("utf8");
-    });
-  }
-
-  request(method: string, params: unknown): Promise<unknown> {
-    const id = this.#nextId;
-    this.#nextId += 1;
-    const result = new Promise<unknown>((resolveRequest, rejectRequest) => {
-      this.#pending.set(id, { resolve: resolveRequest, reject: rejectRequest });
-    });
-    this.#send({ jsonrpc: "2.0", id, method, params });
-    return result;
-  }
-
-  notify(method: string, params: unknown): void {
-    this.#send({ jsonrpc: "2.0", method, params });
-  }
-
-  notification(method: string, predicate: (params: unknown) => boolean): Promise<unknown> {
-    return new Promise((resolveNotification, rejectNotification) => {
-      const timeout = setTimeout(() => {
-        rejectNotification(new Error(`Timed out waiting for ${method}. Server stderr:\n${this.#stderr}`));
-      }, 20_000);
-      this.#waiters.push({
-        method,
-        predicate,
-        resolve: (params) => {
-          clearTimeout(timeout);
-          resolveNotification(params);
-        },
-      });
-    });
-  }
-
-  async close(): Promise<void> {
-    if (this.#process.exitCode !== null) return;
-    try {
-      await this.request("shutdown", null);
-      this.notify("exit", null);
-      await new Promise<void>((resolveClose) => {
-        const timeout = setTimeout(() => {
-          this.#process.kill();
-          resolveClose();
-        }, 5_000);
-        this.#process.once("close", () => {
-          clearTimeout(timeout);
-          resolveClose();
-        });
-      });
-    } finally {
-      if (this.#process.exitCode === null) this.#process.kill();
-    }
-  }
-
-  #send(message: JsonRpcMessage): void {
-    const body = Buffer.from(JSON.stringify(message), "utf8");
-    this.#process.stdin.write(`Content-Length: ${body.length}\r\n\r\n`);
-    this.#process.stdin.write(body);
-  }
-
-  #drain(): void {
-    while (true) {
-      const headerEnd = this.#buffer.indexOf("\r\n\r\n");
-      if (headerEnd === -1) return;
-      const header = this.#buffer.subarray(0, headerEnd).toString("ascii");
-      const lengthMatch = /(?:^|\r\n)Content-Length:\s*(\d+)/iu.exec(header);
-      if (lengthMatch?.[1] === undefined) throw new Error(`Missing Content-Length in ${header}`);
-      const contentLength = Number.parseInt(lengthMatch[1], 10);
-      const bodyStart = headerEnd + 4;
-      const messageEnd = bodyStart + contentLength;
-      if (this.#buffer.length < messageEnd) return;
-      const message = JSON.parse(this.#buffer.subarray(bodyStart, messageEnd).toString("utf8")) as JsonRpcMessage;
-      this.#buffer = this.#buffer.subarray(messageEnd);
-      this.#receive(message);
-    }
-  }
-
-  #receive(message: JsonRpcMessage): void {
-    if (message.id !== undefined && message.method !== undefined) {
-      const result =
-        message.method === "workspace/configuration" &&
-        typeof message.params === "object" &&
-        message.params !== null &&
-        Array.isArray((message.params as { readonly items?: unknown }).items)
-          ? (message.params as { readonly items: readonly unknown[] }).items.map(() => null)
-          : null;
-      this.#send({ jsonrpc: "2.0", id: message.id, result });
-      return;
-    }
-    if (message.id !== undefined && message.method === undefined) {
-      const pending = this.#pending.get(message.id);
-      if (pending === undefined) return;
-      this.#pending.delete(message.id);
-      if (message.error === undefined) pending.resolve(message.result);
-      else pending.reject(new Error(`${message.error.code}: ${message.error.message}`));
-      return;
-    }
-    if (message.method === undefined) return;
-    const waiterIndex = this.#waiters.findIndex(
-      (waiter) => waiter.method === message.method && waiter.predicate(message.params),
-    );
-    if (waiterIndex === -1) return;
-    const [waiter] = this.#waiters.splice(waiterIndex, 1);
-    waiter?.resolve(message.params);
-  }
-}
-
-function positionAt(source: string, offset: number): { readonly line: number; readonly character: number } {
-  const before = source.slice(0, offset);
-  const lastNewline = before.lastIndexOf("\n");
-  return { line: before.split("\n").length - 1, character: offset - lastNewline - 1 };
-}
+import { ProtocolClient, positionAt } from "../../../test/helpers/protocol-client.js";
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceDirectory = resolve(testDirectory, "../../..");
@@ -165,8 +14,28 @@ const configFile = join(workspaceDirectory, "e2e", "postgres", "typed-sql.config
 const serverFile = join(workspaceDirectory, "packages/language-server/dist/packages/language-server/src/server.js");
 
 await describe("typed-sql stdio language server", async () => {
+  await it("reports a pinned preview crash instead of hanging initialization", async () => {
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory, {
+      ...process.env,
+      TYPED_SQL_TYPESCRIPT_PREVIEW_CLI: join(workspaceDirectory, "missing-typescript-preview.js"),
+    });
+    try {
+      await strict.rejects(
+        () =>
+          client.request("initialize", {
+            processId: process.pid,
+            rootUri: pathToFileURL(workspaceDirectory).href,
+            capabilities: {},
+          }),
+        /pinned TypeScript preview process[\s\S]*Reinstall @typed-sql\/language-server@next/u,
+      );
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
   await it("preloads typed overlays for unopened project files", async () => {
-    const client = new ProtocolClient(serverFile, workspaceDirectory);
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
     const e2eDirectory = join(workspaceDirectory, "e2e", "postgres");
     const e2eQueryFile = join(e2eDirectory, "src", "query.ts");
     const source = await readFile(e2eQueryFile, "utf8");
@@ -198,7 +67,7 @@ await describe("typed-sql stdio language server", async () => {
   });
 
   await it("makes inferred rows part of the TypeScript 7 semantic program", async () => {
-    const client = new ProtocolClient(serverFile, workspaceDirectory);
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
     const source = await readFile(queryFile, "utf8");
     const uri = pathToFileURL(queryFile).href;
     try {
@@ -302,7 +171,7 @@ await describe("typed-sql stdio language server", async () => {
   });
 
   await it("exposes the real PostgreSQL fixture row and Actual types", async () => {
-    const client = new ProtocolClient(serverFile, workspaceDirectory);
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
     const e2eDirectory = join(workspaceDirectory, "e2e", "postgres");
     const e2eQueryFile = join(e2eDirectory, "src", "query.ts");
     const source = await readFile(e2eQueryFile, "utf8");
@@ -355,6 +224,58 @@ await describe("typed-sql stdio language server", async () => {
         textDocument: { uri },
       })) as { readonly items?: readonly unknown[] };
       strict.deepStrictEqual(report.items, []);
+    } finally {
+      await client.close();
+    }
+  });
+
+  await it("routes each folder in a multi-root workspace through its installed grammar", async () => {
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
+    const postgresRoot = join(workspaceDirectory, "e2e", "postgres");
+    const mysqlRoot = join(workspaceDirectory, "e2e", "mysql");
+    const postgresSource = `
+      import { sql } from "@typed-sql/postgres";
+      const postgresQuery = sql\`SELECT account.status FROM users AS account\`;
+    `;
+    const mysqlSource = `
+      import { sql } from "@typed-sql/mysql";
+      const mysqlQuery = sql\`SELECT account.active FROM users AS account\`;
+    `;
+    const postgresUri = pathToFileURL(join(postgresRoot, "src", "editor-multi-root.ts")).href;
+    const mysqlUri = pathToFileURL(join(mysqlRoot, "src", "editor-multi-root.ts")).href;
+    try {
+      await client.request("initialize", {
+        processId: process.pid,
+        rootUri: pathToFileURL(postgresRoot).href,
+        workspaceFolders: [
+          { uri: pathToFileURL(postgresRoot).href, name: "postgres-app" },
+          { uri: pathToFileURL(mysqlRoot).href, name: "mysql-app" },
+        ],
+        capabilities: {},
+      });
+      client.notify("initialized", {});
+      client.notify("textDocument/didOpen", {
+        textDocument: {
+          uri: postgresUri,
+          languageId: "typescript",
+          version: 1,
+          text: postgresSource,
+        },
+      });
+      client.notify("textDocument/didOpen", {
+        textDocument: { uri: mysqlUri, languageId: "typescript", version: 1, text: mysqlSource },
+      });
+
+      const postgresHover = await client.request("textDocument/hover", {
+        textDocument: { uri: postgresUri },
+        position: positionAt(postgresSource, postgresSource.indexOf("postgresQuery")),
+      });
+      const mysqlHover = await client.request("textDocument/hover", {
+        textDocument: { uri: mysqlUri },
+        position: positionAt(mysqlSource, mysqlSource.indexOf("mysqlQuery")),
+      });
+      strict.ok(JSON.stringify(postgresHover).includes('status: \\"active\\" | \\"suspended\\"'));
+      strict.ok(JSON.stringify(mysqlHover).includes("active: boolean"));
     } finally {
       await client.close();
     }

--- a/packages/language-server/test/service.test.ts
+++ b/packages/language-server/test/service.test.ts
@@ -67,5 +67,12 @@ await describe("typed-sql language service", async () => {
     strict.throws(() => service.configure(workspaceDirectory, { maxCacheEntries: 0 }), /positive safe integer/);
   });
 
+  await it("claims only typed-sql config and schema watcher events", async () => {
+    strict.strictEqual(await service.handlesWatchedFile(pathToFileURL(configFile).href), true);
+    strict.strictEqual(await service.handlesWatchedFile(pathToFileURL(schemaFile).href), true);
+    strict.strictEqual(await service.handlesWatchedFile(pathToFileURL(projectFile).href), false);
+    strict.strictEqual(await service.handlesWatchedFile("untitled:query.ts"), false);
+  });
+
   await service.close();
 });

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,31 +1,43 @@
 # typed-sql for VS Code (experimental)
 
-This extension bridges typed-sql's generated schema and query resolver to TypeScript 7's native
-language server. Hover over a static `sql` template or its directly assigned variable to see the
-inferred `Query<{ ... }>` type. SQL diagnostics are published inline without modifying source.
+The VS Code extension loads each workspace folder's installed grammar and generated schema. Hover
+over a static `sql` template or any downstream value to see the inferred query type; SQL and
+TypeScript parameter diagnostics, completion, definitions, and safe quick fixes stay inline without
+rewriting source files.
 
-The extension first computes the row through `@typed-sql/ts-bridge`. When the TypeScript 7
-extension exposes `initializeAPIConnection`, it sends the typed overlay through
-`typescript/unstable/async`, asks the native checker for the tagged-template type, and reports that
-authoritative result. If the preview connection is unavailable, hover falls back to the same
-resolver used by `typed-sql check`.
+The extension asks Microsoft's TypeScript 7 preview connection to verify the in-memory overlay. If
+that connection is unavailable or its preview API changes, SQL analysis remains available through a
+clearly labeled resolver fallback. Run **typed-sql: Show TypeScript Bridge Status** to see which path
+is active.
 
-The extension discovers `typed-sql.config.ts` and loads the project's installed grammar. Optional
-overrides are relative to each workspace folder:
+## Install the current experimental build
+
+Until the extension has a Marketplace release, build its VSIX from a clean checkout:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter ./packages/vscode package:vsix
+code --install-extension artifacts/typed-sql-vscode.vsix
+```
+
+In the application, install the selected grammar and generate its schema normally. Configuration is
+optional and scoped independently to each workspace folder:
 
 ```json
 {
   "typedSql.configPath": "typed-sql.config.ts",
-  "typedSql.schemaPath": "src/generated/db/schema.json"
+  "typedSql.schemaPath": "src/generated/db/schema.json",
+  "typedSql.nativePreview": true
 }
 ```
 
-Leave both values empty to use config discovery and `schema.file`. Development setup:
+Leave the path values empty to discover `typed-sql.config.ts` and use its `schema.file`. Opening,
+editing, saving, regenerating a schema, changing settings, or restarting VS Code invalidates the
+bounded analysis caches. Errors are written to the **typed-sql** output channel with the affected
+file and cause.
 
-1. Run `pnpm build` from the repository root.
-2. Install or enable Microsoft's TypeScript 7 extension.
-3. Open this repository in VS Code and launch the `typed-sql extension` configuration.
-4. Open `e2e/postgres/src/query.ts` and hover `query` or the SQL template.
+## Develop this repository
 
-Run **typed-sql: Show TypeScript Bridge Status** to see whether the native preview connection or
-the resolver fallback is active.
+Run `pnpm build`, install or enable Microsoft's TypeScript 7 extension, and launch the
+`typed-sql extension` debug configuration. Open `e2e/postgres/src/query.ts` and hover `query`,
+`rows`, or `Actual`.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typed-sql",
   "displayName": "typed-sql",
   "description": "TypeScript 7-native SQL inference, hover information, and diagnostics.",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "publisher": "lojhan",
   "author": "Lojhan",

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, strict } from "poku";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function text(path: string): Promise<string> {
+  return readFile(join(workspace, path), "utf8");
+}
+
+await describe("external editor distribution", async () => {
+  await it("keeps preview-backed editor surfaces explicitly experimental", async () => {
+    const languageServer = JSON.parse(await text("packages/language-server/package.json")) as {
+      readonly version: string;
+      readonly typedSql?: { readonly releaseTrack?: string };
+    };
+    const vscode = JSON.parse(await text("packages/vscode/package.json")) as {
+      readonly private?: boolean;
+      readonly version: string;
+    };
+    strict.match(languageServer.version, /^1\.0\.0-(?:beta|rc)\.\d+$/u);
+    strict.strictEqual(languageServer.typedSql?.releaseTrack, "experimental");
+    strict.strictEqual(vscode.private, true);
+    strict.match(vscode.version, /^0\.1\./u);
+    strict.ok((await text("editors/zed/extension.toml")).includes('version = "0.1.0"'));
+    strict.ok((await text("editors/zed/Cargo.toml")).includes('version = "0.1.0"'));
+  });
+
+  await it("resolves Zed's application-local package before development fallbacks", async () => {
+    const source = await text("editors/zed/src/lib.rs");
+    const installed = source.indexOf("node_modules/@typed-sql/language-server");
+    const path = source.indexOf('worktree.which("typed-sql-language-server")');
+    const development = source.indexOf("packages/language-server/dist");
+    strict.ok(installed >= 0);
+    strict.ok(path > installed);
+    strict.ok(development >= 0);
+    strict.ok(source.indexOf("join(DEVELOPMENT_SERVER)") > path);
+    strict.ok(source.includes("pnpm add -D @typed-sql/language-server@next"));
+    strict.ok(!source.includes("/Users/"));
+  });
+
+  await it("documents portable startup and the tsserver-free compatibility boundary", async () => {
+    const documentation = [
+      await text("editors/zed/README.md"),
+      await text("packages/language-server/README.md"),
+      await text("packages/vscode/README.md"),
+      await text("docs/COMPATIBILITY.md"),
+    ].join("\n");
+    strict.ok(documentation.includes("pnpm add -D @typed-sql/language-server@next"));
+    strict.ok(documentation.includes("tsserver.js"));
+    strict.ok(documentation.includes("multi-root"));
+    strict.ok(documentation.includes("0.1.x"));
+    strict.ok(!documentation.includes("/Users/"));
+  });
+
+  await it("fails preview startup with actionable context", async () => {
+    const server = await text("packages/language-server/src/server.ts");
+    strict.ok(server.includes("could not start or communicate with its pinned TypeScript preview process"));
+    strict.ok(server.includes("TYPESCRIPT_PREVIEW_VERSION"));
+    strict.ok(server.includes("Reinstall @typed-sql/language-server@next"));
+    strict.ok(server.includes('preview.once("error"'));
+    strict.ok(server.includes('preview.on("exit"'));
+    strict.ok(server.includes("nativeRequest"));
+  });
+});

--- a/test/contracts/packed-consumer.test.ts
+++ b/test/contracts/packed-consumer.test.ts
@@ -2,9 +2,10 @@ import { execFile as execFileCallback } from "node:child_process";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { describe, it, strict } from "poku";
+import { ProtocolClient, positionAt } from "../helpers/protocol-client.js";
 
 const execFile = promisify(execFileCallback);
 const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -22,6 +23,94 @@ const publicPackages = [
   "language-server",
 ] as const;
 const stableModulePackages = new Set(["ast", "core", "config", "schema", "postgres", "mysql", "compiler"]);
+
+async function writeEditorProject(
+  consumer: string,
+  dialect: "mysql" | "postgres",
+): Promise<{ readonly directory: string; readonly queryFile: string; readonly source: string }> {
+  const directory = join(consumer, `editor-${dialect}`);
+  const queryFile = join(directory, "query.ts");
+  const sqlModule = `@typed-sql/${dialect}`;
+  const source = `
+    import { sql } from "${sqlModule}";
+    import type { QueryRow } from "@typed-sql/core";
+
+    declare const includeStatus: boolean;
+    declare function execute<Query>(query: Query): Promise<readonly QueryRow<Query>[]>;
+    const simpleQuery = sql\`SELECT account.id, account.email FROM users AS account\`;
+    const rows = await execute(simpleQuery);
+    type Actual = (typeof rows)[number];
+    const cteQuery = sql\`
+      WITH selected_accounts AS (
+        SELECT account.id, account.status FROM users AS account
+      )
+      SELECT selected_accounts.id, selected_accounts.status FROM selected_accounts
+    \`;
+    const conditionalQuery = sql\`
+      SELECT account.id
+        \${includeStatus ? sql.fragment\`, account.status\` : sql.empty}
+      FROM users AS account
+    \`;
+    const invalidParameter = sql\`SELECT account.id FROM users AS account WHERE account.id = \${"wrong"}\`;
+    void [simpleQuery, rows, cteQuery, conditionalQuery, invalidParameter];
+  `;
+  await mkdir(directory);
+  await writeFile(
+    join(directory, "typed-sql.config.ts"),
+    `
+      import { defineConfig } from "@typed-sql/core";
+      import { ${dialect}, typePolicy } from "${sqlModule}";
+      const dialect = ${dialect}({ typePolicy });
+      export default defineConfig({
+        dialect,
+        schema: { file: "schema.json" },
+        outDir: "generated",
+        projects: ["tsconfig.json"],
+        typePolicy,
+      });
+    `,
+  );
+  await writeFile(
+    join(directory, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          target: "ES2024",
+        },
+        include: ["query.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(directory, "schema.json"),
+    await readFile(join(workspace, "e2e", dialect, "generated", "db", "schema.json"), "utf8"),
+  );
+  await writeFile(queryFile, source);
+  return { directory, queryFile, source };
+}
+
+async function initializeEditor(client: ProtocolClient, directory: string): Promise<void> {
+  await client.request("initialize", {
+    processId: process.pid,
+    rootUri: pathToFileURL(directory).href,
+    workspaceFolders: [{ uri: pathToFileURL(directory).href, name: "packed-consumer" }],
+    capabilities: {},
+  });
+  client.notify("initialized", {});
+}
+
+async function hoverText(client: ProtocolClient, queryFile: string, source: string, binding: string): Promise<string> {
+  const hover = await client.request("textDocument/hover", {
+    textDocument: { uri: pathToFileURL(queryFile).href },
+    position: positionAt(source, source.indexOf(binding)),
+  });
+  return JSON.stringify(hover);
+}
 
 await describe("packed public packages", async () => {
   await it("installs every tarball in isolation without a database driver", async () => {
@@ -297,7 +386,106 @@ await describe("packed public packages", async () => {
       `,
       );
       await execFile(process.execPath, [join(consumer, "verify.mjs")], { cwd: consumer, env: isolatedEnvironment });
-      strict.ok(true);
+
+      const languageServer = join(consumer, "node_modules", ".bin", "typed-sql-language-server");
+      for (const dialect of ["postgres", "mysql"] as const) {
+        const project = await writeEditorProject(consumer, dialect);
+        const uri = pathToFileURL(project.queryFile).href;
+        const client = new ProtocolClient(languageServer, ["--stdio"], project.directory, isolatedEnvironment);
+        try {
+          await initializeEditor(client, project.directory);
+          const diagnosticsReady = client.notification(
+            "textDocument/publishDiagnostics",
+            (params) => (params as { readonly uri?: string }).uri === uri,
+          );
+          client.notify("textDocument/didOpen", {
+            textDocument: { uri, languageId: "typescript", version: 1, text: project.source },
+          });
+          await diagnosticsReady;
+          const diagnostics = (await client.request("textDocument/diagnostic", {
+            textDocument: { uri },
+          })) as {
+            readonly items?: readonly { readonly code?: number | string; readonly message?: string }[];
+          };
+          strict.ok(
+            diagnostics.items?.some((diagnostic) =>
+              /not assignable to parameter of type/u.test(diagnostic.message ?? ""),
+            ),
+            `${dialect} must report the bad interpolation through TypeScript: ${JSON.stringify(diagnostics.items)}`,
+          );
+
+          const simple = await hoverText(client, project.queryFile, project.source, "simpleQuery");
+          strict.ok(simple.includes("id: bigint"), simple);
+          strict.ok(simple.includes("email: string"), simple);
+          strict.ok(!simple.includes("unknown"), simple);
+          const rows = await hoverText(client, project.queryFile, project.source, "rows");
+          strict.ok(rows.includes("readonly"), rows);
+          strict.ok(rows.includes("id: bigint"), rows);
+          strict.ok(rows.includes("email: string"), rows);
+          strict.ok(!rows.includes("unknown"), rows);
+          const actual = await hoverText(client, project.queryFile, project.source, "Actual");
+          strict.ok(actual.includes("id: bigint"), actual);
+          strict.ok(actual.includes("email: string"), actual);
+          strict.ok(!actual.includes("unknown"), actual);
+          const cte = await hoverText(client, project.queryFile, project.source, "cteQuery");
+          strict.ok(cte.includes("id: bigint"), cte);
+          strict.ok(cte.includes('status: \\"active\\" | \\"suspended\\"'), cte);
+          const conditional = await hoverText(client, project.queryFile, project.source, "conditionalQuery");
+          strict.ok(conditional.includes("id: bigint"), conditional);
+          strict.ok(conditional.includes("status"), conditional);
+
+          if (dialect === "postgres") {
+            const schemaFile = join(project.directory, "schema.json");
+            const schema = JSON.parse(await readFile(schemaFile, "utf8")) as {
+              tables: { users: { columns: { email: { nullable: boolean } } } };
+            };
+            schema.tables.users.columns.email.nullable = true;
+            await writeFile(schemaFile, `${JSON.stringify(schema, null, 2)}\n`);
+            const reloaded = client.notification(
+              "textDocument/publishDiagnostics",
+              (params) => (params as { readonly uri?: string }).uri === uri,
+            );
+            client.notify("workspace/didChangeWatchedFiles", {
+              changes: [{ uri: pathToFileURL(schemaFile).href, type: 2 }],
+            });
+            await reloaded;
+            const changed = await hoverText(client, project.queryFile, project.source, "simpleQuery");
+            const reloadDiagnostics = await client.request("textDocument/diagnostic", {
+              textDocument: { uri },
+            });
+            strict.ok(
+              changed.includes("email: string | null"),
+              `${changed}\nReload diagnostics: ${JSON.stringify(reloadDiagnostics)}`,
+            );
+            strict.ok(changed.includes("id: bigint"), changed);
+
+            const reconfigured = client.notification(
+              "textDocument/publishDiagnostics",
+              (params) => (params as { readonly uri?: string }).uri === uri,
+            );
+            client.notify("workspace/didChangeConfiguration", { settings: {} });
+            await reconfigured;
+            const afterConfiguration = await hoverText(client, project.queryFile, project.source, "simpleQuery");
+            strict.ok(afterConfiguration.includes("email: string | null"), afterConfiguration);
+          }
+        } finally {
+          await client.close();
+        }
+
+        if (dialect === "postgres") {
+          const restarted = new ProtocolClient(languageServer, ["--stdio"], project.directory, isolatedEnvironment);
+          try {
+            await initializeEditor(restarted, project.directory);
+            restarted.notify("textDocument/didOpen", {
+              textDocument: { uri, languageId: "typescript", version: 1, text: project.source },
+            });
+            const hover = await hoverText(restarted, project.queryFile, project.source, "simpleQuery");
+            strict.ok(hover.includes("email: string | null"), hover);
+          } finally {
+            await restarted.close();
+          }
+        }
+      }
     } finally {
       await rm(temporary, { recursive: true, force: true });
     }

--- a/test/helpers/protocol-client.ts
+++ b/test/helpers/protocol-client.ts
@@ -1,0 +1,176 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+
+interface JsonRpcMessage {
+  readonly jsonrpc: "2.0";
+  readonly id?: number;
+  readonly method?: string;
+  readonly params?: unknown;
+  readonly result?: unknown;
+  readonly error?: { readonly code: number; readonly message: string };
+}
+
+interface PendingRequest {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: Error) => void;
+}
+
+interface NotificationWaiter {
+  readonly method: string;
+  readonly predicate: (params: unknown) => boolean;
+  readonly resolve: (params: unknown) => void;
+  readonly reject: (error: Error) => void;
+}
+
+export class ProtocolClient {
+  readonly #process: ChildProcessWithoutNullStreams;
+  readonly #pending = new Map<number, PendingRequest>();
+  readonly #waiters: NotificationWaiter[] = [];
+  #buffer = Buffer.alloc(0);
+  #nextId = 1;
+  #stderr = "";
+
+  constructor(
+    command: string,
+    args: readonly string[],
+    workingDirectory: string,
+    environment: NodeJS.ProcessEnv = process.env,
+  ) {
+    this.#process = spawn(command, [...args], {
+      cwd: workingDirectory,
+      env: environment,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.#process.stdout.on("data", (chunk: Buffer) => {
+      this.#buffer = Buffer.concat([this.#buffer, chunk]);
+      this.#drain();
+    });
+    this.#process.stderr.on("data", (chunk: Buffer) => {
+      this.#stderr += chunk.toString("utf8");
+    });
+    this.#process.on("error", (error) => this.#fail(error));
+    this.#process.on("exit", (code, signal) => {
+      if (code === 0) return;
+      this.#fail(
+        new Error(`Language server exited with ${code ?? signal ?? "unknown status"}. Server stderr:\n${this.#stderr}`),
+      );
+    });
+  }
+
+  request(method: string, params: unknown): Promise<unknown> {
+    const id = this.#nextId;
+    this.#nextId += 1;
+    const result = new Promise<unknown>((resolveRequest, rejectRequest) => {
+      this.#pending.set(id, { resolve: resolveRequest, reject: rejectRequest });
+    });
+    this.#send({ jsonrpc: "2.0", id, method, params });
+    return result;
+  }
+
+  notify(method: string, params: unknown): void {
+    this.#send({ jsonrpc: "2.0", method, params });
+  }
+
+  notification(method: string, predicate: (params: unknown) => boolean): Promise<unknown> {
+    return new Promise((resolveNotification, rejectNotification) => {
+      const timeout = setTimeout(() => {
+        rejectNotification(new Error(`Timed out waiting for ${method}. Server stderr:\n${this.#stderr}`));
+      }, 20_000);
+      this.#waiters.push({
+        method,
+        predicate,
+        resolve: (params) => {
+          clearTimeout(timeout);
+          resolveNotification(params);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          rejectNotification(error);
+        },
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.#process.exitCode !== null) return;
+    try {
+      await this.request("shutdown", null);
+      this.notify("exit", null);
+      await new Promise<void>((resolveClose) => {
+        const timeout = setTimeout(() => {
+          this.#process.kill();
+          resolveClose();
+        }, 5_000);
+        this.#process.once("close", () => {
+          clearTimeout(timeout);
+          resolveClose();
+        });
+      });
+    } finally {
+      if (this.#process.exitCode === null) this.#process.kill();
+    }
+  }
+
+  #send(message: JsonRpcMessage): void {
+    const body = Buffer.from(JSON.stringify(message), "utf8");
+    this.#process.stdin.write(`Content-Length: ${body.length}\r\n\r\n`);
+    this.#process.stdin.write(body);
+  }
+
+  #drain(): void {
+    while (true) {
+      const headerEnd = this.#buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      const header = this.#buffer.subarray(0, headerEnd).toString("ascii");
+      const lengthMatch = /(?:^|\r\n)Content-Length:\s*(\d+)/iu.exec(header);
+      if (lengthMatch?.[1] === undefined) throw new Error(`Missing Content-Length in ${header}`);
+      const contentLength = Number.parseInt(lengthMatch[1], 10);
+      const bodyStart = headerEnd + 4;
+      const messageEnd = bodyStart + contentLength;
+      if (this.#buffer.length < messageEnd) return;
+      const message = JSON.parse(this.#buffer.subarray(bodyStart, messageEnd).toString("utf8")) as JsonRpcMessage;
+      this.#buffer = this.#buffer.subarray(messageEnd);
+      this.#receive(message);
+    }
+  }
+
+  #receive(message: JsonRpcMessage): void {
+    if (message.id !== undefined && message.method !== undefined) {
+      const result =
+        message.method === "workspace/configuration" &&
+        typeof message.params === "object" &&
+        message.params !== null &&
+        Array.isArray((message.params as { readonly items?: unknown }).items)
+          ? (message.params as { readonly items: readonly unknown[] }).items.map(() => null)
+          : null;
+      this.#send({ jsonrpc: "2.0", id: message.id, result });
+      return;
+    }
+    if (message.id !== undefined && message.method === undefined) {
+      const pending = this.#pending.get(message.id);
+      if (pending === undefined) return;
+      this.#pending.delete(message.id);
+      if (message.error === undefined) pending.resolve(message.result);
+      else pending.reject(new Error(`${message.error.code}: ${message.error.message}`));
+      return;
+    }
+    if (message.method === undefined) return;
+    const waiterIndex = this.#waiters.findIndex(
+      (waiter) => waiter.method === message.method && waiter.predicate(message.params),
+    );
+    if (waiterIndex === -1) return;
+    const [waiter] = this.#waiters.splice(waiterIndex, 1);
+    waiter?.resolve(message.params);
+  }
+
+  #fail(error: Error): void {
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+    for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
+  }
+}
+
+export function positionAt(source: string, offset: number): { readonly line: number; readonly character: number } {
+  const before = source.slice(0, offset);
+  const lastNewline = before.lastIndexOf("\n");
+  return { line: before.split("\n").length - 1, character: offset - lastNewline - 1 };
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,13 @@
     "noEmit": true,
     "rootDir": ".."
   },
-  "include": ["../packages/*/test/**/*.test.ts", "contracts/**/*.test.ts", "grammar/**/*.ts", "soundness/**/*.ts"],
+  "include": [
+    "../packages/*/test/**/*.test.ts",
+    "contracts/**/*.test.ts",
+    "grammar/**/*.ts",
+    "helpers/**/*.ts",
+    "soundness/**/*.ts"
+  ],
   "exclude": ["fixtures"],
   "references": [
     { "path": "../packages/core" },


### PR DESCRIPTION
Closes #20

## What changed
- resolve the Zed language server from the application package without absolute development paths
- route multi-root LSP workspaces through independent configs, grammars, schemas, and projects
- serialize open, reload, and configuration lifecycles so regenerated schemas retain exact overlays
- fail preview startup and runtime crashes with versioned, actionable diagnostics
- launch the packed npm executable against clean PostgreSQL and MySQL editor projects
- verify exact query, rows, and downstream types, CTEs, conditional projections, invalid parameters, reload, restart, and multi-root behavior
- keep preview-backed packages and private editor integrations explicitly experimental

## Verification
- pnpm verify on Node 24.10.0
- pnpm test:pack
- pnpm --filter ./packages/vscode package:vsix
- cargo test --manifest-path editors/zed/Cargo.toml