### PR TITLE
release: enforce the 1.0 RC soak

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,5 +1,5 @@
 # Changesets
 
-Run `pnpm changeset` for every user-visible change to a public package. The repository is currently
-in Changesets `beta` prerelease mode, so version PRs produce `1.0.0-beta.*` releases for npm's
-`next` tag. Follow `docs/PUBLISHING.md` before exiting prerelease mode or publishing to `latest`.
+Run `pnpm changeset` for every user-visible change to a public package. The active channel is
+declared by `release-manifest.json`; prereleases use npm `next`. Follow `docs/RELEASING.md` and the
+release-candidate soak before exiting prerelease mode or publishing to `latest`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
         type: choice
         options:
           - beta
+          - rc
           - stable
 
 concurrency:
@@ -90,18 +91,45 @@ jobs:
       - name: Assert beta release contract
         if: inputs.channel == 'beta'
         run: pnpm release:assert beta
+      - name: Assert release-candidate contract
+        if: inputs.channel == 'rc'
+        run: pnpm release:assert rc
       - name: Assert stable release contract
         if: inputs.channel == 'stable'
         run: pnpm release:assert stable
-      - uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
+      - name: Assert completed release-candidate soak
+        if: inputs.channel == 'stable'
+        run: pnpm release:soak
+      - name: Publish beta
+        uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'beta'
         with:
           script: pnpm release:beta
           create-github-releases: true
           push-git-tags: true
-      - uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
+      - name: Publish release candidate
+        uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
+        if: inputs.channel == 'rc'
+        with:
+          script: pnpm release:rc
+          create-github-releases: true
+          push-git-tags: true
+      - name: Verify published prerelease from npm
+        if: inputs.channel == 'beta' || inputs.channel == 'rc'
+        run: pnpm e2e:registry
+        env:
+          TYPED_SQL_CONTAINER_ENGINE: docker
+          TYPED_SQL_REGISTRY_TAG: next
+      - name: Publish stable
+        uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'stable'
         with:
           script: pnpm release:stable
           create-github-releases: true
           push-git-tags: true
+      - name: Verify published stable packages from npm
+        if: inputs.channel == 'stable'
+        run: pnpm e2e:registry
+        env:
+          TYPED_SQL_CONTAINER_ENGINE: docker
+          TYPED_SQL_REGISTRY_TAG: latest

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:registry
 - [Releasing](./docs/RELEASING.md)
 - [Stable release rehearsal](./docs/STABLE_REHEARSAL.md)
 - [Registry-only acceptance](./docs/REGISTRY_ACCEPTANCE.md)
+- [Release-candidate soak](./docs/RC_SOAK.md)
 - [Diagnostic code registry](./packages/core/README.md#diagnostics)
 - [Security policy](./SECURITY.md)
 - [Contributing](./CONTRIBUTING.md)

--- a/docs/RC_SOAK.md
+++ b/docs/RC_SOAK.md
@@ -1,0 +1,57 @@
+# Release-candidate soak
+
+typed-sql does not promote an RC to npm `latest` from repository CI alone. The exact candidate must
+spend 7–14 full days in at least three independent, registry-only consumer repositories. The
+PostgreSQL, MySQL, and editor roles must all be represented.
+
+The stable Release workflow runs `pnpm release:soak` before any registry write. That command reads
+`release/rc-soak.json`, validates the evidence, and verifies that its candidate is the same RC from
+which the stable version was rehearsed. A missing report, a report written too early, or evidence
+for an older RC blocks publication.
+
+## Start a soak
+
+1. Publish one coherent `1.0.0-rc.N` train under npm `next`.
+2. Verify the post-publication registry-only PostgreSQL and MySQL suite is green.
+3. Copy `release/rc-soak.example.json` to `release/rc-soak.json`.
+4. Replace every example value with the published RC's real version, commit, publication time, and
+   consumer data.
+5. Install exact npm versions in three repositories. Do not use `workspace:`, `file:`, `link:`, pnpm
+   overrides, or paths into this checkout.
+6. Run every consumer during the first 24 hours and again after the complete minimum period.
+
+`startedAt` cannot precede `publishedAt`. If a release-blocking fix changes inference, generated
+output, runtime contracts, exports, or release mechanics, publish a new RC and start a new report
+and clock. Never carry elapsed time or test evidence from an older candidate.
+
+## Required consumers
+
+The report records exact Node, pnpm, TypeScript, database, driver, editor, and typed-sql versions.
+Each run links to immutable HTTPS evidence and the exact consumer commit.
+
+- `postgres`: clean install, generation, TypeScript checks, runtime execution, schema drift,
+  deterministic generation, `pg` compatibility, and conditional query composition.
+- `mysql`: the equivalent checks against MySQL and `mysql2`.
+- `editor`: installation, generation, TypeScript checks, hover types, diagnostics, quick fixes, and
+  a full editor/language-server restart.
+
+PostgreSQL and MySQL runs record the SHA-256 digest of generated output. Every run for one consumer
+must produce the same digest. Repositories and consumer ids must be distinct; fixtures inside this
+monorepo do not count as external consumers.
+
+## Blockers and decision
+
+Record every discovered blocker in the report. Supported categories cover inference, false
+rejection, false acceptance, nondeterminism, drivers, installation, editor behavior, documentation,
+and security. A blocker must be resolved and link to its regression test; otherwise the stable gate
+fails.
+
+After the complete period, record a reviewed `go` decision, its owner, rationale, and known
+limitations. Then validate locally:
+
+```sh
+pnpm release:soak
+```
+
+The command is intentionally expected to fail until the entire clock and evidence contract are
+satisfied. The report is release evidence, not a checklist to pre-fill.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,7 @@ Every public package repeats that value as `typedSql.releaseTrack` in its packed
 4. Wait for all required CI checks on the exact version commit.
 5. Dispatch the protected Release workflow with the channel matching the version:
    - `beta` for `1.0.0-beta.*`, published under `next`;
+   - `rc` for one coherent `1.0.0-rc.*` package train, published under `next`;
    - `stable` only after prerelease mode has been exited, published under `latest`.
 
 Before creating the stable version PR, run the isolated, no-write rehearsal documented in
@@ -45,6 +46,10 @@ Publishing is blocked unless all of these pass:
 - no open critical- or high-severity CodeQL alert;
 - production dependency audit with no high-severity advisory.
 
+Beta and RC publication finish by installing the just-published `next` packages into the
+registry-only PostgreSQL and MySQL consumers. A successful publish with a failed registry proof is
+not a release-ready candidate.
+
 ## Trusted publishing
 
 Every package trusts the same GitHub Actions identity:
@@ -61,8 +66,8 @@ in GitHub or the repository.
 
 Registry publication is intentionally separate from Changesets' publish planner.
 The planner cannot represent `-beta.N` versions published under the independent `next` dist-tag.
-`release:beta` instead follows `release-manifest.json` deterministically, checks npm before every
-write for retry safety, supports independently versioned packages in the same release graph, packs
+`release:beta` and `release:rc` instead follow `release-manifest.json` deterministically, check npm
+before every write for retry safety, support independently versioned packages in the same release graph, and pack
 workspace-resolved tarballs with pnpm, publishes them through npm's native OIDC client, and asks
 Changesets to create tags only after every package is published. Stable uses the same retry-safe
 publisher, restricted to the stable package train and the `latest` tag.
@@ -72,9 +77,9 @@ traditional tokens. See [npm trusted publishers](https://docs.npmjs.com/trusted-
 
 ## Stable promotion
 
-Do not promote `latest` until registry installs work without workspace overrides, PostgreSQL and
-MySQL packed E2E remain green through the beta soak, editor installation has been exercised outside
-this repository, and no open correctness issue can produce a confidently wrong row type.
+Do not promote `latest` until registry installs work without workspace overrides and the exact RC
+passes the machine-verifiable [release-candidate soak](./RC_SOAK.md). The stable manifest records
+that RC as `sourceCandidate`; the stable workflow rejects evidence for any other candidate.
 
 Create the dedicated release PR from `artifacts/stable-rehearsal/stable-release.diff`. It sets the
 packages in `packagePolicy.stable` to stable `1.0.0`, keeps `packagePolicy.experimental` on explicit
@@ -88,7 +93,7 @@ the stable train.
 
 - Never delete or move a published npm version or release tag.
 - Never publish a beta under `latest`.
-- Retry partial beta releases normally: the publisher skips exact versions already present on npm.
+- Retry partial beta or RC releases normally: the publisher skips exact versions already present on npm.
 - Dispatch releases only from protected `main`.
 - If OIDC fails, verify the case-sensitive owner, repository, workflow and environment before
   considering any token fallback.

--- a/docs/STABLE_REHEARSAL.md
+++ b/docs/STABLE_REHEARSAL.md
@@ -13,9 +13,10 @@ there. The caller's checkout is never versioned.
 
 The rehearsal:
 
-- exits Changesets beta prerelease mode;
+- requires one coherent RC train and exits Changesets `rc` prerelease mode;
 - separates mixed Changesets by the stable and experimental package policies;
-- versions the stable train to exactly `1.0.0` and changes the release manifest to `stable:latest`;
+- versions the stable train to exactly `1.0.0`, changes the release manifest to `stable:latest`,
+  and records the originating RC as `sourceCandidate`;
 - restores experimental package versions, changelogs, and pending Changesets so preview-backed
   work is not accidentally promoted or discarded;
 - refreshes the lockfile and runs `release:assert stable`;
@@ -41,7 +42,7 @@ version-PR change; it is never applied to the caller's checkout automatically.
 
 ## Retry and recovery
 
-Both beta and stable publication use the same fail-closed publisher. Before each package write it
+Beta, RC, and stable publication use the same fail-closed publisher. Before each package write it
 asks npm whether that exact name and version already exists. A retry skips published versions,
 continues in manifest order, and creates Changesets tags only after every package is present.
 

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -11,10 +11,9 @@ typed parameters and structural fragments, editor reliability, security enforcem
 protections, trusted npm publishing, registry-only acceptance, and no-write stable rehearsal are in
 place.
 
-The project is not ready to publish under `latest` yet. npm `next` must first receive one coherent
-beta containing the current package graph—the registry gate correctly rejects the older mixed beta
-currently published. That candidate must then complete the representative consumer soak and final
-documentation review.
+The final coherent beta and its registry-only acceptance suite are green. The remaining release
+blocker is to publish one coherent RC, complete its representative external-consumer soak, and
+finish the stable documentation review.
 
 ## Definition of ready
 
@@ -31,14 +30,12 @@ The stable release is ready when all of the following are true:
 
 ## Milestone 1: Publish and soak the final candidate
 
-1. Merge the remaining prerelease changes and publish one coherent beta under `next`.
-2. Run [`pnpm e2e:registry`](./REGISTRY_ACCEPTANCE.md) against that beta from a clean npm-only
-   consumer.
-3. Publish `1.0.0-rc.0` under `next` once the beta is clean.
-4. Test the RC in independent projects that do not share monorepo configuration.
-5. Allow an agreed soak period, recommended as one to two weeks.
-6. Require at least three representative consumers across PostgreSQL, MySQL, and editor usage.
-7. Publish another RC whenever a release-blocking fix changes generated output, inference, runtime
+1. Publish `1.0.0-rc.0` under `next` from one coherent package train.
+2. Confirm the protected workflow's post-publication registry-only PostgreSQL and MySQL proof.
+3. Test the RC in independent projects that do not share monorepo configuration.
+4. Complete the 7–14 day soak described in [`RC_SOAK.md`](./RC_SOAK.md).
+5. Require at least three representative consumers across PostgreSQL, MySQL, and editor usage.
+6. Publish another RC whenever a release-blocking fix changes generated output, inference, runtime
    contracts, package exports, or release mechanics.
 
 During the soak, track:
@@ -58,12 +55,13 @@ Acceptance criteria:
 - all representative projects upgrade using only npm versions;
 - generated output is deterministic and checked into consumers without unexplained churn;
 - every reported correctness issue has a regression test before resolution.
+- `pnpm release:soak` validates the exact source RC, external evidence, deterministic hashes, and
+  recorded go/no-go decision.
 
 ## Milestone 2: Finish stable documentation
 
 Before the stable version PR:
 
-- remove the stale deleted-document reference from `.changeset/README.md`;
 - make the root README show the registry-first installation and stable package boundary;
 - ensure package READMEs describe only exports and commands present in packed artifacts;
 - update compatibility documentation with exact TypeScript, Node.js, PostgreSQL, MySQL, `pg`,

--- a/package.json
+++ b/package.json
@@ -31,14 +31,16 @@
     "release:artifacts": "pnpm build && pnpm test:pack",
     "release:assert": "node scripts/assert-release-channel.mjs",
     "release:security": "node scripts/code-scanning-policy.mjs",
+    "release:soak": "node scripts/assert-rc-soak.mjs",
     "release:beta": "pnpm release:assert beta && node scripts/publish-prerelease.mjs",
+    "release:rc": "pnpm release:assert rc && node scripts/publish-prerelease.mjs rc",
     "release:stable": "pnpm release:assert stable && node scripts/publish-prerelease.mjs stable",
     "release:rehearse": "node scripts/rehearse-stable-release.mjs",
     "release:check": "pnpm verify && pnpm --filter @typed-sql/e2e-packed e2e && pnpm audit --prod --audit-level high",
     "coverage": "pnpm --filter @typed-sql/core coverage && pnpm --filter @typed-sql/ast coverage && pnpm --filter @typed-sql/schema coverage && pnpm --filter @typed-sql/config coverage && pnpm --filter @typed-sql/compiler coverage && pnpm --filter @typed-sql/postgres coverage && pnpm --filter @typed-sql/mysql coverage",
     "test:watch": "poku --config=poku.config.js --watch",
     "typecheck": "node scripts/require-typescript-7.mjs && tsc -b --pretty false",
-    "version-packages": "changeset version"
+    "version-packages": "node scripts/version-packages.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.10",

--- a/release/rc-soak.example.json
+++ b/release/rc-soak.example.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "series": "1.0.0",
+  "candidate": "1.0.0-rc.0",
+  "npmTag": "next",
+  "releaseCommit": "0000000000000000000000000000000000000000",
+  "publishedAt": "2026-08-26T00:00:00.000Z",
+  "startedAt": "2026-08-26T00:00:00.000Z",
+  "minimumDays": 7,
+  "consumers": [
+    {
+      "id": "postgres-application",
+      "role": "postgres",
+      "repository": "https://github.com/example/typed-sql-postgres-soak",
+      "installSource": "registry",
+      "node": "24.10.0",
+      "packageManager": "pnpm@10.32.1",
+      "typescript": { "name": "typescript", "version": "7.0.2" },
+      "database": { "name": "postgresql", "version": "18.0.0" },
+      "driver": { "name": "pg", "version": "8.23.0" },
+      "packages": {
+        "@typed-sql/core": "1.0.0-rc.0",
+        "@typed-sql/postgres": "1.0.0-rc.0",
+        "@typed-sql/cli": "1.0.0-rc.0"
+      },
+      "runs": []
+    },
+    {
+      "id": "mysql-application",
+      "role": "mysql",
+      "repository": "https://github.com/example/typed-sql-mysql-soak",
+      "installSource": "registry",
+      "node": "24.10.0",
+      "packageManager": "pnpm@10.32.1",
+      "typescript": { "name": "typescript", "version": "7.0.2" },
+      "database": { "name": "mysql", "version": "9.4.0" },
+      "driver": { "name": "mysql2", "version": "3.24.1" },
+      "packages": {
+        "@typed-sql/core": "1.0.0-rc.0",
+        "@typed-sql/mysql": "1.0.0-rc.0",
+        "@typed-sql/cli": "1.0.0-rc.0"
+      },
+      "runs": []
+    },
+    {
+      "id": "zed-editor-project",
+      "role": "editor",
+      "repository": "https://github.com/example/typed-sql-editor-soak",
+      "installSource": "registry",
+      "node": "24.10.0",
+      "packageManager": "pnpm@10.32.1",
+      "typescript": { "name": "typescript", "version": "7.0.2" },
+      "editor": { "name": "zed", "version": "0.202.5" },
+      "packages": {
+        "@typed-sql/language-server": "1.0.0-rc.0",
+        "@typed-sql/ts-bridge": "1.0.0-rc.0"
+      },
+      "runs": []
+    }
+  ],
+  "blockers": [],
+  "decision": {
+    "outcome": "go",
+    "decidedAt": "2026-09-02T00:00:00.000Z",
+    "owner": "Lojhan",
+    "rationale": "All required consumers passed for the complete soak window.",
+    "knownLimitations": ["Replace this example with the reviewed limitations for the actual RC."]
+  }
+}

--- a/scripts/assert-rc-soak.d.mts
+++ b/scripts/assert-rc-soak.d.mts
@@ -1,0 +1,23 @@
+export interface RcSoakValidationOptions {
+  readonly series: string;
+  readonly now?: Date;
+}
+
+export interface AssertRcSoakOptions {
+  readonly workspace?: string;
+  readonly reportPath?: string;
+  readonly now?: Date;
+}
+
+export interface RcSoakSummary {
+  readonly candidate: string;
+  readonly releaseCommit: string;
+  readonly minimumDays: number;
+  readonly consumerCount: number;
+  readonly blockerCount: number;
+  readonly decision: "go";
+}
+
+export function validateRcSoakReport(value: unknown, options: RcSoakValidationOptions): RcSoakSummary;
+export function assertRcSoak(options?: AssertRcSoakOptions): Promise<RcSoakSummary>;
+export function main(): Promise<void>;

--- a/scripts/assert-rc-soak.mjs
+++ b/scripts/assert-rc-soak.mjs
@@ -1,0 +1,265 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadReleaseManifest } from "./release-policy.mjs";
+
+const defaultWorkspace = fileURLToPath(new URL("..", import.meta.url));
+const roles = {
+  postgres: {
+    packages: ["@typed-sql/core", "@typed-sql/postgres", "@typed-sql/cli"],
+    checks: [
+      "install",
+      "generation",
+      "typecheck",
+      "runtime",
+      "drift",
+      "determinism",
+      "driver-compatibility",
+      "query-composition",
+    ],
+    deterministic: true,
+  },
+  mysql: {
+    packages: ["@typed-sql/core", "@typed-sql/mysql", "@typed-sql/cli"],
+    checks: [
+      "install",
+      "generation",
+      "typecheck",
+      "runtime",
+      "drift",
+      "determinism",
+      "driver-compatibility",
+      "query-composition",
+    ],
+    deterministic: true,
+  },
+  editor: {
+    packages: ["@typed-sql/language-server", "@typed-sql/ts-bridge"],
+    checks: ["install", "generation", "typecheck", "hover", "diagnostics", "quick-fix", "restart"],
+    deterministic: false,
+  },
+};
+const blockerCategories = new Set([
+  "inference",
+  "false-rejection",
+  "false-acceptance",
+  "nondeterminism",
+  "driver",
+  "installation",
+  "editor",
+  "documentation",
+  "security",
+]);
+
+function object(value, label) {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new TypeError(`${label} must be an object`);
+  return value;
+}
+
+function string(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${label} must be a non-empty string`);
+  return value;
+}
+
+function exactVersion(value, label) {
+  const version = string(value, label);
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/u.test(version)) {
+    throw new TypeError(`${label} must be an exact semantic version`);
+  }
+  return version;
+}
+
+function array(value, label) {
+  if (!Array.isArray(value)) throw new TypeError(`${label} must be an array`);
+  return value;
+}
+
+function instant(value, label) {
+  const parsed = Date.parse(string(value, label));
+  if (!Number.isFinite(parsed)) throw new TypeError(`${label} must be an ISO date-time`);
+  return parsed;
+}
+
+function httpsUrl(value, label) {
+  const parsed = new URL(string(value, label));
+  if (parsed.protocol !== "https:") throw new TypeError(`${label} must use https`);
+  return parsed.href;
+}
+
+function exactStrings(value, label) {
+  const items = array(value, label).map((item, index) => string(item, `${label}[${index}]`));
+  if (new Set(items).size !== items.length) throw new TypeError(`${label} must not contain duplicates`);
+  return items;
+}
+
+function versionedTool(value, label, expectedName) {
+  const tool = object(value, label);
+  const name = string(tool.name, `${label}.name`);
+  if (expectedName !== undefined && name !== expectedName) {
+    throw new TypeError(`${label}.name must be ${expectedName}`);
+  }
+  exactVersion(tool.version, `${label}.version`);
+  return tool;
+}
+
+export function validateRcSoakReport(value, options) {
+  const report = object(value, "RC soak report");
+  if (report.schemaVersion !== 1) throw new TypeError("RC soak report schemaVersion must be 1");
+  const series = string(report.series, "series");
+  if (series !== options.series) throw new TypeError(`RC soak series ${series} does not match ${options.series}`);
+  const candidate = string(report.candidate, "candidate");
+  if (!new RegExp(`^${series.replaceAll(".", "\\.")}-rc\\.\\d+$`, "u").test(candidate)) {
+    throw new TypeError(`candidate must be a ${series}-rc.N version`);
+  }
+  if (report.npmTag !== "next") throw new TypeError("RC soak candidate must be installed from npm next");
+  const releaseCommit = string(report.releaseCommit, "releaseCommit");
+  if (!/^[\da-f]{40}$/u.test(releaseCommit)) throw new TypeError("releaseCommit must be a full lowercase git SHA");
+  if (!Number.isSafeInteger(report.minimumDays) || report.minimumDays < 7 || report.minimumDays > 14) {
+    throw new TypeError("minimumDays must be a safe integer from 7 through 14");
+  }
+  const startedAt = instant(report.startedAt, "startedAt");
+  const publishedAt = instant(report.publishedAt, "publishedAt");
+  if (startedAt < publishedAt) throw new TypeError("startedAt cannot precede RC publication");
+  const requiredEnd = startedAt + report.minimumDays * 86_400_000;
+  const now = options.now instanceof Date ? options.now.getTime() : Date.now();
+  if (now < requiredEnd) throw new Error(`RC soak has not completed ${report.minimumDays} full days`);
+
+  const consumers = array(report.consumers, "consumers");
+  if (consumers.length < 3) throw new TypeError("RC soak requires at least three consumers");
+  const seenRepositories = new Set();
+  const seenConsumerIds = new Set();
+  const seenRoles = new Set();
+  for (const [consumerIndex, rawConsumer] of consumers.entries()) {
+    const label = `consumers[${consumerIndex}]`;
+    const consumer = object(rawConsumer, label);
+    const consumerId = string(consumer.id, `${label}.id`);
+    if (seenConsumerIds.has(consumerId)) throw new TypeError("RC consumer ids must be distinct");
+    seenConsumerIds.add(consumerId);
+    const role = string(consumer.role, `${label}.role`);
+    if (!Object.hasOwn(roles, role)) throw new TypeError(`${label}.role must be postgres, mysql, or editor`);
+    seenRoles.add(role);
+    const repository = httpsUrl(consumer.repository, `${label}.repository`);
+    if (seenRepositories.has(repository)) throw new TypeError("RC consumers must use distinct external repositories");
+    if (/^https:\/\/github\.com\/Lojhan\/typed-sql(?:\.git)?\/?$/u.test(repository)) {
+      throw new TypeError("The typed-sql monorepo cannot count as an external RC consumer");
+    }
+    seenRepositories.add(repository);
+    if (consumer.installSource !== "registry") {
+      throw new TypeError(`${label}.installSource must be registry`);
+    }
+    exactVersion(consumer.node, `${label}.node`);
+    const packageManager = string(consumer.packageManager, `${label}.packageManager`);
+    if (!/^pnpm@\d+\.\d+\.\d+$/u.test(packageManager)) {
+      throw new TypeError(`${label}.packageManager must pin an exact pnpm version`);
+    }
+    const typescript = versionedTool(consumer.typescript, `${label}.typescript`, "typescript");
+    if (!typescript.version.startsWith("7.")) throw new TypeError(`${label}.typescript must use TypeScript 7`);
+    if (role === "postgres") {
+      versionedTool(consumer.database, `${label}.database`, "postgresql");
+      versionedTool(consumer.driver, `${label}.driver`, "pg");
+    } else if (role === "mysql") {
+      versionedTool(consumer.database, `${label}.database`, "mysql");
+      versionedTool(consumer.driver, `${label}.driver`, "mysql2");
+    } else {
+      versionedTool(consumer.editor, `${label}.editor`);
+    }
+    const packages = object(consumer.packages, `${label}.packages`);
+    for (const name of roles[role].packages) {
+      if (packages[name] !== candidate) throw new TypeError(`${label}.packages must pin ${name} to ${candidate}`);
+    }
+
+    const runs = array(consumer.runs, `${label}.runs`);
+    if (runs.length < 2) throw new TypeError(`${label} requires at least two successful runs`);
+    const hashes = new Set();
+    let firstRun = Number.POSITIVE_INFINITY;
+    let lastRun = Number.NEGATIVE_INFINITY;
+    for (const [runIndex, rawRun] of runs.entries()) {
+      const runLabel = `${label}.runs[${runIndex}]`;
+      const run = object(rawRun, runLabel);
+      const at = instant(run.at, `${runLabel}.at`);
+      if (at < startedAt || at > now) throw new TypeError(`${runLabel}.at is outside the measured soak window`);
+      firstRun = Math.min(firstRun, at);
+      lastRun = Math.max(lastRun, at);
+      if (run.result !== "pass") throw new Error(`${runLabel} did not pass`);
+      if (!/^[\da-f]{40}$/u.test(string(run.consumerCommit, `${runLabel}.consumerCommit`))) {
+        throw new TypeError(`${runLabel}.consumerCommit must be a full lowercase git SHA`);
+      }
+      httpsUrl(run.evidence, `${runLabel}.evidence`);
+      const checks = exactStrings(run.checks, `${runLabel}.checks`);
+      for (const check of roles[role].checks) {
+        if (!checks.includes(check)) throw new TypeError(`${runLabel} is missing ${check}`);
+      }
+      if (roles[role].deterministic) {
+        const hash = string(run.generatedHash, `${runLabel}.generatedHash`);
+        if (!/^[\da-f]{64}$/u.test(hash)) throw new TypeError(`${runLabel}.generatedHash must be a SHA-256 hex digest`);
+        hashes.add(hash);
+      }
+    }
+    if (firstRun > startedAt + 86_400_000) throw new Error(`${label} did not begin within the first soak day`);
+    if (lastRun < requiredEnd) throw new Error(`${label} has no passing run after the minimum soak period`);
+    if (roles[role].deterministic && hashes.size !== 1)
+      throw new Error(`${label} generated output changed during the soak`);
+  }
+  for (const role of Object.keys(roles)) {
+    if (!seenRoles.has(role)) throw new TypeError(`RC soak is missing an independent ${role} consumer`);
+  }
+
+  const blockers = array(report.blockers, "blockers");
+  for (const [index, rawBlocker] of blockers.entries()) {
+    const label = `blockers[${index}]`;
+    const blocker = object(rawBlocker, label);
+    string(blocker.id, `${label}.id`);
+    if (!blockerCategories.has(blocker.category)) throw new TypeError(`${label}.category is unsupported`);
+    if (blocker.status !== "resolved") throw new Error(`${label} remains unresolved`);
+    const resolvedAt = instant(blocker.resolvedAt, `${label}.resolvedAt`);
+    if (resolvedAt < startedAt || resolvedAt > now) {
+      throw new TypeError(`${label}.resolvedAt is outside the soak window`);
+    }
+    httpsUrl(blocker.regressionTest, `${label}.regressionTest`);
+  }
+
+  const decision = object(report.decision, "decision");
+  if (decision.outcome !== "go") throw new Error("RC soak decision must be go before stable publication");
+  const decidedAt = instant(decision.decidedAt, "decision.decidedAt");
+  if (decidedAt < requiredEnd || decidedAt > now) {
+    throw new TypeError("decision.decidedAt must be inside the completed soak window");
+  }
+  string(decision.owner, "decision.owner");
+  string(decision.rationale, "decision.rationale");
+  exactStrings(decision.knownLimitations, "decision.knownLimitations");
+
+  return {
+    candidate,
+    releaseCommit,
+    minimumDays: report.minimumDays,
+    consumerCount: consumers.length,
+    blockerCount: blockers.length,
+    decision: decision.outcome,
+  };
+}
+
+export async function assertRcSoak(options = {}) {
+  const workspace = resolve(options.workspace ?? defaultWorkspace);
+  const release = await loadReleaseManifest(workspace);
+  const reportPath = resolve(options.reportPath ?? join(workspace, "release", "rc-soak.json"));
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+  const result = validateRcSoakReport(report, { series: release.series, now: options.now });
+  if (release.channel === "stable" && release.sourceCandidate !== result.candidate) {
+    throw new Error(
+      `Stable release was rehearsed from ${release.sourceCandidate}, but soak covers ${result.candidate}`,
+    );
+  }
+  return result;
+}
+
+export async function main() {
+  const result = await assertRcSoak({ reportPath: process.argv[2] });
+  process.stdout.write(
+    `RC soak verified: ${result.candidate}, ${result.minimumDays} days, ${result.consumerCount} consumers, ${result.blockerCount} resolved blockers\n`,
+  );
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/assert-release-channel.mjs
+++ b/scripts/assert-release-channel.mjs
@@ -7,8 +7,8 @@ import { loadReleaseManifest } from "./release-policy.mjs";
 const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const requestedChannel = process.argv[2];
 
-if (requestedChannel !== "beta" && requestedChannel !== "stable") {
-  throw new Error("Usage: node scripts/assert-release-channel.mjs <beta|stable>");
+if (requestedChannel !== "beta" && requestedChannel !== "rc" && requestedChannel !== "stable") {
+  throw new Error("Usage: node scripts/assert-release-channel.mjs <beta|rc|stable>");
 }
 
 const release = await loadReleaseManifest(workspace);
@@ -34,16 +34,18 @@ for (const track of ["stable", "experimental"]) {
   }
 }
 
-if (requestedChannel === "beta") {
-  const pattern = new RegExp(`^${release.series.replaceAll(".", "\\.")}-beta\\.\\d+$`, "u");
+if (requestedChannel === "beta" || requestedChannel === "rc") {
+  const pattern = new RegExp(`^${release.series.replaceAll(".", "\\.")}-${requestedChannel}\\.\\d+$`, "u");
   for (const manifest of manifests) {
     if (!pattern.test(manifest.version)) {
-      throw new Error(`${manifest.name}@${manifest.version} is not a ${release.series}-beta.N version`);
+      throw new Error(`${manifest.name}@${manifest.version} is not a ${release.series}-${requestedChannel}.N version`);
     }
   }
-  if (release.npmTag !== "next") throw new Error("Beta releases must use the next npm tag");
+  if (release.npmTag !== "next") throw new Error("Prereleases must use the next npm tag");
   const pre = JSON.parse(await readFile(join(workspace, ".changeset", "pre.json"), "utf8"));
-  if (pre.mode !== "pre" || pre.tag !== "beta") throw new Error("Changesets is not in beta prerelease mode");
+  if (pre.mode !== "pre" || pre.tag !== requestedChannel) {
+    throw new Error(`Changesets is not in ${requestedChannel} prerelease mode`);
+  }
 } else {
   for (const manifest of manifests) {
     if (manifest.version !== release.series) {

--- a/scripts/publish-prerelease.d.mts
+++ b/scripts/publish-prerelease.d.mts
@@ -23,7 +23,7 @@ export interface PublishPrereleaseOptions {
 }
 
 export interface PublishReleaseOptions {
-  readonly channel?: "beta" | "stable";
+  readonly channel?: "beta" | "rc" | "stable";
   readonly workspace?: string;
   readonly plan?: ReleasePlan;
   readonly isPublished?: (name: string, version: string) => Promise<boolean>;
@@ -39,7 +39,7 @@ export interface RegistryLookupOptions {
 }
 
 export function loadPrereleasePlan(workspace?: string): Promise<PrereleasePlan>;
-export function loadReleasePlan(channel: "beta" | "stable", workspace?: string): Promise<ReleasePlan>;
+export function loadReleasePlan(channel: "beta" | "rc" | "stable", workspace?: string): Promise<ReleasePlan>;
 export function isPublishedOnNpm(name: string, version: string, options?: RegistryLookupOptions): Promise<boolean>;
 export function publicationCommands(
   pkg: ReleasePackage,

--- a/scripts/publish-prerelease.mjs
+++ b/scripts/publish-prerelease.mjs
@@ -43,9 +43,9 @@ export async function loadReleasePlan(requestedChannel, workspace = defaultWorks
   }
 
   const versionPattern =
-    requestedChannel === "beta"
-      ? new RegExp(`^${escapeRegularExpression(release.series)}-beta\\.\\d+$`, "u")
-      : new RegExp(`^${escapeRegularExpression(release.series)}$`, "u");
+    requestedChannel === "stable"
+      ? new RegExp(`^${escapeRegularExpression(release.series)}$`, "u")
+      : new RegExp(`^${escapeRegularExpression(release.series)}-${requestedChannel}\\.\\d+$`, "u");
   const packages = [];
   for (const expectedName of release.packages) {
     const directory = packageDirectory(workspace, expectedName);
@@ -162,8 +162,8 @@ export async function publishPrerelease(options = {}) {
 
 export async function main() {
   const requestedChannel = process.argv[2] ?? "beta";
-  if (requestedChannel !== "beta" && requestedChannel !== "stable") {
-    throw new Error("Usage: node scripts/publish-prerelease.mjs <beta|stable>");
+  if (requestedChannel !== "beta" && requestedChannel !== "rc" && requestedChannel !== "stable") {
+    throw new Error("Usage: node scripts/publish-prerelease.mjs <beta|rc|stable>");
   }
   await publishRelease({ channel: requestedChannel });
 }

--- a/scripts/rehearse-stable-release.mjs
+++ b/scripts/rehearse-stable-release.mjs
@@ -98,7 +98,24 @@ async function restoreExperimentalState(workspace, state, deferredChangesets) {
   }
 }
 
-async function writeStableManifest(workspace, release) {
+async function releaseCandidateVersion(workspace, release) {
+  const versions = new Set();
+  for (const name of release.packages) {
+    const manifest = JSON.parse(
+      await readFile(join(workspace, "packages", name.slice("@typed-sql/".length), "package.json"), "utf8"),
+    );
+    versions.add(manifest.version);
+  }
+  if (versions.size !== 1) throw new Error("Stable rehearsal requires one coherent release-candidate version");
+  const [candidate] = versions;
+  const pattern = new RegExp(`^${release.series.replaceAll(".", "\\.")}-rc\\.\\d+$`, "u");
+  if (typeof candidate !== "string" || !pattern.test(candidate)) {
+    throw new Error(`Stable rehearsal requires a ${release.series}-rc.N candidate`);
+  }
+  return candidate;
+}
+
+async function writeStableManifest(workspace, release, sourceCandidate) {
   await writeFile(
     join(workspace, "release-manifest.json"),
     `${JSON.stringify(
@@ -106,6 +123,7 @@ async function writeStableManifest(workspace, release) {
         ...release,
         channel: "stable",
         npmTag: "latest",
+        sourceCandidate,
         packages: release.packagePolicy.stable,
       },
       null,
@@ -116,10 +134,11 @@ async function writeStableManifest(workspace, release) {
 
 export async function prepareStableVersion(workspace, options = {}) {
   const release = await loadReleaseManifest(workspace);
-  if (release.channel !== "beta" || release.npmTag !== "next") {
-    throw new Error(`Stable rehearsal must begin on beta:next, received ${release.channel}:${release.npmTag}`);
+  if (release.channel !== "rc" || release.npmTag !== "next") {
+    throw new Error(`Stable rehearsal must begin on rc:next, received ${release.channel}:${release.npmTag}`);
   }
   const experimentalPackages = new Set(release.packagePolicy.experimental);
+  const sourceCandidate = await releaseCandidateVersion(workspace, release);
   const state = await packageState(workspace, experimentalPackages);
   const deferred = await partitionChangesets(workspace, experimentalPackages);
   const runCommand = options.runCommand ?? run;
@@ -134,7 +153,7 @@ export async function prepareStableVersion(workspace, options = {}) {
     label: "Versioning stable packages",
   });
   await restoreExperimentalState(workspace, state, deferred);
-  await writeStableManifest(workspace, release);
+  await writeStableManifest(workspace, release, sourceCandidate);
   await runCommand("pnpm", ["exec", "biome", "format", "--write", "release-manifest.json"], {
     cwd: workspace,
     label: "Formatting the rehearsed release manifest",
@@ -303,6 +322,7 @@ export async function rehearseStableRelease(options = {}) {
           channel: release.channel,
           npmTag: release.npmTag,
           series: release.series,
+          sourceCandidate: release.sourceCandidate,
           versions,
           publicationOrder: release.packages,
           dependencyRanges,

--- a/scripts/release-policy.d.mts
+++ b/scripts/release-policy.d.mts
@@ -4,9 +4,10 @@ export interface ReleasePackagePolicy {
 }
 
 export interface ReleaseManifest {
-  readonly channel: "beta" | "stable";
+  readonly channel: "beta" | "rc" | "stable";
   readonly series: string;
   readonly npmTag: "next" | "latest";
+  readonly sourceCandidate?: string;
   readonly packages: readonly string[];
   readonly packagePolicy: ReleasePackagePolicy;
 }

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -22,8 +22,8 @@ function sameMembers(left, right) {
 export function validateReleaseManifest(value) {
   if (typeof value !== "object" || value === null) throw new TypeError("release-manifest.json must be an object");
   const manifest = value;
-  if (manifest.channel !== "beta" && manifest.channel !== "stable") {
-    throw new TypeError("release-manifest.json channel must be beta or stable");
+  if (manifest.channel !== "beta" && manifest.channel !== "rc" && manifest.channel !== "stable") {
+    throw new TypeError("release-manifest.json channel must be beta, rc, or stable");
   }
   if (typeof manifest.series !== "string" || !seriesPattern.test(manifest.series)) {
     throw new TypeError("release-manifest.json series must be a stable X.Y.Z version");
@@ -31,6 +31,14 @@ export function validateReleaseManifest(value) {
   const expectedTag = manifest.channel === "stable" ? "latest" : "next";
   if (manifest.npmTag !== expectedTag) {
     throw new TypeError(`${manifest.channel} releases must use the ${expectedTag} npm tag`);
+  }
+  const sourceCandidatePattern = new RegExp(`^${manifest.series.replaceAll(".", "\\.")}-rc\\.\\d+$`, "u");
+  if (manifest.channel === "stable") {
+    if (typeof manifest.sourceCandidate !== "string" || !sourceCandidatePattern.test(manifest.sourceCandidate)) {
+      throw new TypeError(`stable releases must declare sourceCandidate as ${manifest.series}-rc.N`);
+    }
+  } else if (manifest.sourceCandidate !== undefined) {
+    throw new TypeError("sourceCandidate is only valid for stable releases");
   }
   if (typeof manifest.packagePolicy !== "object" || manifest.packagePolicy === null) {
     throw new TypeError("release-manifest.json must declare packagePolicy");
@@ -47,13 +55,14 @@ export function validateReleaseManifest(value) {
   const expectedPackages = manifest.channel === "stable" ? stable : [...stable, ...experimental];
   if (!sameMembers(packages, expectedPackages)) {
     throw new TypeError(
-      `${manifest.channel} release packages must match the ${manifest.channel === "stable" ? "stable" : "complete beta"} package policy`,
+      `${manifest.channel} release packages must match the ${manifest.channel === "stable" ? "stable" : "complete prerelease"} package policy`,
     );
   }
   return {
     channel: manifest.channel,
     series: manifest.series,
     npmTag: manifest.npmTag,
+    sourceCandidate: manifest.sourceCandidate,
     packages,
     packagePolicy: { stable, experimental },
   };

--- a/scripts/version-packages.d.mts
+++ b/scripts/version-packages.d.mts
@@ -1,0 +1,16 @@
+import type { ReleaseManifest } from "./release-policy.mjs";
+
+export interface VersionPackagesOptions {
+  readonly workspace?: string;
+  readonly runCommand?: (command: string, args: readonly string[], cwd: string) => Promise<void>;
+}
+
+export function nextReleaseCandidateNumber(versions: Iterable<string>, series: string): number;
+export function normalizeReleaseCandidateVersions(
+  workspace: string,
+  release: ReleaseManifest,
+  originalVersions: ReadonlyMap<string, string>,
+  number: number,
+): Promise<string>;
+export function versionPackages(options?: VersionPackagesOptions): Promise<string | undefined>;
+export function main(): Promise<void>;

--- a/scripts/version-packages.mjs
+++ b/scripts/version-packages.mjs
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadReleaseManifest } from "./release-policy.mjs";
+
+const defaultWorkspace = fileURLToPath(new URL("..", import.meta.url));
+const changesetsCli = fileURLToPath(new URL("../node_modules/@changesets/cli/bin.js", import.meta.url));
+
+function escapeRegularExpression(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function packageDirectory(workspace, name) {
+  return join(workspace, "packages", name.slice("@typed-sql/".length));
+}
+
+function run(command, args, cwd) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, { cwd, env: process.env, stdio: "inherit" });
+    child.once("error", rejectRun);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolveRun();
+      else rejectRun(new Error(`${command} failed (${signal ?? code ?? "unknown"})`));
+    });
+  });
+}
+
+export function nextReleaseCandidateNumber(versions, series) {
+  const pattern = new RegExp(`^${escapeRegularExpression(series)}-rc\\.(\\d+)$`, "u");
+  let highest = -1;
+  for (const version of versions) {
+    const match = pattern.exec(version);
+    if (match !== null) highest = Math.max(highest, Number(match[1]));
+  }
+  return highest + 1;
+}
+
+function addReleaseHeading(changelog, targetVersion) {
+  const newline = changelog.indexOf("\n");
+  if (newline < 0) throw new Error("Package changelog must begin with a title");
+  return `${changelog.slice(0, newline)}\n\n## ${targetVersion}\n\n### Patch Changes\n\n- Publish the coherent ${targetVersion} release-candidate train.\n${changelog.slice(newline + 1)}`;
+}
+
+function rewriteLatestRelease(changelog, provisionalVersion, targetVersion, packageName) {
+  const heading = `## ${provisionalVersion}\n`;
+  const start = changelog.indexOf(heading);
+  if (start < 0) throw new Error(`${packageName} changelog is missing ${heading.trim()}`);
+  const nextRelease = changelog.indexOf("\n## ", start + heading.length);
+  const end = nextRelease < 0 ? changelog.length : nextRelease;
+  return `${changelog.slice(0, start)}${changelog.slice(start, end).replaceAll(provisionalVersion, targetVersion)}${changelog.slice(end)}`;
+}
+
+export async function normalizeReleaseCandidateVersions(workspace, release, originalVersions, number) {
+  const targetVersion = `${release.series}-rc.${number}`;
+  for (const name of release.packages) {
+    const directory = packageDirectory(workspace, name);
+    const manifestPath = join(directory, "package.json");
+    const changelogPath = join(directory, "CHANGELOG.md");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const provisionalVersion = manifest.version;
+    const changedByChangesets = provisionalVersion !== originalVersions.get(name);
+    manifest.version = targetVersion;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    let changelog = await readFile(changelogPath, "utf8");
+    if (changedByChangesets && provisionalVersion !== targetVersion) {
+      changelog = rewriteLatestRelease(changelog, provisionalVersion, targetVersion, name);
+    }
+    if (!changelog.includes(`## ${targetVersion}\n`)) changelog = addReleaseHeading(changelog, targetVersion);
+    await writeFile(changelogPath, changelog);
+  }
+  return targetVersion;
+}
+
+export async function versionPackages(options = {}) {
+  const workspace = resolve(options.workspace ?? defaultWorkspace);
+  const release = await loadReleaseManifest(workspace);
+  const runCommand = options.runCommand ?? run;
+  if (release.channel !== "rc") {
+    await runCommand(process.execPath, [changesetsCli, "version"], workspace);
+    return undefined;
+  }
+
+  const pre = JSON.parse(await readFile(join(workspace, ".changeset", "pre.json"), "utf8"));
+  if (pre.mode !== "pre" || pre.tag !== "rc") throw new Error("RC versioning requires Changesets rc prerelease mode");
+  const originalVersions = new Map();
+  for (const name of release.packages) {
+    const manifest = JSON.parse(await readFile(join(packageDirectory(workspace, name), "package.json"), "utf8"));
+    originalVersions.set(name, manifest.version);
+  }
+  const number = nextReleaseCandidateNumber(originalVersions.values(), release.series);
+  await runCommand(process.execPath, [changesetsCli, "version"], workspace);
+  const targetVersion = await normalizeReleaseCandidateVersions(workspace, release, originalVersions, number);
+  await runCommand("pnpm", ["install", "--lockfile-only", "--offline", "--ignore-scripts"], workspace);
+  process.stdout.write(`Versioned coherent release candidate ${targetVersion}\n`);
+  return targetVersion;
+}
+
+export async function main() {
+  await versionPackages();
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -161,7 +161,10 @@ await describe("public package graph", async () => {
 
   await it("publishes consistent Lojhan-owned release metadata", async () => {
     const releaseManifest = await loadReleaseManifest(workspace);
-    const betaPattern = new RegExp(`^${releaseManifest.series.replaceAll(".", "\\.")}-beta\\.\\d+$`, "u");
+    const channelPattern = new RegExp(
+      `^${releaseManifest.series.replaceAll(".", "\\.")}-${releaseManifest.channel}\\.\\d+$`,
+      "u",
+    );
     const prereleasePattern = new RegExp(`^${releaseManifest.series.replaceAll(".", "\\.")}-(?:beta|rc)\\.\\d+$`, "u");
     const expectedLicense = await readFile(join(workspace, "LICENSE"), "utf8");
     strict.deepStrictEqual(
@@ -178,10 +181,10 @@ await describe("public package graph", async () => {
       const releaseTrack = stablePackages.includes(packageName as (typeof stablePackages)[number])
         ? "stable"
         : "experimental";
-      if (releaseManifest.channel === "beta") {
+      if (releaseManifest.channel === "beta" || releaseManifest.channel === "rc") {
         strict.ok(
-          betaPattern.test(packageManifest.version ?? ""),
-          `${packageManifest.name} must be in the declared beta series`,
+          channelPattern.test(packageManifest.version ?? ""),
+          `${packageManifest.name} must be in the declared prerelease series`,
         );
       } else if (releaseTrack === "stable") strict.strictEqual(packageManifest.version, releaseManifest.series);
       else strict.ok(prereleasePattern.test(packageManifest.version ?? ""));

--- a/test/contracts/rc-release.test.ts
+++ b/test/contracts/rc-release.test.ts
@@ -1,0 +1,155 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it, strict } from "poku";
+import { type ReleaseManifest, validateReleaseManifest } from "../../scripts/release-policy.mjs";
+import {
+  nextReleaseCandidateNumber,
+  normalizeReleaseCandidateVersions,
+  versionPackages,
+} from "../../scripts/version-packages.mjs";
+
+const workspace = resolve(import.meta.dirname, "../..");
+
+const rcRelease: ReleaseManifest = {
+  channel: "rc",
+  series: "1.0.0",
+  npmTag: "next",
+  packages: ["@typed-sql/core", "@typed-sql/compiler"],
+  packagePolicy: {
+    stable: ["@typed-sql/core", "@typed-sql/compiler"],
+    experimental: [],
+  },
+};
+
+await describe("release-candidate policy", async () => {
+  await it("accepts only a complete RC train on npm next", () => {
+    strict.strictEqual(validateReleaseManifest(rcRelease).channel, "rc");
+    strict.throws(() => validateReleaseManifest({ ...rcRelease, npmTag: "latest" }), /must use the next npm tag/u);
+    strict.throws(
+      () => validateReleaseManifest({ ...rcRelease, packages: ["@typed-sql/core"] }),
+      /complete prerelease package policy/u,
+    );
+    strict.throws(
+      () => validateReleaseManifest({ ...rcRelease, sourceCandidate: "1.0.0-rc.0" }),
+      /only valid for stable releases/u,
+    );
+  });
+
+  await it("increments a coherent candidate counter without inheriting beta numbers", () => {
+    strict.strictEqual(nextReleaseCandidateNumber(["1.0.0-beta.9", "1.0.0-beta.11"], "1.0.0"), 0);
+    strict.strictEqual(nextReleaseCandidateNumber(["1.0.0-rc.0", "1.0.0-beta.11"], "1.0.0"), 1);
+    strict.strictEqual(nextReleaseCandidateNumber(["1.0.0-rc.3", "1.0.0-rc.1"], "1.0.0"), 4);
+  });
+
+  await it("normalizes changed and unchanged packages into one RC version", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-rc-version-"));
+    try {
+      const fixtures = [
+        {
+          directory: "core",
+          version: "1.0.0-rc.3",
+          changelog:
+            "# @typed-sql/core\n\n## 1.0.0-rc.3\n\n### Patch Changes\n\n- Updated @typed-sql/compiler@1.0.0-rc.3.\n\n## 1.0.0-beta.2\n\n- Historical reference to 1.0.0-rc.3.\n",
+        },
+        {
+          directory: "compiler",
+          version: "1.0.0-beta.2",
+          changelog: "# @typed-sql/compiler\n\n## 1.0.0-beta.2\n\n- History.\n",
+        },
+      ] as const;
+      for (const fixture of fixtures) {
+        const directory = join(temporary, "packages", fixture.directory);
+        await mkdir(directory, { recursive: true });
+        await writeFile(
+          join(directory, "package.json"),
+          `${JSON.stringify({ name: `@typed-sql/${fixture.directory}`, version: fixture.version }, null, 2)}\n`,
+        );
+        await writeFile(join(directory, "CHANGELOG.md"), fixture.changelog);
+      }
+
+      const target = await normalizeReleaseCandidateVersions(
+        temporary,
+        rcRelease,
+        new Map([
+          ["@typed-sql/core", "1.0.0-beta.2"],
+          ["@typed-sql/compiler", "1.0.0-beta.2"],
+        ]),
+        0,
+      );
+      strict.strictEqual(target, "1.0.0-rc.0");
+      for (const fixture of fixtures) {
+        const manifest = JSON.parse(
+          await readFile(join(temporary, "packages", fixture.directory, "package.json"), "utf8"),
+        );
+        strict.strictEqual(manifest.version, target);
+        const changelog = await readFile(join(temporary, "packages", fixture.directory, "CHANGELOG.md"), "utf8");
+        strict.ok(changelog.includes("## 1.0.0-rc.0\n"));
+        strict.ok(changelog.includes("## 1.0.0-beta.2\n"), "historical beta notes must remain unchanged");
+        if (fixture.directory === "core") {
+          strict.ok(changelog.includes("Updated @typed-sql/compiler@1.0.0-rc.0."));
+          strict.ok(changelog.includes("Historical reference to 1.0.0-rc.3."));
+        }
+      }
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("runs Changesets first and refreshes the lockfile after RC normalization", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-rc-orchestration-"));
+    try {
+      await mkdir(join(temporary, ".changeset"), { recursive: true });
+      await writeFile(join(temporary, "release-manifest.json"), JSON.stringify(rcRelease));
+      await writeFile(join(temporary, ".changeset", "pre.json"), JSON.stringify({ mode: "pre", tag: "rc" }));
+      for (const directoryName of ["core", "compiler"]) {
+        const directory = join(temporary, "packages", directoryName);
+        await mkdir(directory, { recursive: true });
+        await writeFile(
+          join(directory, "package.json"),
+          JSON.stringify({ name: `@typed-sql/${directoryName}`, version: "1.0.0-beta.2" }),
+        );
+        await writeFile(join(directory, "CHANGELOG.md"), `# @typed-sql/${directoryName}\n`);
+      }
+
+      const commands: string[] = [];
+      const target = await versionPackages({
+        workspace: temporary,
+        runCommand: async (command, args) => {
+          commands.push(`${command}:${args.join(" ")}`);
+          if (args.at(-1) === "version") {
+            const core = join(temporary, "packages", "core");
+            await writeFile(
+              join(core, "package.json"),
+              JSON.stringify({ name: "@typed-sql/core", version: "1.0.0-rc.7" }),
+            );
+            await writeFile(join(core, "CHANGELOG.md"), "# @typed-sql/core\n\n## 1.0.0-rc.7\n\n- Fix.\n");
+          }
+        },
+      });
+
+      strict.strictEqual(target, "1.0.0-rc.0");
+      strict.strictEqual(commands.length, 2);
+      strict.ok(commands[0]?.endsWith(" version"));
+      strict.ok(commands[1]?.includes("pnpm:install --lockfile-only --offline --ignore-scripts"));
+      for (const directoryName of ["core", "compiler"]) {
+        const manifest = JSON.parse(await readFile(join(temporary, "packages", directoryName, "package.json"), "utf8"));
+        strict.strictEqual(manifest.version, target);
+      }
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("keeps RC assertion, publication, registry proof, and stable soak in workflow order", async () => {
+    const workflow = await readFile(join(workspace, ".github", "workflows", "release.yml"), "utf8");
+    strict.ok(workflow.includes("          - rc"));
+    const assertRc = workflow.indexOf("run: pnpm release:assert rc");
+    const publishRc = workflow.indexOf("script: pnpm release:rc");
+    const verifyPublished = workflow.indexOf("name: Verify published prerelease from npm");
+    strict.ok(assertRc > 0 && publishRc > assertRc && verifyPublished > publishRc);
+    const assertSoak = workflow.indexOf("run: pnpm release:soak");
+    const publishStable = workflow.indexOf("script: pnpm release:stable");
+    strict.ok(assertSoak > 0 && publishStable > assertSoak);
+  });
+});

--- a/test/contracts/rc-soak.test.ts
+++ b/test/contracts/rc-soak.test.ts
@@ -1,0 +1,193 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, strict } from "poku";
+import { assertRcSoak, validateRcSoakReport } from "../../scripts/assert-rc-soak.mjs";
+
+const startedAt = "2026-08-01T00:00:00.000Z";
+const finishedAt = "2026-08-08T00:00:00.000Z";
+const candidate = "1.0.0-rc.0";
+const databaseChecks = [
+  "install",
+  "generation",
+  "typecheck",
+  "runtime",
+  "drift",
+  "determinism",
+  "driver-compatibility",
+  "query-composition",
+];
+const editorChecks = ["install", "generation", "typecheck", "hover", "diagnostics", "quick-fix", "restart"];
+
+function run(at: string, checks: readonly string[], suffix: string, generatedHash?: string) {
+  return {
+    at,
+    result: "pass",
+    consumerCommit: suffix.repeat(40),
+    evidence: `https://github.com/Lojhan/consumer/actions/runs/${suffix}`,
+    checks,
+    ...(generatedHash === undefined ? {} : { generatedHash }),
+  };
+}
+
+function validReport() {
+  const hash = "a".repeat(64);
+  return {
+    schemaVersion: 1,
+    series: "1.0.0",
+    candidate,
+    npmTag: "next",
+    releaseCommit: "f".repeat(40),
+    publishedAt: startedAt,
+    startedAt,
+    minimumDays: 7,
+    consumers: [
+      {
+        id: "postgres-app",
+        role: "postgres",
+        repository: "https://github.com/Lojhan/postgres-consumer",
+        installSource: "registry",
+        node: "24.10.0",
+        packageManager: "pnpm@10.32.1",
+        typescript: { name: "typescript", version: "7.0.2" },
+        database: { name: "postgresql", version: "18.0.0" },
+        driver: { name: "pg", version: "8.23.0" },
+        packages: {
+          "@typed-sql/core": candidate,
+          "@typed-sql/postgres": candidate,
+          "@typed-sql/cli": candidate,
+        },
+        runs: [run(startedAt, databaseChecks, "1", hash), run(finishedAt, databaseChecks, "2", hash)],
+      },
+      {
+        id: "mysql-app",
+        role: "mysql",
+        repository: "https://github.com/Lojhan/mysql-consumer",
+        installSource: "registry",
+        node: "22.14.0",
+        packageManager: "pnpm@10.32.1",
+        typescript: { name: "typescript", version: "7.1.0-dev.20260825" },
+        database: { name: "mysql", version: "9.4.0" },
+        driver: { name: "mysql2", version: "3.24.1" },
+        packages: {
+          "@typed-sql/core": candidate,
+          "@typed-sql/mysql": candidate,
+          "@typed-sql/cli": candidate,
+        },
+        runs: [run(startedAt, databaseChecks, "3", hash), run(finishedAt, databaseChecks, "4", hash)],
+      },
+      {
+        id: "zed-app",
+        role: "editor",
+        repository: "https://github.com/Lojhan/editor-consumer",
+        installSource: "registry",
+        node: "24.10.0",
+        packageManager: "pnpm@10.32.1",
+        typescript: { name: "typescript", version: "7.0.2" },
+        editor: { name: "zed", version: "0.202.5" },
+        packages: {
+          "@typed-sql/language-server": candidate,
+          "@typed-sql/ts-bridge": candidate,
+        },
+        runs: [run(startedAt, editorChecks, "5"), run(finishedAt, editorChecks, "6")],
+      },
+    ],
+    blockers: [
+      {
+        id: "typed-sql#29",
+        category: "false-acceptance",
+        status: "resolved",
+        resolvedAt: "2026-08-02T00:00:00.000Z",
+        regressionTest: "https://github.com/Lojhan/typed-sql/blob/abcdef/test.ts",
+      },
+    ],
+    decision: {
+      outcome: "go",
+      decidedAt: finishedAt,
+      owner: "Lojhan",
+      rationale: "All consumers passed for seven full days.",
+      knownLimitations: ["Editor tooling remains experimental."],
+    },
+  };
+}
+
+const validationOptions = { series: "1.0.0", now: new Date("2026-08-09T00:00:00.000Z") };
+
+await describe("release-candidate soak policy", async () => {
+  await it("accepts complete evidence from three independent consumers", () => {
+    strict.deepStrictEqual(validateRcSoakReport(validReport(), validationOptions), {
+      candidate,
+      releaseCommit: "f".repeat(40),
+      minimumDays: 7,
+      consumerCount: 3,
+      blockerCount: 1,
+      decision: "go",
+    });
+  });
+
+  await it("rejects an incomplete soak window", () => {
+    strict.throws(
+      () => validateRcSoakReport(validReport(), { series: "1.0.0", now: new Date("2026-08-07T00:00:00.000Z") }),
+      /has not completed/u,
+    );
+  });
+
+  await it("rejects non-independent consumers and incomplete checks", () => {
+    const duplicate = validReport();
+    duplicate.consumers[1]!.repository = duplicate.consumers[0]!.repository;
+    strict.throws(() => validateRcSoakReport(duplicate, validationOptions), /distinct external repositories/u);
+
+    const workspaceLinked = validReport();
+    workspaceLinked.consumers[0]!.installSource = "workspace";
+    strict.throws(() => validateRcSoakReport(workspaceLinked, validationOptions), /installSource must be registry/u);
+
+    const incomplete = validReport();
+    incomplete.consumers[0]!.runs[0]!.checks = databaseChecks.filter((check) => check !== "query-composition");
+    strict.throws(() => validateRcSoakReport(incomplete, validationOptions), /missing query-composition/u);
+  });
+
+  await it("rejects generated drift, incorrect pins, and unresolved blockers", () => {
+    const drifted = validReport();
+    drifted.consumers[0]!.runs[1]!.generatedHash = "b".repeat(64);
+    strict.throws(() => validateRcSoakReport(drifted, validationOptions), /generated output changed/u);
+
+    const wrongVersion = validReport();
+    wrongVersion.consumers[1]!.packages["@typed-sql/mysql"] = "1.0.0-rc.1";
+    strict.throws(() => validateRcSoakReport(wrongVersion, validationOptions), /must pin @typed-sql\/mysql/u);
+
+    const blocked = validReport();
+    blocked.blockers[0]!.status = "open";
+    strict.throws(() => validateRcSoakReport(blocked, validationOptions), /remains unresolved/u);
+  });
+
+  await it("requires an explicit post-soak go decision", () => {
+    const undecided = validReport();
+    undecided.decision.outcome = "no-go";
+    strict.throws(() => validateRcSoakReport(undecided, validationOptions), /decision must be go/u);
+  });
+
+  await it("ties stable publication to the exact rehearsed RC", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-rc-soak-"));
+    try {
+      await writeFile(
+        join(temporary, "release-manifest.json"),
+        JSON.stringify({
+          channel: "stable",
+          series: "1.0.0",
+          npmTag: "latest",
+          sourceCandidate: "1.0.0-rc.1",
+          packages: ["@typed-sql/core"],
+          packagePolicy: { stable: ["@typed-sql/core"], experimental: [] },
+        }),
+      );
+      const reportPath = join(temporary, "soak.json");
+      await writeFile(reportPath, JSON.stringify(validReport()));
+      await strict.rejects(
+        assertRcSoak({ workspace: temporary, reportPath, now: validationOptions.now }),
+        /rehearsed from 1\.0\.0-rc\.1, but soak covers 1\.0\.0-rc\.0/u,
+      );
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/contracts/release-publisher.test.ts
+++ b/test/contracts/release-publisher.test.ts
@@ -29,6 +29,7 @@ await describe("prerelease publisher", async () => {
       channel: "stable",
       series: "1.0.0",
       npmTag: "latest",
+      sourceCandidate: "1.0.0-rc.0",
       packages: ["@typed-sql/core"],
       packagePolicy: {
         stable: ["@typed-sql/core"],
@@ -42,6 +43,7 @@ await describe("prerelease publisher", async () => {
           channel: "stable",
           series: "1.0.0",
           npmTag: "latest",
+          sourceCandidate: "1.0.0-rc.0",
           packages: ["@typed-sql/core", "@typed-sql/ts-bridge"],
           packagePolicy: {
             stable: ["@typed-sql/core"],
@@ -293,6 +295,7 @@ await describe("prerelease publisher", async () => {
           channel: "stable",
           series: "1.0.0",
           npmTag: "latest",
+          sourceCandidate: "1.0.0-rc.0",
           packages: ["@typed-sql/core"],
           packagePolicy: {
             stable: ["@typed-sql/core"],

--- a/test/contracts/stable-rehearsal.test.ts
+++ b/test/contracts/stable-rehearsal.test.ts
@@ -17,6 +17,8 @@ await describe("stable release rehearsal policy", async () => {
       '"worktree", "remove", "--force"',
       'changesetsCli, "pre", "exit"',
       'changesetsCli, "version"',
+      'release.channel !== "rc"',
+      "sourceCandidate",
       '"release-manifest.json"',
       '"verify"',
       '"e2e:packed"',


### PR DESCRIPTION
## Summary

- add a coherent beta-to-RC version path and protected RC publication channel
- require post-publication registry acceptance for beta, RC, and stable releases
- block stable publication without 7-14 days of evidence from independent PostgreSQL, MySQL, and editor consumers
- bind stable promotion to the exact rehearsed RC through sourceCandidate
- document the evidence format, restart rules, blocker regressions, and go/no-go decision

## Verification

- pnpm release:assert beta
- pnpm verify
- focused Poku RC release, soak, publisher, rehearsal, registry, and package-graph contracts

Progresses #22. The issue remains open until a real RC completes the required soak.