### PR TITLE
feat: add trusted structural-template quick fixes

### DIFF
--- a/.changeset/trusted-structural-fragment.md
+++ b/.changeset/trusted-structural-fragment.md
@@ -1,0 +1,11 @@
+---
+"@typed-sql/core": patch
+"@typed-sql/compiler": patch
+"@typed-sql/cli": patch
+"@typed-sql/ts-bridge": patch
+"@typed-sql/language-server": patch
+---
+
+Report `TSQ004` for bare nested templates used as conditional SQL structure and offer an alias-aware
+language-server quick fix that prefixes the template with `sql.fragment`. Ordinary and nested
+values remain parameterized across the edit.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ the installed grammar to analyze each complete SQL statement. Multiple literal `
 selections produce exact result shapes; runtime booleans produce the corresponding union. Direct and
 nested interpolation values are checked against one complete ordered parameter tuple.
 
+The `sql.fragment` tag is the trust marker that distinguishes SQL structure from a parameter value.
+A bare nested template such as
+``${select.status ? `, account.status` : sql.empty}`` is still an ordinary JavaScript string, so
+typed-sql reports `TSQ004` on that template. In Zed and other LSP clients, the preferred quick fix
+prefixes it with `sql.fragment` without changing its contents. Values nested inside the fixed
+fragment remain driver parameters; typed-sql never promotes a runtime string into SQL text.
+
 Independent conditions can produce `2ⁿ` statements, so analysis is bounded before a grammar is
 invoked. The default maximum is 64 variants and can be changed through
 `compiler.maxStructuralVariants`; exceeding it reports `TSQ003` rather than consuming unbounded

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,6 +116,9 @@ Composed fragment values remain parameterized and type-preserving. Direct fragme
 `sql.append()` call receive cumulative grammar analysis; fragments hidden behind arbitrary runtime
 functions or mutable collections do not. Structural fragment text must come from `sql.fragment`
 templates or another explicit trusted fragment API; `sql.raw()` remains a deliberate escape hatch.
+An untagged template paired with a structural branch produces compiler-owned `TSQ004` before any
+grammar runs. The language server can safely fix it by inserting the locally imported SQL tag's
+`.fragment` member; it never copies or evaluates the template contents.
 
 Editor inference is a development feature. CI correctness comes from the same compiler transform
 through `typed-sql check`; runtime code does not depend on an editor being present.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -106,6 +106,8 @@ application-owned driver loading and adapters are isolated under `/pg` and `/mys
 - Confidently incorrect inference is a release-blocking correctness defect.
 - Parameter values remain driver parameters unless the developer deliberately uses a structural
   API such as `sql.ident` or trusted `sql.raw`.
+- A nested JavaScript template is not SQL structure by itself. Conditional structural branches must
+  use `sql.fragment`; `TSQ004` and its editor quick fix preserve that explicit trust boundary.
 - Static types depend on the generated snapshot and configured driver codec policy. They do not
   replace runtime validation at external trust boundaries.
 - Conditional structural analysis is finite and bounded by `compiler.maxStructuralVariants`.
@@ -114,7 +116,8 @@ The release-blocking classification and cross-surface regression rules are defin
 [inference soundness policy](./SOUNDNESS.md).
 
 Diagnostic codes become stable at 1.0. Automation should depend on the exported code and registry,
-not English message text.
+not English message text. A diagnostic may include a structured `SqlDiagnosticFix`; editor tooling
+validates its source offsets and maps it to the client's native edit format without parsing prose.
 
 ## Compatibility policy
 

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -112,7 +112,7 @@ await describe(`${consumerSource} real-database consumers`, async () => {
             mysql2: "3.24.1",
             tsx: "4.23.12",
             typescript: "7.0.2",
-            "@types/node": "24.3.0",
+            "@types/node": "24.13.3",
           }
         : {
             pg: `link:${join(workspace, "node_modules", "pg")}`,

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -45,6 +45,11 @@ Repeated uses of the same condition are correlated and do not multiply the branc
 fragment that receives incompatible parameter expectations across valid branches fails closed with
 `TSQ205`.
 
+Before grammar analysis, the scanner rejects an untagged template paired with `sql.empty` or a
+trusted fragment as `TSQ004`. This produces one focused source diagnostic instead of a downstream
+SQL parse error. Ordinary value templates remain parameters; the compiler never interprets their
+runtime strings as SQL structure.
+
 Application projects normally use this through `typed-sql check` or the language server. It is
 public for grammar, editor, and build-tool integrations.
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -6,7 +6,13 @@ import {
   type SchemaSnapshot,
   type SqlDiagnostic,
 } from "@typed-sql/core";
-import { type ExtractedQuery, extractAppendFragments, extractStaticQueries, mapSqlRange } from "./scanner.js";
+import {
+  type ExtractedQuery,
+  extractAppendFragments,
+  extractStaticQueries,
+  findUntaggedStructuralTemplates,
+  mapSqlRange,
+} from "./scanner.js";
 import { expandStructuralQuery, structuralRowType } from "./structural.js";
 
 export const DEFAULT_MAX_STRUCTURAL_VARIANTS = 64;
@@ -75,6 +81,27 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
   const compiledFragments: CompiledFragment[] = [];
   const diagnostics: SqlDiagnostic[] = [];
   for (const query of extracted) {
+    const untaggedStructuralTemplates = findUntaggedStructuralTemplates(source, query);
+    if (untaggedStructuralTemplates.length > 0) {
+      diagnostics.push(
+        ...untaggedStructuralTemplates.map(
+          (template): SqlDiagnostic => ({
+            code: "TSQ004",
+            message: "Untagged template literals are parameter values; SQL structure requires a trusted fragment",
+            range: template.range,
+            severity: "error",
+            suggestion: `Prefix this template with ${template.tagName}.fragment.`,
+            fix: {
+              title: `Mark as ${template.tagName}.fragment`,
+              range: { ...template.range, end: template.range.start },
+              newText: `${template.tagName}.fragment`,
+              preferred: true,
+            },
+          }),
+        ),
+      );
+      continue;
+    }
     const expansion = expandStructuralQuery(source, query, (index) => dialect.placeholder(index), maximumVariants);
     if (expansion?.kind === "limit") {
       diagnostics.push({

--- a/packages/compiler/src/scanner.ts
+++ b/packages/compiler/src/scanner.ts
@@ -40,6 +40,11 @@ export interface StructuralInterpolation {
   readonly falsy?: StructuralOperand;
 }
 
+export interface UntaggedStructuralTemplate {
+  readonly tagName: string;
+  readonly range: SourceRange;
+}
+
 function isIdentifierStart(char: string | undefined): boolean {
   if (char === undefined) return false;
   const code = char.charCodeAt(0);
@@ -203,10 +208,22 @@ function positionRange(source: string, start: number, end: number): SourceRange 
 }
 
 function skipQuoted(source: string, start: number, quote: string): number {
+  if (quote === "`") return skipTemplate(source, start);
   let index = start + 1;
   while (index < source.length) {
     if (source[index] === "\\") index += 2;
     else if (source[index] === quote) return index + 1;
+    else index += 1;
+  }
+  return source.length;
+}
+
+function skipTemplate(source: string, start: number): number {
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === "\\") index += 2;
+    else if (source[index] === "`") return index + 1;
+    else if (source[index] === "$" && source[index + 1] === "{") index = interpolationEnd(source, index + 2);
     else index += 1;
   }
   return source.length;
@@ -407,13 +424,13 @@ function structuralOperand(source: string, start: number, end: number, tagName: 
   return { kind: "fragment", ...range, backtick };
 }
 
-export function parseStructuralInterpolation(
-  source: string,
-  interpolation: ExtractedInterpolation,
-  tagName: string,
-): StructuralInterpolation | undefined {
-  const expression = unwrappedRange(source, interpolation.expressionStart, interpolation.expressionEnd);
-  const { start, end } = expression;
+interface ConditionalRanges {
+  readonly condition: { readonly start: number; readonly end: number };
+  readonly truthy: { readonly start: number; readonly end: number };
+  readonly falsy: { readonly start: number; readonly end: number };
+}
+
+function conditionalRanges(source: string, start: number, end: number): ConditionalRanges | undefined {
   let question: number | undefined;
   let colon: number | undefined;
   let round = 0;
@@ -457,16 +474,60 @@ export function parseStructuralInterpolation(
     }
     index += 1;
   }
-  if (question === undefined || colon === undefined) {
+  if (question === undefined || colon === undefined) return undefined;
+  return {
+    condition: unwrappedRange(source, start, question),
+    truthy: unwrappedRange(source, question + 1, colon),
+    falsy: unwrappedRange(source, colon + 1, end),
+  };
+}
+
+function bareTemplateRange(source: string, start: number, end: number): SourceRange | undefined {
+  const range = unwrappedRange(source, start, end);
+  if (source[range.start] !== "`" || skipQuoted(source, range.start, "`") !== range.end) return undefined;
+  return positionRange(source, range.start, range.end);
+}
+
+export function findUntaggedStructuralTemplates(
+  source: string,
+  query: ExtractedQuery,
+): readonly UntaggedStructuralTemplate[] {
+  const templates: UntaggedStructuralTemplate[] = [];
+  for (const interpolation of query.interpolations) {
+    const expression = unwrappedRange(source, interpolation.expressionStart, interpolation.expressionEnd);
+    const conditional = conditionalRanges(source, expression.start, expression.end);
+    if (conditional === undefined) continue;
+    const truthyStructural = structuralOperand(source, conditional.truthy.start, conditional.truthy.end, query.tagName);
+    const falsyStructural = structuralOperand(source, conditional.falsy.start, conditional.falsy.end, query.tagName);
+    const truthyTemplate = bareTemplateRange(source, conditional.truthy.start, conditional.truthy.end);
+    const falsyTemplate = bareTemplateRange(source, conditional.falsy.start, conditional.falsy.end);
+    if (truthyTemplate !== undefined && falsyStructural !== undefined) {
+      templates.push({ tagName: query.tagName, range: truthyTemplate });
+    }
+    if (falsyTemplate !== undefined && truthyStructural !== undefined) {
+      templates.push({ tagName: query.tagName, range: falsyTemplate });
+    }
+  }
+  return templates;
+}
+
+export function parseStructuralInterpolation(
+  source: string,
+  interpolation: ExtractedInterpolation,
+  tagName: string,
+): StructuralInterpolation | undefined {
+  const expression = unwrappedRange(source, interpolation.expressionStart, interpolation.expressionEnd);
+  const { start, end } = expression;
+  const conditional = conditionalRanges(source, start, end);
+  if (conditional === undefined) {
     const truthy = structuralOperand(source, start, end, tagName);
     return truthy === undefined ? undefined : { truthy };
   }
-  const truthy = structuralOperand(source, question + 1, colon, tagName);
-  const falsy = structuralOperand(source, colon + 1, end, tagName);
+  const truthy = structuralOperand(source, conditional.truthy.start, conditional.truthy.end, tagName);
+  const falsy = structuralOperand(source, conditional.falsy.start, conditional.falsy.end, tagName);
   if (truthy === undefined || falsy === undefined) return undefined;
-  const condition = unwrappedRange(source, start, question);
   return {
-    condition: source.slice(condition.start, condition.end).replace(/\s+/gu, " "),
+    condition: source.slice(conditional.condition.start, conditional.condition.end).replace(/\s+/gu, " "),
     truthy,
     falsy,
   };

--- a/packages/compiler/test/compiler.test.ts
+++ b/packages/compiler/test/compiler.test.ts
@@ -7,7 +7,12 @@ import { DIALECT_CONTRACT_VERSION, type DialectPlugin, type SchemaSnapshot } fro
 import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
 import { loadSchemaSnapshot } from "../../schema/src/index.js";
 import { checkFile, compileSource, extractStaticQueries, mapSqlRange } from "../src/index.js";
-import { extractAppendFragments, extractStructuralOperand, parseStructuralInterpolation } from "../src/scanner.js";
+import {
+  extractAppendFragments,
+  extractStructuralOperand,
+  findUntaggedStructuralTemplates,
+  parseStructuralInterpolation,
+} from "../src/scanner.js";
 import { structuralRowType } from "../src/structural.js";
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
@@ -118,6 +123,27 @@ await describe("TypeScript 7 compiler wrapper", async () => {
     strict.strictEqual(structural?.condition, "select.status");
     strict.strictEqual(structural?.truthy.kind, "fragment");
     strict.strictEqual(structural?.falsy?.kind, "empty");
+  });
+
+  await it("finds only bare templates paired with trusted structural branches", () => {
+    const source = [
+      'import { sql as querySql } from "@typed-sql/core";',
+      'const hostile = "\' OR TRUE --";',
+      "const query = querySql`SELECT users.id",
+      "  ${select.name ? `, users.name` : querySql.empty}",
+      "  FROM users WHERE users.name <> ${`${`${hostile}`}%`}",
+      "  ${filters.name == null ? querySql.empty : (`AND users.name = ${filters.name}`)}`;",
+    ].join("\n");
+    const query = extractStaticQueries(source, (index) => `$${index}`)[0]!;
+    const templates = findUntaggedStructuralTemplates(source, query);
+    strict.strictEqual(templates.length, 2);
+    strict.deepStrictEqual(
+      templates.map(({ tagName, range }) => ({ tagName, text: source.slice(range.start, range.end) })),
+      [
+        { tagName: "querySql", text: "`, users.name`" },
+        { tagName: "querySql", text: "`AND users.name = ${filters.name}`" },
+      ],
+    );
   });
 
   await it("preserves inline generic selection types for computed structural properties", () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -90,6 +90,11 @@ a complete statement and supplies the branch-dependent row type; no clause-build
 introduced. Structural compilation defaults to at most 64 correlated variants and fails with
 `TSQ003` before invoking a grammar if independent conditions exceed that bound.
 
+Structural branches must use `sql.fragment`; an untagged nested template is a JavaScript string and
+therefore a parameter value. The compiler reports `TSQ004` when such a template is paired with
+`sql.empty` or another trusted structural branch. The explicit marker is an injection boundary:
+interpolated values inside `sql.fragment` remain parameters rather than becoming SQL text.
+
 `sql.join()` accepts only `SqlFragment` values. Its optional separator is also a trusted fragment,
 so use `sql.raw(" UNION ALL ")` when a non-comma separator is intentional; an arbitrary runtime
 string is never promoted to SQL implicitly.
@@ -140,6 +145,7 @@ message text. The machine-readable registry is exported as `diagnosticRegistry`.
 | `TSQ001` | SQL syntax error |
 | `TSQ002` | Parser resource limit exceeded |
 | `TSQ003` | Conditional SQL exceeded the configured structural variant bound |
+| `TSQ004` | Structural SQL requires an explicitly trusted fragment |
 | `TSQ007` | Dialect/snapshot contract mismatch |
 | `TSQ100`–`TSQ108` | Catalog lookup, ambiguity, output naming, and cast errors |
 | `TSQ202`–`TSQ204` | Unknown/ambiguous functions and unsafe operator inference |

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -2,6 +2,7 @@ export const diagnosticRegistry = Object.freeze({
   TSQ001: { category: "syntax", summary: "SQL syntax could not be parsed." },
   TSQ002: { category: "resource", summary: "SQL exceeded a parser resource limit." },
   TSQ003: { category: "resource", summary: "Conditional SQL exceeded the structural variant limit." },
+  TSQ004: { category: "contract", summary: "Structural SQL requires an explicitly trusted fragment." },
   TSQ007: { category: "contract", summary: "The schema snapshot and dialect do not match." },
   TSQ100: { category: "schema", summary: "A referenced table does not exist." },
   TSQ101: { category: "schema", summary: "A referenced column does not exist." },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SchemaSnapshot,
   SourceRange,
   SqlDiagnostic,
+  SqlDiagnosticFix,
   TableSnapshot,
   TypedSqlConfig,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,14 @@ export interface SqlDiagnostic {
   readonly range: SourceRange;
   readonly severity: "error" | "warning" | "info";
   readonly suggestion?: string;
+  readonly fix?: SqlDiagnosticFix;
+}
+
+export interface SqlDiagnosticFix {
+  readonly title: string;
+  readonly range: SourceRange;
+  readonly newText: string;
+  readonly preferred?: boolean;
 }
 
 export interface ColumnSnapshot {

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -43,6 +43,15 @@ await describe("runtime SQL tag", async () => {
     });
   });
 
+  await it("keeps hostile strings parameterized inside trusted structural fragments", () => {
+    const hostile = "' OR TRUE; DROP TABLE users; --";
+    const predicate = sql.fragment` AND users.name = ${hostile}`;
+    strict.deepStrictEqual(renderQuery(sql`SELECT id FROM users WHERE TRUE${predicate}`, renderer), {
+      text: "SELECT id FROM users WHERE TRUE AND users.name = $1",
+      values: [hostile],
+    });
+  });
+
   await it("preserves an explicit ordered parameter tuple", () => {
     const query = sql<
       { readonly id: number },

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -16,6 +16,10 @@ The server discovers `typed-sql.config.ts`, loads the project's installed dialec
 queries against the generated schema, applies the inferred type overlay in memory, and proxies the
 native TypeScript 7.1 preview semantic program. Source files are never rewritten.
 
+When a conditional SQL branch uses a bare template beside `sql.empty` or `sql.fragment`, the server
+reports `TSQ004` at the nested template and offers a preferred `Mark as sql.fragment` quick fix. The
+edit only adds the trusted tag; nested values remain parameterized.
+
 The executable and its pinned preview are self-contained in the project installation. It does not
 load the workspace TypeScript package or require `tsserver.js`; a TypeScript 7.0 package without that
 legacy file is supported. Failure to start the pinned preview returns an initialization error with

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -95,6 +95,31 @@ function severity(value: "error" | "info" | "warning"): DiagnosticSeverity {
   return value === "warning" ? DiagnosticSeverity.Warning : DiagnosticSeverity.Information;
 }
 
+interface DiagnosticFixData {
+  readonly title: string;
+  readonly range: { readonly start: number; readonly end: number };
+  readonly newText: string;
+  readonly preferred?: boolean;
+}
+
+function diagnosticFix(value: unknown, documentLength: number): DiagnosticFixData | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.title !== "string" || typeof candidate.newText !== "string") return undefined;
+  if (typeof candidate.range !== "object" || candidate.range === null) return undefined;
+  const range = candidate.range as Record<string, unknown>;
+  if (!Number.isSafeInteger(range.start) || !Number.isSafeInteger(range.end)) return undefined;
+  const start = range.start as number;
+  const end = range.end as number;
+  if (start < 0 || end < start || end > documentLength) return undefined;
+  return {
+    title: candidate.title,
+    range: { start, end },
+    newText: candidate.newText,
+    ...(typeof candidate.preferred === "boolean" ? { preferred: candidate.preferred } : {}),
+  };
+}
+
 export function settingsFrom(value: unknown): TypedSqlLanguageServerSettings {
   if (typeof value !== "object" || value === null) return {};
   const object = value as Record<string, unknown>;
@@ -161,7 +186,10 @@ export class TypedSqlLanguageService {
         severity: severity(item.severity),
         source: "typed-sql",
         code: item.code,
-        data: item.suggestion === undefined ? undefined : { suggestion: item.suggestion },
+        data:
+          item.suggestion === undefined && item.fix === undefined
+            ? undefined
+            : { suggestion: item.suggestion, fix: item.fix },
       }),
     );
   }
@@ -301,10 +329,34 @@ export class TypedSqlLanguageService {
   ): Promise<readonly CodeAction[]> {
     cancelled(token);
     const actions: CodeAction[] = [];
+    const documentLength = document.getText().length;
     for (const diagnostic of diagnostics) {
       if (diagnostic.source !== "typed-sql") continue;
-      const data = diagnostic.data as { readonly suggestion?: unknown } | undefined;
+      const data = diagnostic.data as { readonly suggestion?: unknown; readonly fix?: unknown } | undefined;
       const suggestion = typeof data?.suggestion === "string" ? data.suggestion : undefined;
+      const fix = diagnosticFix(data?.fix, documentLength);
+      if (fix !== undefined) {
+        actions.push({
+          title: fix.title,
+          kind: CodeActionKind.QuickFix,
+          diagnostics: [diagnostic],
+          ...(fix.preferred === undefined ? {} : { isPreferred: fix.preferred }),
+          edit: {
+            changes: {
+              [document.uri]: [
+                {
+                  range: {
+                    start: document.positionAt(fix.range.start),
+                    end: document.positionAt(fix.range.end),
+                  },
+                  newText: fix.newText,
+                },
+              ],
+            },
+          },
+        });
+        continue;
+      }
       const replacement =
         suggestion === undefined ? undefined : /^Did you mean ([A-Za-z_$][\w$]*)\?$/u.exec(suggestion)?.[1];
       if (replacement === undefined) continue;

--- a/packages/language-server/test/language-server.test.ts
+++ b/packages/language-server/test/language-server.test.ts
@@ -66,6 +66,52 @@ await describe("typed-sql stdio language server", async () => {
     }
   });
 
+  await it("publishes the trusted-fragment quick fix over stdio", async () => {
+    const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
+    const source = [
+      'import { sql } from "@typed-sql/postgres";',
+      "declare const selected: boolean;",
+      "const query = sql`SELECT user.id ${selected ? `, user.name` : sql.empty} FROM users AS user`;",
+    ].join("\n");
+    const uri = pathToFileURL(join(fixtureDirectory, "structural-fix.ts")).href;
+    try {
+      await client.request("initialize", {
+        processId: process.pid,
+        rootUri: pathToFileURL(workspaceDirectory).href,
+        workspaceFolders: [{ uri: pathToFileURL(workspaceDirectory).href, name: "typed-sql" }],
+        capabilities: {},
+        initializationOptions: { configPath: configFile, schemaPath: schemaFile, projectFile, nativePreview: false },
+      });
+      client.notify("initialized", {});
+      const published = client.notification("textDocument/publishDiagnostics", (params) => {
+        const value = params as { readonly uri?: string; readonly diagnostics?: readonly { readonly code?: string }[] };
+        return value.uri === uri && value.diagnostics?.some(({ code }) => code === "TSQ004") === true;
+      });
+      client.notify("textDocument/didOpen", {
+        textDocument: { uri, languageId: "typescript", version: 1, text: source },
+      });
+      const report = (await published) as {
+        readonly diagnostics?: readonly { readonly code?: string; readonly range?: unknown; readonly data?: unknown }[];
+      };
+      const diagnostic = report.diagnostics?.find(({ code }) => code === "TSQ004");
+      strict.ok(diagnostic !== undefined);
+      const actions = (await client.request("textDocument/codeAction", {
+        textDocument: { uri },
+        range: diagnostic?.range,
+        context: { diagnostics: [diagnostic] },
+      })) as readonly {
+        readonly title?: string;
+        readonly isPreferred?: boolean;
+        readonly edit?: { readonly changes?: Readonly<Record<string, readonly { readonly newText?: string }[]>> };
+      }[];
+      const action = actions.find(({ title }) => title === "Mark as sql.fragment");
+      strict.strictEqual(action?.isPreferred, true);
+      strict.strictEqual(action?.edit?.changes?.[uri]?.[0]?.newText, "sql.fragment");
+    } finally {
+      await client.close();
+    }
+  });
+
   await it("makes inferred rows part of the TypeScript 7 semantic program", async () => {
     const client = new ProtocolClient(process.execPath, [serverFile, "--stdio"], workspaceDirectory);
     const source = await readFile(queryFile, "utf8");

--- a/packages/language-server/test/service.test.ts
+++ b/packages/language-server/test/service.test.ts
@@ -55,6 +55,55 @@ await describe("typed-sql language service", async () => {
     strict.strictEqual(actions[0]?.isPreferred, true);
   });
 
+  await it("marks bare structural templates as trusted fragments without promoting their values", async () => {
+    const text = [
+      'import { sql as querySql } from "@typed-sql/postgres";',
+      'const hostile = "\' OR TRUE --";',
+      "interface Selection { readonly name: boolean }",
+      "interface Filters { readonly name?: string | null }",
+      "function users(select: Selection, filters: Filters) {",
+      "  return querySql`SELECT user.id",
+      "    ${select.name ? `, user.name` : querySql.empty}",
+      "    FROM users AS user WHERE user.name <> ${hostile}",
+      "    ${filters.name == null ? querySql.empty : `AND user.name = ${filters.name}`}`;",
+      "}",
+    ].join("\n");
+    const current = document("fragment-fix.ts", text);
+    const diagnostics = (await service.diagnostics(current)).filter(({ code }) => code === "TSQ004");
+    strict.strictEqual(diagnostics.length, 2);
+    strict.deepStrictEqual(
+      diagnostics.map(({ range }) => current.getText(range)),
+      ["`, user.name`", "`AND user.name = ${filters.name}`"],
+    );
+
+    const edits = [];
+    for (const diagnostic of diagnostics) {
+      const actions = await service.codeActions(current, [diagnostic]);
+      strict.strictEqual(actions[0]?.title, "Mark as querySql.fragment");
+      strict.strictEqual(actions[0]?.isPreferred, true);
+      edits.push(...(actions[0]?.edit?.changes?.[current.uri] ?? []));
+    }
+    let fixed = text;
+    for (const edit of edits.sort(
+      (left, right) => current.offsetAt(right.range.start) - current.offsetAt(left.range.start),
+    )) {
+      const start = current.offsetAt(edit.range.start);
+      const end = current.offsetAt(edit.range.end);
+      fixed = `${fixed.slice(0, start)}${edit.newText}${fixed.slice(end)}`;
+    }
+    const updated = document("fragment-fix.ts", fixed, 2);
+    strict.deepStrictEqual(await service.diagnostics(updated), []);
+    const analysis = await service.analysis(updated);
+    strict.ok(analysis?.transformedSource.includes("querySql.fragment<readonly [string]>") === true);
+    strict.ok(fixed.includes("user.name <> ${hostile}"));
+
+    const malformed = {
+      ...diagnostics[0]!,
+      data: { fix: { title: "Unsafe edit", range: { start: -1, end: text.length + 1 }, newText: "sql.raw" } },
+    };
+    strict.deepStrictEqual(await service.codeActions(current, [malformed]), []);
+  });
+
   await it("bounds caches and honors cancellation", async () => {
     await service.analysis(document("cache-a.ts"));
     await service.analysis(document("cache-b.ts"));

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -25,6 +25,8 @@ import type {
   QueryRow,
   RenderedQuery,
   SchemaSnapshot,
+  SqlDiagnostic,
+  SqlDiagnosticFix,
   SqlFragment,
   SqlRenderer,
   SqlSegment,
@@ -92,6 +94,8 @@ type ReferencedStableTypes =
   | QueryExecutor
   | RenderedQuery
   | SqlFragment
+  | SqlDiagnostic
+  | SqlDiagnosticFix
   | SqlRenderer
   | SqlSegment
   | SqlTag

--- a/test/contracts/registry-acceptance.test.ts
+++ b/test/contracts/registry-acceptance.test.ts
@@ -23,6 +23,8 @@ await describe("registry-only consumer acceptance", async () => {
 
     for (const contract of [
       'process.env.TYPED_SQL_REGISTRY_TAG ?? "next"',
+      'typescript: "7.0.2"',
+      '"@types/node": "24.13.3"',
       'for (const protocol of ["workspace:", "link:", "file:"])',
       "resolved outside disposable consumer",
       "resolved from the repository",

--- a/test/soundness/source-corpus.ts
+++ b/test/soundness/source-corpus.ts
@@ -83,6 +83,24 @@ export const sourceSoundnessCorpus: readonly SourceSoundnessCase[] = [
     expectation: { kind: "diagnostic", codes: ["TSQ101"], sourceTarget: "deleted_at" },
   },
   {
+    id: "untagged-structural-template-diagnostic",
+    source: [
+      moduleImport,
+      'const hostile = "\' OR TRUE --";',
+      "interface Selection { readonly status: boolean }",
+      'interface Filters { readonly status?: "active" | "suspended" | null }',
+      "export function accounts(select: Selection, filters: Filters) {",
+      "  return sql`SELECT users.id, users.email",
+      `    ${interpolation("select.status ? `, users.status` : sql.empty")}`,
+      `    FROM users WHERE users.email <> ${interpolation("hostile")}`,
+      `    ${interpolation(
+        `filters.status == null ? sql.empty : \`AND users.status = ${interpolation("filters.status")}\``,
+      )}\`;`,
+      "}",
+    ].join("\n"),
+    expectation: { kind: "diagnostic", codes: ["TSQ004"], sourceTarget: ", users.status" },
+  },
+  {
     id: "incompatible-structural-parameter-context",
     source: [
       moduleImport,


### PR DESCRIPTION
Closes #29. Advances #22.\n\nAdds compiler-owned TSQ004 diagnostics for bare nested templates paired with trusted structural branches, structured grammar-neutral diagnostic fixes, and a preferred alias-aware language-server edit. Values inside fixed fragments remain driver parameters. Coverage spans PostgreSQL, MySQL, nullable filters, conditional projections, hostile strings, malformed fix metadata, and real stdio LSP routing.\n\nAlso aligns the registry-only consumer with TypeScript 7-compatible Node declarations; the published final beta now passes the complete npm-only PostgreSQL/MySQL/editor gate.\n\nVerified on Node 24.10 with pnpm verify and the registry-only next-tag acceptance suite.