### PR TITLE
feat: establish production adapter execution foundations

### DIFF
--- a/.changeset/advanced-adapter-foundations.md
+++ b/.changeset/advanced-adapter-foundations.md
@@ -1,0 +1,7 @@
+---
+"@typed-sql/core": minor
+"@typed-sql/mysql": minor
+"@typed-sql/postgres": minor
+---
+
+Add grammar-neutral stream and ordered-result type contracts, and add lazy prepared-query factories to the PostgreSQL and MySQL runtime adapters. Prepared factories retain exact query types, validate stable SQL shapes, and remain available inside nested transactions.

--- a/.changeset/fast-mysql-decoding.md
+++ b/.changeset/fast-mysql-decoding.md
@@ -1,0 +1,7 @@
+---
+"@typed-sql/mysql": patch
+---
+
+Compile MySQL result-field decoders once per result and avoid copying rows when runtime type-policy
+decoding does not change their values. This removes repeated field scans and makes buffered decoding
+scale linearly with result width.

--- a/.changeset/lazy-typed-query-streams.md
+++ b/.changeset/lazy-typed-query-streams.md
@@ -1,0 +1,9 @@
+---
+"@typed-sql/postgres": minor
+"@typed-sql/mysql": minor
+---
+
+Add lazy, exactly typed query streams to the PostgreSQL and MySQL runtime adapters. PostgreSQL
+uses an application-owned optional `pg-cursor` installation for bounded cursor reads. MySQL uses
+mysql2's execute-protocol stream and shared decoder plan. Both adapters enforce deterministic
+cleanup, transaction ownership, and positive safe-integer batch sizes.

--- a/.changeset/ordered-typed-batches.md
+++ b/.changeset/ordered-typed-batches.md
@@ -1,0 +1,11 @@
+---
+"@typed-sql/postgres": minor
+"@typed-sql/mysql": minor
+"@typed-sql/core": minor
+---
+
+Add a grammar-neutral validated query-batch type and ordered, exactly typed query batches to the
+PostgreSQL and MySQL runtime adapters. Non-empty root batches execute sequentially on one leased
+connection, transaction batches reuse their transaction connection, and empty batches avoid
+connection acquisition. Batch execution preserves prepared metadata and adapter codecs, stops at
+the first failure, and rejects transaction work that escapes its callback.

--- a/.changeset/safe-postgres-statement-timeouts.md
+++ b/.changeset/safe-postgres-statement-timeouts.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/mysql": patch
+"@typed-sql/postgres": patch
+---
+
+Own in-flight transaction executions through settlement so unawaited work can never race commit, savepoint release, rollback, or connection release.
+
+The PostgreSQL adapter now also rejects pg's client-side `query_timeout` option because it can settle before the connection is safe to reuse. Root batches discard checked-out clients after query rejection, while caught transaction query, batch, and stream failures force rollback and discard the lease. Use PostgreSQL's server-enforced `statement_timeout` for statement deadlines.

--- a/.changeset/typed-transaction-scopes.md
+++ b/.changeset/typed-transaction-scopes.md
@@ -1,0 +1,9 @@
+---
+"@typed-sql/core": patch
+"@typed-sql/postgres": patch
+"@typed-sql/mysql": patch
+---
+
+Allow adapters to retain enriched capabilities in transaction callbacks and nested transactions
+through a self-typed core database contract. Transaction cleanup now also preserves the original
+operation error when rollback or connection-release cleanup fails.

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -18,11 +18,14 @@ The production performance suite covers:
 - correlated and independent conditional structure;
 - rejecting structural expansion before grammar work exceeds its bound;
 - core fragment composition and rendering;
+- adapter render, encode, decode, 100-row stream, and 25-query batch overhead with deterministic fake drivers;
 - cold, unchanged, incrementally edited, and schema-reloaded language-service analysis;
 - cancellation before expensive analysis;
 - retained heap under cache pressure.
 
 The structural scenarios assert their analysis counts as well as their timing. A fast but incorrect implementation does not pass.
+
+Adapter microbenchmarks are tracking baselines rather than database latency claims or release budgets. They isolate typed-sql's local work from network, server, pool, and native-driver time so regressions remain visible without presenting fixture timings as production throughput.
 
 ## Latency budgets
 

--- a/docs/dialects/mysql.md
+++ b/docs/dialects/mysql.md
@@ -33,4 +33,14 @@ Recursive CTE inference, `FULL JOIN`, array constructors, aggregate `FILTER`, an
 
 The adapter controls mysql2 options that affect row shape and decoding. Supplying conflicting `poolConfig` options such as `typeCast`, `rowsAsArray`, or incompatible bigint, decimal, date, or JSON settings fails before a pool is created. Connection, TLS, timeout, and pool-capacity settings remain application-owned.
 
-See [Database type mappings](../reference/type-mappings.md#mysql) and [Compatibility](../reference/compatibility.md).
+`database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. MySQL execution uses mysql2's `execute()` path and its per-connection prepared-statement cache. The factory rejects duplicate names and SQL text that changes between calls.
+
+## Streaming
+
+MySQL streaming uses mysql2's protocol-backed execute stream and does not require another package. `batchSize` maps to the object-mode high-water mark, so it controls client-side buffering rather than server cursor page size.
+
+An early `break`, `close()`, or async disposal stops delivering rows to the consumer, then waits for mysql2 to drain the remaining protocol response before releasing the connection. It does not claim to cancel the running MySQL statement. A connection is reused only after the native command finishes successfully; protocol failures keep it out of the reusable pool path.
+
+Inside a transaction, the stream reuses the transaction connection and never releases it directly. The stream must complete or close before the transaction callback returns.
+
+See [Execute queries](../guides/execution.md), [Database type mappings](../reference/type-mappings.md#mysql), and [Compatibility](../reference/compatibility.md).

--- a/docs/dialects/mysql.md
+++ b/docs/dialects/mysql.md
@@ -35,6 +35,8 @@ The adapter controls mysql2 options that affect row shape and decoding. Supplyin
 
 `database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. MySQL execution uses mysql2's `execute()` path and its per-connection prepared-statement cache. The factory rejects duplicate names and SQL text that changes between calls.
 
+`database.batch(queries)` leases one mysql2 connection and calls `execute()` sequentially for every query, preserving mysql2's per-connection prepared cache and typed-sql's result decoding. It is not a multi-statement string or one protocol round trip. Root batches use ordinary autocommit behavior. Transactional statements can use an explicit typed-sql transaction when atomicity is required; MySQL operations that implicitly commit, such as DDL, retain their native semantics.
+
 ## Streaming
 
 MySQL streaming uses mysql2's protocol-backed execute stream and does not require another package. `batchSize` maps to the object-mode high-water mark, so it controls client-side buffering rather than server cursor page size.

--- a/docs/dialects/postgresql.md
+++ b/docs/dialects/postgresql.md
@@ -41,6 +41,8 @@ The adapter installs parsers per query and does not mutate `pg.types`. Policy-co
 
 `database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. Buffered execution passes the stable name to `pg`, whose prepared statements are cached per PostgreSQL connection. The factory rejects duplicate names and SQL text that changes between calls.
 
+`database.batch(queries)` checks out one `pg` client and dispatches the queries sequentially. It is not a pipeline and does not combine statements into one SQL string or network round trip. Root batches use PostgreSQL's ordinary autocommit behavior; transactional statements can use an explicit typed-sql transaction when atomicity is required.
+
 ## Streaming
 
 Install `pg-cursor` only in applications that call `stream()`:

--- a/docs/dialects/postgresql.md
+++ b/docs/dialects/postgresql.md
@@ -5,7 +5,7 @@ description: PostgreSQL grammar coverage, catalog introspection, application-own
 
 # PostgreSQL
 
-`@typed-sql/postgres` contains the PostgreSQL grammar, catalog model, resolver, type policy, and runtime codecs. The optional `@typed-sql/postgres/pg` entrypoint loads the `pg` driver installed by your application.
+`@typed-sql/postgres` contains the PostgreSQL grammar, catalog model, resolver, type policy, and runtime codecs. The optional `@typed-sql/postgres/pg` entrypoint loads the `pg` driver installed by your application. Streaming additionally uses the application-owned `pg-cursor` package.
 
 ## Public entrypoints
 
@@ -39,4 +39,20 @@ The provider records tables, views, columns, defaults, server version, arrays, e
 
 The adapter installs parsers per query and does not mutate `pg.types`. Policy-controlled OIDs are decoded by typed-sql; other OIDs delegate to the installed driver's parser table. Driver settings that would contradict the selected type policy are rejected.
 
-See [Database type mappings](../reference/type-mappings.md#postgresql) and [Compatibility](../reference/compatibility.md).
+`database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. Buffered execution passes the stable name to `pg`, whose prepared statements are cached per PostgreSQL connection. The factory rejects duplicate names and SQL text that changes between calls.
+
+## Streaming
+
+Install `pg-cursor` only in applications that call `stream()`:
+
+```sh
+pnpm add pg-cursor
+```
+
+The adapter imports it when iteration starts, leases one `pg` pool client, and reads cursor pages according to `batchSize`. Completing or closing the stream closes the portal before the client is returned to the pool. Missing `pg-cursor` produces an actionable error at first iteration; ordinary execution and prepared factories never load it.
+
+`pg-cursor` always parses its cursor statement unnamed. A query produced by `database.prepare()` remains valid for streaming and retains its inferred row and parameter types, but the cursor path cannot reuse the prepared statement name used by buffered `pg` execution.
+
+Inside a transaction, the stream reuses the transaction client and never releases it directly. The stream must complete or close before the transaction callback returns.
+
+See [Execute queries](../guides/execution.md), [Database type mappings](../reference/type-mappings.md#postgresql), and [Compatibility](../reference/compatibility.md).

--- a/docs/dialects/postgresql.md
+++ b/docs/dialects/postgresql.md
@@ -39,6 +39,8 @@ The provider records tables, views, columns, defaults, server version, arrays, e
 
 The adapter installs parsers per query and does not mutate `pg.types`. Policy-controlled OIDs are decoded by typed-sql; other OIDs delegate to the installed driver's parser table. Driver settings that would contradict the selected type policy are rejected.
 
+Use PostgreSQL's server-enforced `statement_timeout` when a pool-wide statement deadline is required. `createPgDatabase` rejects pg's client-side `query_timeout` in both `poolConfig` and the resolved connection URI, including URIs returned by an asynchronous provider. `adaptPgPool` applies the same check to an application-created pool's exposed options and raw connection URI. pg can report this client timeout before the server reaches `ReadyForQuery`, so returning the connection to the pool would be unsafe. As a conservative fallback for opaque pool implementations, root batches and streams discard their checked-out client after a query or cursor rejection. A transaction scope cannot continue after a driver operation rejects: a root scope rolls back, while a successfully rolled-back nested savepoint lets its parent continue. The checked-out client is still discarded when the outer transaction finishes. Callback-only failures that roll back successfully do not discard an otherwise healthy client. A timeout does not imply support for `AbortSignal` or a PostgreSQL cancel request.
+
 `database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. Buffered execution passes the stable name to `pg`, whose prepared statements are cached per PostgreSQL connection. The factory rejects duplicate names and SQL text that changes between calls.
 
 `database.batch(queries)` checks out one `pg` client and dispatches the queries sequentially. It is not a pipeline and does not combine statements into one SQL string or network round trip. Root batches use PostgreSQL's ordinary autocommit behavior; transactional statements can use an explicit typed-sql transaction when atomicity is required.
@@ -55,6 +57,6 @@ The adapter imports it when iteration starts, leases one `pg` pool client, and r
 
 `pg-cursor` always parses its cursor statement unnamed. A query produced by `database.prepare()` remains valid for streaming and retains its inferred row and parameter types, but the cursor path cannot reuse the prepared statement name used by buffered `pg` execution.
 
-Inside a transaction, the stream reuses the transaction client and never releases it directly. The stream must complete or close before the transaction callback returns.
+Inside a transaction, the stream reuses the transaction client and never releases it directly. The stream must complete or close before the transaction callback returns. Transaction `execute()` and `batch()` calls must likewise be awaited before return; the adapter settles outstanding work before rollback and never selects commit first.
 
 See [Execute queries](../guides/execution.md), [Database type mappings](../reference/type-mappings.md#postgresql), and [Compatibility](../reference/compatibility.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,6 +14,14 @@ pnpm add @typed-sql/core @typed-sql/postgres pg
 pnpm add -D @typed-sql/cli typescript@7.0.2
 ```
 
+Applications that call `database.stream()` also install the application-owned PostgreSQL cursor package:
+
+```sh
+pnpm add pg-cursor
+```
+
+Buffered execution, transactions, and prepared factories do not load `pg-cursor`.
+
 ## MySQL
 
 ```sh
@@ -35,7 +43,7 @@ It contains its own isolated TypeScript preview process. You do not need a works
 
 ## Package boundary
 
-Installing `@typed-sql/postgres` does not install `pg`, MySQL packages, or another database client. Installing `@typed-sql/mysql` follows the same rule for `mysql2`.
+Installing `@typed-sql/postgres` does not install `pg`, `pg-cursor`, MySQL packages, or another database client. Installing `@typed-sql/mysql` follows the same rule for `mysql2`.
 
 Driver-specific behavior is available only from explicit adapter entrypoints:
 

--- a/docs/guides/execution.md
+++ b/docs/guides/execution.md
@@ -179,7 +179,7 @@ await database.transaction(async (transaction) => {
 
 Declare reusable prepared factories once from the root database during application bootstrap. Prepared names remain reserved for that database instance, so declaring the same name inside a repeatedly called transaction callback would collide after its first invocation. The ordinary queries returned by a root factory retain their prepared metadata when executed or streamed through that database's transaction scopes.
 
-A transaction stream must complete or close before its callback returns. It cannot escape the callback for later iteration. While a transaction stream or batch owns the connection, that connection cannot execute competing work or enter a nested transaction. If the callback returns with an open stream or running batch, the adapter settles the work, reports the misuse, and rolls back instead of committing.
+A transaction stream must complete or close before its callback returns. It cannot escape the callback for later iteration. Every `execute()` and `batch()` call must also be awaited before returning. While a transaction stream or batch owns the connection, that connection cannot execute competing work or enter a nested transaction. If the callback returns with an execution still running, an open stream, or a running batch, the adapter settles the work, reports the misuse, and rolls back instead of committing.
 
 ## Parameters and identifiers
 

--- a/docs/guides/execution.md
+++ b/docs/guides/execution.md
@@ -78,6 +78,41 @@ The factory exposes its readonly `statementName`. A name must be non-empty, cont
 
 Preparation is lazy: declaring the factory performs no I/O and checks out no connection. PostgreSQL uses the name for ordinary buffered execution. MySQL delegates execution to mysql2's per-connection prepared-statement cache.
 
+## Execute an ordered batch
+
+`database.batch(queries)` executes an ordered tuple or array on one leased connection. A const-generic tuple retains the exact result type for every position:
+
+```ts
+const accountQuery = sql`
+  SELECT account.id, account.email
+  FROM accounts AS account
+  WHERE account.id = ${42n}
+`;
+const projectQuery = sql`
+  SELECT project.id, project.name
+  FROM projects AS project
+  WHERE project.owner_id = ${42n}
+`;
+
+const [accounts, projects] = await database.batch([accountQuery, projectQuery]);
+```
+
+`accounts` and `projects` retain their respective inferred row arrays. Prepared queries remain ordinary `Query` values and can appear in the same batch. Passing an empty tuple returns immediately without acquiring a connection.
+
+A root batch is sequential and non-atomic. It performs one driver execution per query on the same connection, stops at the first failure, and does not claim a single network round trip. Successfully completed statements are not rolled back when a later statement fails.
+
+Use an explicit transaction when atomicity is required and supported by the statements and database:
+
+```ts
+const [accounts, projects] = await database.transaction((transaction) =>
+  transaction.batch([accountQuery, projectQuery]),
+);
+```
+
+Always await a transaction batch before returning from its callback. The adapters reject escaped or concurrent batch work rather than allowing queries to run after commit or connection release.
+
+The surrounding database's transaction rules still apply. For example, MySQL statements that implicitly commit cannot be made atomic by placing them in a batch.
+
 ## Stream large result sets
 
 `database.stream(query, options?)` returns a lazy `QueryStream<Row>`. Creating it renders the query but does not acquire a connection. The first `next()` call or `for await` iteration starts driver work.
@@ -120,7 +155,7 @@ PostgreSQL streaming requires the application-owned `pg-cursor` package in addit
 
 ## Use capabilities inside transactions
 
-Transaction callbacks receive the selected adapter's transaction type, so `execute()`, `prepare()`, and `stream()` remain available:
+Transaction callbacks receive the selected adapter's transaction type, so `execute()`, `batch()`, `prepare()`, and `stream()` remain available:
 
 ```ts
 const changedAccount = database.prepare("changed-account", (accountId: bigint) => sql`
@@ -144,7 +179,7 @@ await database.transaction(async (transaction) => {
 
 Declare reusable prepared factories once from the root database during application bootstrap. Prepared names remain reserved for that database instance, so declaring the same name inside a repeatedly called transaction callback would collide after its first invocation. The ordinary queries returned by a root factory retain their prepared metadata when executed or streamed through that database's transaction scopes.
 
-A transaction stream must complete or close before its callback returns. It cannot escape the callback for later iteration. While a transaction stream is active, the same connection cannot execute another query, start another stream, or enter a nested transaction. If the callback returns with an open stream, the adapter closes it, reports the misuse, and rolls back instead of committing.
+A transaction stream must complete or close before its callback returns. It cannot escape the callback for later iteration. While a transaction stream or batch owns the connection, that connection cannot execute competing work or enter a nested transaction. If the callback returns with an open stream or running batch, the adapter settles the work, reports the misuse, and rolls back instead of committing.
 
 ## Parameters and identifiers
 

--- a/docs/guides/execution.md
+++ b/docs/guides/execution.md
@@ -1,13 +1,15 @@
 ---
 title: Execute queries
-description: Execute typed queries with an application-owned pg or mysql2 driver and matching runtime codecs.
+description: Execute, prepare, and stream typed queries with application-owned PostgreSQL or MySQL drivers.
 ---
 
 # Execute queries
 
 The dialect root supplies the query type and renderer. A driver-specific adapter connects that contract to the driver owned by your application.
 
-## PostgreSQL
+## Connect an adapter
+
+### PostgreSQL
 
 ```ts
 import { sql, typePolicy } from "@typed-sql/postgres";
@@ -31,7 +33,7 @@ try {
 }
 ```
 
-## MySQL
+### MySQL
 
 ```ts
 import { sql, typePolicy } from "@typed-sql/mysql";
@@ -56,6 +58,93 @@ try {
 ```
 
 `database.execute(query)` returns `Promise<readonly Row[]>`, where `Row` is the type inferred for the complete statement. Command statements without a result surface use `never` as their row type.
+
+## Prepare repeated queries
+
+`database.prepare(name, factory)` records a stable execution hint and returns a callable factory. Each call still produces an ordinary `Query`, so the result works with the same `execute()` and `stream()` methods as any other query.
+
+```ts
+const accountById = database.prepare("account-by-id", (accountId: bigint) => sql`
+  SELECT account.id, account.email, account.status
+  FROM accounts AS account
+  WHERE account.id = ${accountId}
+`);
+
+const query = accountById(42n);
+const rows = await database.execute(query);
+```
+
+The factory exposes its readonly `statementName`. A name must be non-empty, contain no NUL character, and be unique within one database instance. The first factory call records the rendered SQL text. Later calls may provide different parameter values, but they must render the same SQL text or typed-sql fails before driver dispatch.
+
+Preparation is lazy: declaring the factory performs no I/O and checks out no connection. PostgreSQL uses the name for ordinary buffered execution. MySQL delegates execution to mysql2's per-connection prepared-statement cache.
+
+## Stream large result sets
+
+`database.stream(query, options?)` returns a lazy `QueryStream<Row>`. Creating it renders the query but does not acquire a connection. The first `next()` call or `for await` iteration starts driver work.
+
+```ts
+const accounts = database.stream(
+  sql`
+    SELECT account.id, account.email, account.status
+    FROM accounts AS account
+    ORDER BY account.id
+  `,
+  { batchSize: 500 },
+);
+
+for await (const account of accounts) {
+  await indexAccount(account);
+
+  if (shouldStop(account)) break;
+}
+```
+
+The row retains the query's exact inferred type. `batchSize` must be a positive safe integer and expresses a preferred row count, not a byte limit. Its native meaning depends on the adapter: PostgreSQL fetches bounded cursor pages, while MySQL uses it as the protocol stream's object-mode high-water mark.
+
+Natural completion, `break`, explicit `close()`, and async disposal finish the native stream and release a root-level connection exactly once. `close()` is idempotent. For manual iteration, close in a `finally` block:
+
+```ts
+const accounts = database.stream(query);
+
+try {
+  const first = await accounts.next();
+  if (!first.done) await indexAccount(first.value);
+} finally {
+  await accounts.close();
+}
+```
+
+`QueryStream` also implements `AsyncDisposable`, so runtimes that support explicit resource management can use `await using`.
+
+PostgreSQL streaming requires the application-owned `pg-cursor` package in addition to `pg`. It is loaded only when iteration begins. MySQL streaming uses mysql2 itself and needs no additional package. See the [PostgreSQL](../dialects/postgresql.md#streaming) and [MySQL](../dialects/mysql.md#streaming) adapter details.
+
+## Use capabilities inside transactions
+
+Transaction callbacks receive the selected adapter's transaction type, so `execute()`, `prepare()`, and `stream()` remain available:
+
+```ts
+const changedAccount = database.prepare("changed-account", (accountId: bigint) => sql`
+  SELECT account.id, account.email
+  FROM accounts AS account
+  WHERE account.id = ${accountId}
+`);
+
+await database.transaction(async (transaction) => {
+  const stream = transaction.stream(changedAccount(42n));
+
+  try {
+    for await (const account of stream) {
+      await indexAccount(account);
+    }
+  } finally {
+    await stream.close();
+  }
+});
+```
+
+Declare reusable prepared factories once from the root database during application bootstrap. Prepared names remain reserved for that database instance, so declaring the same name inside a repeatedly called transaction callback would collide after its first invocation. The ordinary queries returned by a root factory retain their prepared metadata when executed or streamed through that database's transaction scopes.
+
+A transaction stream must complete or close before its callback returns. It cannot escape the callback for later iteration. While a transaction stream is active, the same connection cannot execute another query, start another stream, or enter a nested transaction. If the callback returns with an open stream, the adapter closes it, reports the misuse, and rolls back instead of committing.
 
 ## Parameters and identifiers
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -68,6 +68,20 @@ Prepared names are non-empty, NUL-free, and unique within a database instance. T
 
 The same prepared-state registry is available to transaction scopes created by the database. A prepared query executed through another database instance is treated as an ordinary query because preparation metadata is instance-local.
 
+### Ordered batches
+
+PostgreSQL and MySQL database and transaction adapters expose:
+
+```ts
+database.batch(queries)
+```
+
+The input is a readonly query tuple or homogeneous query array. `QueryResults<Queries>` maps every query to its `readonly Row[]` result while preserving tuple order. Non-query values are rejected by the parameter type.
+
+An empty batch returns without leasing a connection. A non-empty root batch leases one connection and executes each query sequentially, stopping at the first failure. It is neither atomic nor a one-round-trip protocol. Calling `batch()` inside `database.transaction()` reuses the transaction connection, so transactional statements follow the surrounding transaction's commit or rollback. Database rules such as MySQL DDL implicit commits still apply.
+
+Transaction batches are scoped operations. Callers must await them before the callback returns, and adapters reject competing connection work while a batch is active.
+
 ### Query streams
 
 `QueryStream<Row>` extends `AsyncIterableIterator<Row>` and `AsyncDisposable` and adds:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -54,6 +54,40 @@ The declarations contain an internal `sql.__typed` member used by compiler overl
 
 Most applications use `createPgDatabase` or `createMySql2Database` rather than constructing a neutral adapter directly.
 
+### Prepared query factories
+
+PostgreSQL and MySQL adapters expose:
+
+```ts
+database.prepare(name, (...arguments) => query)
+```
+
+The return value is a callable adapter-specific prepared-query factory with a readonly `statementName`. Its arguments and returned `Query<Row, Parameters>` remain exact. Calling the factory does not create a separate executable query class; it returns the ordinary `Query` produced by the callback.
+
+Prepared names are non-empty, NUL-free, and unique within a database instance. The first call fixes the exact rendered SQL text for that name. Later calls with a different rendered shape throw before driver dispatch. Parameter values may vary because they do not change rendered SQL text.
+
+The same prepared-state registry is available to transaction scopes created by the database. A prepared query executed through another database instance is treated as an ordinary query because preparation metadata is instance-local.
+
+### Query streams
+
+`QueryStream<Row>` extends `AsyncIterableIterator<Row>` and `AsyncDisposable` and adds:
+
+```ts
+close(): Promise<void>
+```
+
+PostgreSQL and MySQL database and transaction adapters expose:
+
+```ts
+database.stream(query, options?)
+```
+
+`StreamOptions` currently contains `batchSize?: number`. Adapters reject values that are not positive safe integers. `stream()` is lazy with respect to driver work: no connection is acquired before the first iteration. Natural completion, iterator return, explicit close, and async disposal perform terminal cleanup exactly once.
+
+Transaction streams are scoped resources. They must reach completion or close before the callback returns, and an adapter rejects concurrent operations that would reuse the same transaction connection while a stream is active.
+
+Streaming is an adapter capability rather than a method on the minimal core `Database` contract. PostgreSQL maps it to an application-owned cursor; MySQL maps it to protocol streaming. See [Execute queries](../guides/execution.md#stream-large-result-sets) for consumer examples.
+
 ## Configuration and schema contracts
 
 `defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, and compiler options.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -82,6 +82,8 @@ An empty batch returns without leasing a connection. A non-empty root batch leas
 
 Transaction batches are scoped operations. Callers must await them before the callback returns, and adapters reject competing connection work while a batch is active.
 
+Transaction `execute()` calls are scoped operations too. A callback must await every dispatched execution before returning. If execution is still in flight, the adapter waits for it to settle and rolls back instead of selecting commit or releasing the connection underneath it.
+
 ### Query streams
 
 `QueryStream<Row>` extends `AsyncIterableIterator<Row>` and `AsyncDisposable` and adds:

--- a/e2e/mysql/src/stream-query.ts
+++ b/e2e/mysql/src/stream-query.ts
@@ -1,0 +1,11 @@
+import { sql } from "@typed-sql/mysql";
+
+export const streamAccountsQuery = sql`
+  SELECT user_account.id,
+         user_account.email,
+         user_account.status,
+         project.budget
+  FROM users AS user_account
+  LEFT JOIN projects AS project ON user_account.id = project.owner_id
+  ORDER BY user_account.id
+`;

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -387,15 +387,27 @@ try {
           { id: 2n, email: "bob@example.com", status: "suspended", budget: null },
         ]);
 
-        const transactionTotal = await database.transaction(async (transaction) => {
+        const [batchedAccounts, batchedTotals, commandRows] = await database.batch([
+          preparedAccounts(),
+          sql<{ total: bigint }>`SELECT user_count() AS total`,
+          sql<never>`UPDATE users SET active = active WHERE id = -1`,
+        ]);
+        strict.deepStrictEqual(batchedAccounts, allRows);
+        strict.strictEqual(batchedTotals[0]?.total, 2n);
+        strict.deepStrictEqual(commandRows, []);
+
+        const transactionResult = await database.transaction(async (transaction) => {
           for await (const row of transaction.stream(preparedAccounts(), { batchSize: 1 })) {
             strict.strictEqual(row.id, 1n);
             break;
           }
-          const totals = await transaction.execute(sql<{ total: bigint }>`SELECT user_count() AS total`);
-          return totals[0]?.total;
+          const [accounts, totals] = await transaction.batch([
+            preparedAccounts(),
+            sql<{ total: bigint }>`SELECT user_count() AS total`,
+          ]);
+          return { accountCount: accounts.length, total: totals[0]?.total };
         });
-        strict.strictEqual(transactionTotal, 2n);
+        strict.deepStrictEqual(transactionResult, { accountCount: 2, total: 2n });
 
         const rowsAfterTransaction = await database.execute(preparedAccounts());
         strict.strictEqual(rowsAfterTransaction.length, 2);

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Query } from "@typed-sql/core";
 import { type MySqlSchemaSnapshot, mysql, sql, typePolicy } from "@typed-sql/mysql";
 import { createMySql2Database } from "@typed-sql/mysql/mysql2";
 import { analyzeSource } from "@typed-sql/ts-bridge";
@@ -9,6 +10,7 @@ import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-previ
 import { createPool } from "mysql2/promise";
 import { describe, it, log, strict, waitForExpectedResult, waitForPort } from "poku";
 import { mysqlCodecFidelity } from "../src/codec-query.js";
+import { streamAccountsQuery } from "../src/stream-query.js";
 
 interface CommandResult {
   readonly code: number;
@@ -197,6 +199,19 @@ try {
           'Query<never, readonly [string, "active" | "suspended", unknown]>',
         );
         strict.ok(inspections.slice(0, 2).every((inspection) => !inspection.typeText.includes("unknown")));
+
+        const streamSourcePath = join(packageDirectory, "src/stream-query.ts");
+        const streamSource = await readFile(streamSourcePath, "utf8");
+        const streamAnalysis = analyzeSource(streamSource, snapshot as MySqlSchemaSnapshot, mysql());
+        const streamInspections = await bridge.inspectFile({
+          fileName: streamSourcePath,
+          projectFile: join(packageDirectory, "tsconfig.json"),
+          analysis: streamAnalysis,
+        });
+        strict.strictEqual(streamInspections.length, 1);
+        strict.ok(streamInspections[0]?.typeText.includes("id: bigint"));
+        strict.ok(streamInspections[0]?.typeText.includes('status: "active" | "suspended"'));
+        strict.ok(streamInspections[0]?.typeText.includes("budget: string | null"));
       } finally {
         await bridge.close();
       }
@@ -334,6 +349,57 @@ try {
         strict.strictEqual(codec.enum_value, "ready");
         strict.strictEqual(codec.set_value, "read,write");
         strict.strictEqual(codec.nullable_text, null);
+      } finally {
+        await database.close();
+      }
+    });
+
+    await it("streams an inferred prepared query and leaves real mysql2 connections reusable", async () => {
+      type Account = {
+        id: bigint;
+        email: string;
+        status: "active" | "suspended";
+        budget: string | null;
+      };
+      // The preceding preview-bridge check proves this exact source binding's inferred type. The
+      // ordinary E2E tsc pass does not install the preview bridge, so retain that verified type at
+      // the harness boundary while exercising the original immutable Query object at runtime.
+      const accountsQuery = streamAccountsQuery as unknown as Query<Account, readonly []>;
+      const database = await createMySql2Database({ connectionUri, typePolicy });
+      try {
+        const preparedAccounts = database.prepare("e2e-accounts", () => accountsQuery);
+        strict.strictEqual(preparedAccounts.statementName, "e2e-accounts");
+
+        const firstRows: Array<{ id: bigint; email: string }> = [];
+        for await (const row of database.stream(preparedAccounts(), { batchSize: 1 })) {
+          firstRows.push({ id: row.id, email: row.email });
+          break;
+        }
+        strict.deepStrictEqual(firstRows, [{ id: 1n, email: "alice@example.com" }]);
+
+        const countAfterBreak = await database.execute(sql<{ total: bigint }>`SELECT user_count() AS total`);
+        strict.strictEqual(countAfterBreak[0]?.total, 2n);
+
+        const allRows: Account[] = [];
+        for await (const row of database.stream(preparedAccounts(), { batchSize: 1 })) allRows.push(row);
+        strict.deepStrictEqual(allRows, [
+          { id: 1n, email: "alice@example.com", status: "active", budget: "12500.50" },
+          { id: 2n, email: "bob@example.com", status: "suspended", budget: null },
+        ]);
+
+        const transactionTotal = await database.transaction(async (transaction) => {
+          for await (const row of transaction.stream(preparedAccounts(), { batchSize: 1 })) {
+            strict.strictEqual(row.id, 1n);
+            break;
+          }
+          const totals = await transaction.execute(sql<{ total: bigint }>`SELECT user_count() AS total`);
+          return totals[0]?.total;
+        });
+        strict.strictEqual(transactionTotal, 2n);
+
+        const rowsAfterTransaction = await database.execute(preparedAccounts());
+        strict.strictEqual(rowsAfterTransaction.length, 2);
+        strict.strictEqual(rowsAfterTransaction[1]?.status, "suspended");
       } finally {
         await database.close();
       }

--- a/e2e/postgres/package.json
+++ b/e2e/postgres/package.json
@@ -15,7 +15,8 @@
     "@typed-sql/core": "workspace:*",
     "@typed-sql/postgres": "workspace:*",
     "@typed-sql/ts-bridge": "workspace:*",
-    "pg": "8.23.0"
+    "pg": "8.23.0",
+    "pg-cursor": "2.22.0"
   },
   "devDependencies": {
     "poku": "4.5.0",

--- a/e2e/postgres/src/stream-query.ts
+++ b/e2e/postgres/src/stream-query.ts
@@ -1,0 +1,20 @@
+import { sql } from "@typed-sql/postgres";
+
+export const postgresAccountStream = sql`
+  SELECT user_account.id,
+         user_account.email,
+         user_account.status,
+         project.budget::NUMERIC AS budget
+  FROM users AS user_account
+  LEFT JOIN projects AS project ON user_account.id = project.owner_id
+  ORDER BY user_account.id
+`;
+
+export const postgresAccountsAtOrAbove = (minimumId: bigint) => sql`
+  SELECT user_account.id,
+         user_account.email,
+         user_account.status
+  FROM users AS user_account
+  WHERE user_account.id >= ${minimumId}
+  ORDER BY user_account.id
+`;

--- a/e2e/postgres/test/developer-flow.e2e.test.ts
+++ b/e2e/postgres/test/developer-flow.e2e.test.ts
@@ -451,7 +451,7 @@ try {
       }
     });
 
-    await it("streams compiler-inferred and prepared queries through a reusable one-client pool", async () => {
+    await it("batches and streams inferred and prepared queries through a reusable one-client pool", async () => {
       const database = await createPgDatabase({
         connectionString,
         typePolicy,
@@ -469,6 +469,21 @@ try {
         strict.deepStrictEqual(preparedRows, [
           { id: 1n, email: "alice@example.com", status: "active" },
           { id: 2n, email: "bob@example.com", status: "suspended" },
+        ]);
+
+        const [batchPreparedRows, batchInferredRows] = await database.batch([
+          accountAtOrAbove(2n),
+          postgresAccountStream,
+        ]);
+        strict.deepStrictEqual(batchPreparedRows, [{ id: 2n, email: "bob@example.com", status: "suspended" }]);
+        strict.deepStrictEqual(batchInferredRows, [
+          {
+            id: 1n,
+            email: "alice@example.com",
+            status: "active",
+            budget: "12500.50",
+          },
+          { id: 2n, email: "bob@example.com", status: "suspended", budget: null },
         ]);
 
         const inferredRows: unknown[] = [];
@@ -502,6 +517,15 @@ try {
           }
           const stillUsable = await transaction.execute(accountAtOrAbove(2n));
           strict.deepStrictEqual(stillUsable, [{ id: 2n, email: "bob@example.com", status: "suspended" }]);
+          const [transactionPreparedRows, transactionHealth] = await transaction.batch([
+            accountAtOrAbove(1n),
+            sql<{ total: bigint }>`SELECT active_user_count() AS total`,
+          ]);
+          strict.deepStrictEqual(transactionPreparedRows, [
+            { id: 1n, email: "alice@example.com", status: "active" },
+            { id: 2n, email: "bob@example.com", status: "suspended" },
+          ]);
+          strict.deepStrictEqual(transactionHealth, [{ total: 1n }]);
           return first;
         });
         strict.deepStrictEqual(transactionFirst, {

--- a/e2e/postgres/test/developer-flow.e2e.test.ts
+++ b/e2e/postgres/test/developer-flow.e2e.test.ts
@@ -9,6 +9,7 @@ import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-previ
 import { Pool } from "pg";
 import { describe, it, log, strict, waitForExpectedResult, waitForPort } from "poku";
 import { postgresCodecFidelity } from "../src/codec-query.js";
+import { postgresAccountStream, postgresAccountsAtOrAbove } from "../src/stream-query.js";
 
 interface CommandResult {
   readonly code: number;
@@ -41,6 +42,7 @@ interface GeneratedSnapshot {
 
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workspaceDirectory = resolve(packageDirectory, "../..");
+const pgCursorPackage: string = "pg-cursor";
 const generatedDirectory = join(packageDirectory, "generated");
 const generatedDatabaseDirectory = join(generatedDirectory, "db");
 const generatedSnapshotPath = join(generatedDatabaseDirectory, "schema.json");
@@ -190,6 +192,15 @@ try {
         "--project",
         join(packageDirectory, "tsconfig.json"),
       );
+      await cli(
+        "check",
+        "--config",
+        join(packageDirectory, "typed-sql.config.ts"),
+        "--file",
+        join(packageDirectory, "src/stream-query.ts"),
+        "--project",
+        join(packageDirectory, "tsconfig.json"),
+      );
     });
 
     await it("exposes the inferred Query type through the TypeScript preview bridge", async () => {
@@ -217,6 +228,34 @@ try {
         strict.ok(inspections[2]?.typeText.includes('status: "active" | "suspended"'));
         strict.ok(!inspections[2]?.typeText.includes("unknown"));
         strict.strictEqual(inspections[3]?.typeText, "Query<never, readonly [unknown, bigint]>");
+      } finally {
+        await bridge.close();
+      }
+    });
+
+    await it("infers the same queries used by the prepared and streaming runtime flow", async () => {
+      const sourcePath = join(packageDirectory, "src/stream-query.ts");
+      const source = await readFile(sourcePath, "utf8");
+      const snapshot = JSON.parse(await readFile(generatedSnapshotPath, "utf8")) as Parameters<typeof analyzeSource>[1];
+      const analysis = analyzeSource(source, snapshot as PostgresSchemaSnapshot, postgres());
+      strict.deepStrictEqual(analysis.diagnostics, []);
+      strict.strictEqual(analysis.queries.length, 2);
+      const bridge = NativePreviewTypeScriptBridge.spawn({ cwd: workspaceDirectory });
+      try {
+        const inspections = await bridge.inspectFile({
+          fileName: sourcePath,
+          projectFile: join(packageDirectory, "tsconfig.json"),
+          analysis,
+        });
+        strict.strictEqual(inspections.length, 2);
+        strict.ok(inspections[0]?.typeText.includes("id: bigint"));
+        strict.ok(inspections[0]?.typeText.includes("budget: string | null"));
+        strict.ok(!inspections[0]?.typeText.includes("unknown"));
+        strict.ok(inspections[1]?.typeText.includes("id: bigint"));
+        strict.ok(inspections[1]?.typeText.includes("email: string"));
+        strict.ok(inspections[1]?.typeText.includes('status: "active" | "suspended"'));
+        strict.ok(inspections[1]?.typeText.includes("readonly [bigint]"));
+        strict.ok(!inspections[1]?.typeText.includes("unknown"));
       } finally {
         await bridge.close();
       }
@@ -407,6 +446,72 @@ try {
         strict.deepStrictEqual(codec.numeric_array, ["1.25", "12345678901234567890.1234567890"]);
         strict.deepStrictEqual(codec.text_array, ["one", "two"]);
         strict.strictEqual(codec.nullable_text, null);
+      } finally {
+        await database.close();
+      }
+    });
+
+    await it("streams compiler-inferred and prepared queries through a reusable one-client pool", async () => {
+      const database = await createPgDatabase({
+        connectionString,
+        typePolicy,
+        poolConfig: { max: 1, connectionTimeoutMillis: 2_000 },
+        // The workspace package is symlinked outside this fixture's node_modules tree. Supplying
+        // the application-owned loader preserves pnpm's strict dependency boundary in this E2E.
+        cursorImporter: () => import(pgCursorPackage),
+      });
+      try {
+        const accountAtOrAbove = database.prepare("e2e-account-at-or-above", postgresAccountsAtOrAbove);
+        strict.strictEqual(accountAtOrAbove.statementName, "e2e-account-at-or-above");
+
+        const preparedQuery = accountAtOrAbove(1n);
+        const preparedRows = await database.execute(preparedQuery);
+        strict.deepStrictEqual(preparedRows, [
+          { id: 1n, email: "alice@example.com", status: "active" },
+          { id: 2n, email: "bob@example.com", status: "suspended" },
+        ]);
+
+        const inferredRows: unknown[] = [];
+        for await (const row of database.stream(postgresAccountStream, { batchSize: 1 })) inferredRows.push(row);
+        strict.deepStrictEqual(inferredRows, [
+          {
+            id: 1n,
+            email: "alice@example.com",
+            status: "active",
+            budget: "12500.50",
+          },
+          { id: 2n, email: "bob@example.com", status: "suspended", budget: null },
+        ]);
+
+        const early = database.stream(accountAtOrAbove(1n), { batchSize: 1 });
+        for await (const row of early) {
+          strict.deepStrictEqual(row, { id: 1n, email: "alice@example.com", status: "active" });
+          break;
+        }
+
+        strict.deepStrictEqual(await database.execute(accountAtOrAbove(2n)), [
+          { id: 2n, email: "bob@example.com", status: "suspended" },
+        ]);
+
+        const transactionFirst = await database.transaction(async (transaction) => {
+          const stream = transaction.stream(accountAtOrAbove(1n), { batchSize: 1 });
+          let first: unknown;
+          for await (const row of stream) {
+            first = row;
+            break;
+          }
+          const stillUsable = await transaction.execute(accountAtOrAbove(2n));
+          strict.deepStrictEqual(stillUsable, [{ id: 2n, email: "bob@example.com", status: "suspended" }]);
+          return first;
+        });
+        strict.deepStrictEqual(transactionFirst, {
+          id: 1n,
+          email: "alice@example.com",
+          status: "active",
+        });
+
+        const health = await database.execute(sql<{ total: bigint }>`SELECT active_user_count() AS total`);
+        strict.deepStrictEqual(health, [{ total: 1n }]);
       } finally {
         await database.close();
       }

--- a/packages/compiler/test/compiler.test.ts
+++ b/packages/compiler/test/compiler.test.ts
@@ -548,6 +548,48 @@ await describe("TypeScript 7 compiler wrapper", async () => {
     }
   });
 
+  await it("preserves inferred rows and parameters through adapter prepared factories", async () => {
+    const directory = await mkdtemp(join(fixtureDirectory, ".typed-sql-prepared-factory-"));
+    try {
+      const file = join(directory, "prepared-factory.ts");
+      await writeFile(
+        file,
+        [
+          'import { sql } from "@typed-sql/postgres";',
+          'import type { QueryParameters, QueryRow } from "@typed-sql/core";',
+          'import type { PostgresDatabase, PostgresPreparedQueryFactory } from "@typed-sql/postgres/runtime";',
+          "type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;",
+          "type Assert<T extends true> = T;",
+          "declare const database: PostgresDatabase;",
+          'const byId = database.prepare("user-by-id", (id: number) =>',
+          "  sql`SELECT users.id, users.name FROM users WHERE users.id = ${id}`",
+          ");",
+          "const query = byId(1);",
+          "const row: Assert<Equal<QueryRow<typeof query>, { id: number; name: string }>> = true;",
+          "const params: Assert<Equal<QueryParameters<typeof query>, readonly [number]>> = true;",
+          "const factory: PostgresPreparedQueryFactory<",
+          "  [id: number],",
+          "  { id: number; name: string },",
+          "  readonly [number]",
+          "> = byId;",
+          "void row; void params; void factory;",
+        ].join("\n"),
+      );
+
+      const result = await checkFile({
+        file,
+        schema: schemaPath,
+        dialect: postgres(),
+        project: resolve(fixtureDirectory, "tsconfig.json"),
+      });
+      strict.deepStrictEqual(result.sqlDiagnostics, []);
+      strict.strictEqual(result.ok, true, result.typeScript?.output);
+      strict.ok(result.transformedSource.includes("readonly [number]>`SELECT users.id"));
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   await it("infers conditional structural SELECT fragments without replacing SQL with a builder", async () => {
     const directory = await mkdtemp(join(fixtureDirectory, ".typed-sql-structural-"));
     try {

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -12,6 +12,11 @@ export type QueryResults<Queries extends readonly unknown[]> = {
   readonly [Index in keyof Queries]: QueryResult<Queries[Index]>;
 };
 
+/** Validates an ordered tuple or array while preserving every query's exact type. */
+export type QueryBatch<Queries extends readonly unknown[]> = Queries & {
+  readonly [Index in keyof Queries]: Queries[Index] extends Query<infer Row, infer Params> ? Query<Row, Params> : never;
+};
+
 /** Common, grammar-neutral stream configuration. */
 export interface StreamOptions {
   /**

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -1,0 +1,29 @@
+import type { Query } from "./query.js";
+
+/** The buffered rows produced by executing one typed query. */
+export type QueryResult<Value> = Value extends Query<infer Row, infer _Params> ? readonly Row[] : never;
+
+/**
+ * Maps an ordered query tuple or array to its ordered buffered results.
+ *
+ * A tuple remains a tuple, while a homogeneous query array remains an array.
+ */
+export type QueryResults<Queries extends readonly unknown[]> = {
+  readonly [Index in keyof Queries]: QueryResult<Queries[Index]>;
+};
+
+/** Common, grammar-neutral stream configuration. */
+export interface StreamOptions {
+  /**
+   * Preferred number of rows fetched or buffered at a time.
+   *
+   * Adapters must reject values that are not positive safe integers. This is a row count, not a
+   * byte limit or a guarantee of server-side cursor paging.
+   */
+  readonly batchSize?: number;
+}
+
+/** A lazy, explicitly closeable stream of typed query rows. */
+export interface QueryStream<Row> extends AsyncIterableIterator<Row>, AsyncDisposable {
+  close(): Promise<void>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export type { TypedSqlDiagnosticCode } from "./diagnostics.js";
 export { diagnosticRegistry, isTypedSqlDiagnosticCode } from "./diagnostics.js";
+export type { QueryResult, QueryResults, QueryStream, StreamOptions } from "./execution.js";
 export type {
   Database,
   OptionalSqlFragment,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   SqlRenderer,
   SqlSegment,
   SqlTag,
+  TransactionDatabase,
   TransactionRunner,
 } from "./query.js";
 export { createDatabase, renderQuery, sql } from "./query.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export type { TypedSqlDiagnosticCode } from "./diagnostics.js";
 export { diagnosticRegistry, isTypedSqlDiagnosticCode } from "./diagnostics.js";
-export type { QueryResult, QueryResults, QueryStream, StreamOptions } from "./execution.js";
+export type { QueryBatch, QueryResult, QueryResults, QueryStream, StreamOptions } from "./execution.js";
 export type {
   Database,
   OptionalSqlFragment,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -109,10 +109,12 @@ export interface QueryExecutor {
   execute(text: string, values: readonly unknown[]): Promise<readonly unknown[]>;
 }
 
-export interface Database {
+export interface Database<TransactionScope extends Database<TransactionScope> = TransactionDatabase> {
   execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]>;
-  transaction<T>(fn: (db: Database) => Promise<T>): Promise<T>;
+  transaction<T>(fn: (db: TransactionScope) => Promise<T>): Promise<T>;
 }
+
+export interface TransactionDatabase extends Database<TransactionDatabase> {}
 
 export type TransactionRunner = <T>(fn: (executor: QueryExecutor) => Promise<T>) => Promise<T>;
 

--- a/packages/core/test/execution.test.ts
+++ b/packages/core/test/execution.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, strict } from "poku";
+import {
+  type Query,
+  type QueryResult,
+  type QueryResults,
+  type QueryStream,
+  type StreamOptions,
+  sql,
+} from "../src/index.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+
+type Account = { readonly id: bigint; readonly email: string };
+type Project = { readonly id: bigint; readonly ownerId: bigint };
+
+const accountQuery = sql<Account, readonly [bigint]>`SELECT id, email FROM account WHERE id = ${1n}`;
+const projectQuery = sql<Project, readonly []>`SELECT id, owner_id FROM project`;
+
+function inferBatchResults<const Queries extends readonly unknown[]>(queries: Queries): QueryResults<Queries> {
+  void queries;
+  return [] as unknown as QueryResults<Queries>;
+}
+
+await describe("grammar-neutral execution capability types", async () => {
+  await it("maps one query to its readonly buffered rows", () => {
+    const exact: Assert<Equal<QueryResult<typeof accountQuery>, readonly Account[]>> = true;
+    const unsupported: Assert<Equal<QueryResult<{ readonly text: string }>, never>> = true;
+    strict.strictEqual(exact, true);
+    strict.strictEqual(unsupported, true);
+  });
+
+  await it("preserves heterogeneous inline tuples without an as-const assertion", () => {
+    const results = inferBatchResults([accountQuery, projectQuery]);
+    const exact: Assert<Equal<typeof results, readonly [readonly Account[], readonly Project[]]>> = true;
+    strict.strictEqual(exact, true);
+  });
+
+  await it("preserves homogeneous mapped arrays", () => {
+    const queries = [1n, 2n].map(
+      (id): Query<Account, readonly [bigint]> => sql`SELECT id, email FROM account WHERE id = ${id}`,
+    );
+    const results = inferBatchResults(queries);
+    const exact: Assert<Equal<typeof results, readonly (readonly Account[])[]>> = true;
+    strict.strictEqual(exact, true);
+  });
+
+  await it("defines a closeable async-iterator lifecycle without cancellation", async () => {
+    let closeCount = 0;
+    const stream: QueryStream<Account> = {
+      async next() {
+        return { done: true, value: undefined };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async close() {
+        closeCount += 1;
+      },
+      async [Symbol.asyncDispose]() {
+        await this.close();
+      },
+    };
+
+    const options = { batchSize: 500 } satisfies StreamOptions;
+    // @ts-expect-error cancellation is intentionally absent until adapters share safe semantics
+    const unsupportedOptions: StreamOptions = { signal: new AbortController().signal };
+    void unsupportedOptions;
+
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+    await stream[Symbol.asyncDispose]();
+    strict.strictEqual(closeCount, 1);
+    strict.strictEqual(options.batchSize, 500);
+  });
+});

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -35,6 +35,8 @@ const accountById = database.prepare("account-by-id", (id: bigint) => sql`
   WHERE account.id = ${id}
 `);
 
+const [selectedAccounts, allAccounts] = await database.batch([accountById(42n), query]);
+
 for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
   // account retains the query's inferred row type
 }

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -28,6 +28,16 @@ const database = await createMySql2Database({
 });
 
 const rows = await database.execute(query);
+
+const accountById = database.prepare("account-by-id", (id: bigint) => sql`
+  SELECT account.id, account.email
+  FROM users AS account
+  WHERE account.id = ${id}
+`);
+
+for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
+  // account retains the query's inferred row type
+}
 ```
 
 The package root exports `sql`, `mysql`, and the MySQL type policy. The `/mysql2` entrypoint exports
@@ -35,6 +45,7 @@ the schema provider and execution adapter; `/runtime` exposes driver-neutral MyS
 codecs.
 
 Read the [MySQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/mysql.md),
+[execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
 [configuration](https://github.com/Lojhan/typed-sql/blob/main/docs/getting-started/configuration.md), and
 [database type mappings](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/type-mappings.md).
 

--- a/packages/mysql/src/decoding.ts
+++ b/packages/mysql/src/decoding.ts
@@ -1,0 +1,125 @@
+import type { MySqlTypePolicy } from "./type-policy.js";
+
+export interface MySqlFieldLike {
+  readonly name: string;
+  readonly columnType: number;
+  readonly columnLength?: number;
+}
+
+export type MySqlRuntimeTypePolicy = Pick<MySqlTypePolicy, "bigint" | "decimal" | "date" | "json" | "tinyint1">;
+
+type ValueDecoder = (value: unknown) => unknown;
+
+export interface MySqlColumnDecoder {
+  readonly name: string;
+  readonly decode: ValueDecoder;
+}
+
+const mysqlTypes = { tiny: 1, longlong: 8, date: 10, datetime: 12, timestamp: 7, json: 245, decimal: 246 } as const;
+
+export function encodeMySqlValue(value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : Array.isArray(value) ? value.map(encodeMySqlValue) : value;
+}
+
+function finite(value: string, label: string): number {
+  const result = Number(value);
+  if (!Number.isFinite(result))
+    throw new RangeError(`${label} value ${value} cannot be represented as a finite number`);
+  return result;
+}
+
+function nullable(decoder: ValueDecoder): ValueDecoder {
+  return (value) => (value === null || value === undefined ? value : decoder(value));
+}
+
+function compileValueDecoder(
+  field: MySqlFieldLike,
+  typePolicy: MySqlRuntimeTypePolicy,
+  decimal?: (value: string) => unknown,
+): ValueDecoder | undefined {
+  if (field.columnType === mysqlTypes.longlong) {
+    if (typePolicy.bigint === "bigint") return nullable((value) => BigInt(String(value)));
+    if (typePolicy.bigint === "number")
+      return nullable((value) => {
+        const result = finite(String(value), "bigint");
+        if (!Number.isSafeInteger(result))
+          throw new RangeError(`bigint value ${value} exceeds JavaScript's safe integer range`);
+        return result;
+      });
+    return nullable((value) => String(value));
+  }
+  if (field.columnType === mysqlTypes.decimal) {
+    if (typePolicy.decimal === "number") return nullable((value) => finite(String(value), "decimal"));
+    if (typePolicy.decimal === "Decimal") {
+      if (decimal === undefined) throw new TypeError("decimal=Decimal requires a decimal(value) codec");
+      return nullable((value) => decimal(String(value)));
+    }
+    return nullable((value) => String(value));
+  }
+  if (
+    field.columnType === mysqlTypes.date ||
+    field.columnType === mysqlTypes.datetime ||
+    field.columnType === mysqlTypes.timestamp
+  ) {
+    return typePolicy.date === "string"
+      ? nullable((value) => String(value))
+      : nullable((value) => (value instanceof Date ? value : new Date(String(value))));
+  }
+  if (field.columnType === mysqlTypes.json && typePolicy.json === "string")
+    return nullable((value) => (typeof value === "string" ? value : JSON.stringify(value)));
+  if (field.columnType === mysqlTypes.tiny && field.columnLength === 1 && typePolicy.tinyint1 === "boolean")
+    return nullable((value) => value === true || value === 1 || value === "1");
+  return undefined;
+}
+
+/** Compiles immutable field metadata into a decoder plan shared by buffered and streamed rows. */
+export function compileMySqlRowDecoders(
+  fields: readonly MySqlFieldLike[],
+  typePolicy: MySqlRuntimeTypePolicy,
+  decimal?: (value: string) => unknown,
+): readonly MySqlColumnDecoder[] {
+  const decoders: MySqlColumnDecoder[] = [];
+  const visited = new Set<string>();
+  for (const field of fields) {
+    // Preserve established behavior: the first metadata entry for a row property owns its decoding.
+    if (visited.has(field.name)) continue;
+    visited.add(field.name);
+    const decode = compileValueDecoder(field, typePolicy, decimal);
+    if (decode !== undefined) decoders.push({ name: field.name, decode });
+  }
+  return decoders;
+}
+
+export function decodeMySqlRows(
+  rows: readonly Record<string, unknown>[],
+  decoders: readonly MySqlColumnDecoder[],
+): readonly Record<string, unknown>[] {
+  if (decoders.length === 0) return rows;
+  // Keep driver objects intact until a codec produces a different value for that specific row.
+  let decodedRows: Record<string, unknown>[] | undefined;
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex]!;
+    const decodedRow = decodeMySqlRow(row, decoders);
+    if (decodedRow === row) continue;
+    decodedRows ??= rows.slice() as Record<string, unknown>[];
+    decodedRows[rowIndex] = decodedRow;
+  }
+  return decodedRows ?? rows;
+}
+
+/** Decodes one streamed row without allocating an intermediate one-element array. */
+export function decodeMySqlRow(
+  row: Record<string, unknown>,
+  decoders: readonly MySqlColumnDecoder[],
+): Record<string, unknown> {
+  let decodedRow: Record<string, unknown> | undefined;
+  for (const column of decoders) {
+    if (!Object.prototype.propertyIsEnumerable.call(row, column.name)) continue;
+    const value = row[column.name];
+    const decoded = column.decode(value);
+    if (Object.is(decoded, value)) continue;
+    decodedRow ??= { ...row };
+    decodedRow[column.name] = decoded;
+  }
+  return decodedRow ?? row;
+}

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -1,3 +1,4 @@
+import type { Connection as CallbackConnection, Query as CallbackQuery } from "mysql2";
 import type { FieldPacket, Pool, PoolConnection, PoolOptions } from "mysql2/promise";
 import type { MySqlSchemaSnapshot } from "./index.js";
 import { type MySqlQueryable, MySqlSchemaProvider } from "./provider.js";
@@ -8,6 +9,7 @@ import {
   type MySqlExecutionResult,
   type MySqlFieldLike,
   type MySqlPoolLike,
+  type MySqlProtocolStream,
 } from "./runtime.js";
 import type { MySqlTypePolicy } from "./type-policy.js";
 
@@ -116,11 +118,127 @@ function connectionAdapter(connection: PoolConnection): MySqlConnectionLike {
   const executable = connection as unknown as Executable;
   return {
     execute: (sql, values) => execute(executable, "execute", sql, values),
+    stream: (sql, values, options) =>
+      createMySql2ProtocolStream(
+        connection.connection as unknown as CallbackConnection,
+        sql,
+        values,
+        options.batchSize,
+      ),
     query: (sql) => execute(executable, "query", sql),
     beginTransaction: () => connection.beginTransaction(),
     commit: () => connection.commit(),
     rollback: () => connection.rollback(),
     release: () => connection.release(),
+  };
+}
+
+function createMySql2ProtocolStream(
+  connection: CallbackConnection,
+  sql: string,
+  values: readonly unknown[],
+  batchSize: number,
+): MySqlProtocolStream {
+  // mysql2's promise API buffers execute() results. Its public PoolConnection.connection is the
+  // same callback connection, whose Execute command exposes the protocol-backed Readable while
+  // retaining mysql2's per-connection prepared statement cache.
+  const command = connection.execute(sql, values as never) as CallbackQuery;
+  let resolveFields!: (value: readonly MySqlFieldLike[]) => void;
+  let rejectFields!: (reason: unknown) => void;
+  let fieldsSettled = false;
+  const fieldMetadata = new Promise<readonly MySqlFieldLike[]>((resolve, reject) => {
+    resolveFields = resolve;
+    rejectFields = reject;
+  });
+  // A driver failure can happen before the runtime starts awaiting metadata.
+  void fieldMetadata.catch(() => undefined);
+
+  let resolveTerminal!: () => void;
+  const terminal = new Promise<void>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  let protocolError: unknown;
+  let connectionReusable = false;
+  let terminalSettled = false;
+  let readable: ReturnType<CallbackQuery["stream"]> | undefined;
+  const settleTerminal = (reusable: boolean) => {
+    if (terminalSettled) return;
+    terminalSettled = true;
+    connectionReusable = reusable;
+    connection.removeListener("error", onConnectionError);
+    connection.removeListener("end", onConnectionEnd);
+    connection.removeListener("close", onConnectionEnd);
+    resolveTerminal();
+  };
+  const onConnectionError = (error: unknown) => {
+    protocolError ??= error;
+    if (!fieldsSettled) {
+      fieldsSettled = true;
+      rejectFields(error);
+    }
+    readable?.destroy(error as Error);
+    settleTerminal(false);
+  };
+  const onConnectionEnd = () => {
+    const error = new Error("MySQL connection ended before the streaming command completed");
+    protocolError ??= error;
+    if (!fieldsSettled) {
+      fieldsSettled = true;
+      rejectFields(error);
+    }
+    readable?.destroy(error);
+    settleTerminal(false);
+  };
+  connection.once("error", onConnectionError);
+  connection.once("end", onConnectionEnd);
+  connection.once("close", onConnectionEnd);
+  command.once("fields", (value: readonly FieldPacket[] | undefined) => {
+    if (fieldsSettled) return;
+    fieldsSettled = true;
+    resolveFields(value === undefined ? [] : fields(value));
+  });
+  command.once("error", (error: unknown) => {
+    protocolError = error;
+    if (!fieldsSettled) {
+      fieldsSettled = true;
+      rejectFields(error);
+    }
+  });
+  command.once("end", () => {
+    if (!fieldsSettled) {
+      fieldsSettled = true;
+      resolveFields([]);
+    }
+    settleTerminal(true);
+  });
+
+  readable = command.stream({ highWaterMark: batchSize });
+  // Query.stream can destroy with an error before next() installs the async iterator's listener.
+  // Keep the process safe while preserving the same error for fields/iteration/close.
+  readable.on("error", () => undefined);
+  const iterator = readable[Symbol.asyncIterator]() as AsyncIterableIterator<Record<string, unknown>>;
+  let closePromise: Promise<void> | undefined;
+
+  return {
+    fields: fieldMetadata,
+    get connectionReusable() {
+      return connectionReusable;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next: () => iterator.next(),
+    close() {
+      closePromise ??= (async () => {
+        // Destroying this Readable stops delivery and resumes the socket. The independently attached
+        // command listeners remain until the Execute command really ends, so the connection is never
+        // released or reused while protocol packets are still arriving.
+        if (!readable.destroyed) readable.destroy();
+        await terminal;
+        if (protocolError !== undefined) throw protocolError;
+      })();
+      return closePromise;
+    },
   };
 }
 

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -43,8 +43,8 @@ export interface MySql2SchemaProviderOptions {
 }
 
 interface Executable {
-  execute(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, readonly FieldPacket[]]>;
-  query(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, readonly FieldPacket[]]>;
+  execute(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, (readonly FieldPacket[])?]>;
+  query(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, (readonly FieldPacket[])?]>;
 }
 
 export async function loadMySql2Driver(
@@ -110,7 +110,7 @@ async function execute(
   const [rows, metadata] = await value[method](sql, values);
   return {
     rows: rows as readonly Record<string, unknown>[] | Record<string, unknown>,
-    ...(metadata.length === 0 ? {} : { fields: fields(metadata) }),
+    ...(metadata === undefined || metadata.length === 0 ? {} : { fields: fields(metadata) }),
   };
 }
 

--- a/packages/mysql/src/prepared.ts
+++ b/packages/mysql/src/prepared.ts
@@ -1,0 +1,73 @@
+import { type Query, type RenderedQuery, renderQuery, type SqlRenderer } from "@typed-sql/core";
+
+export interface MySqlPreparedQueryFactory<
+  Arguments extends readonly unknown[],
+  Row,
+  Params extends readonly unknown[],
+> {
+  (...args: Arguments): Query<Row, Params>;
+  readonly statementName: string;
+}
+
+export interface MySqlPreparedQueryMetadata {
+  readonly statementName: string;
+  readonly rendered: RenderedQuery;
+}
+
+interface PreparedStatement {
+  text: string | undefined;
+}
+
+export interface MySqlPreparedQueryState {
+  readonly statements: Map<string, PreparedStatement>;
+  readonly queries: WeakMap<object, MySqlPreparedQueryMetadata>;
+}
+
+export function createMySqlPreparedQueryState(): MySqlPreparedQueryState {
+  return {
+    statements: new Map(),
+    queries: new WeakMap(),
+  };
+}
+
+function validateStatementName(statementName: string): void {
+  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0")) {
+    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
+  }
+}
+
+export function prepareMySqlQuery<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+  state: MySqlPreparedQueryState,
+  renderer: SqlRenderer,
+  statementName: string,
+  factory: (...args: Arguments) => Query<Row, Params>,
+): MySqlPreparedQueryFactory<Arguments, Row, Params> {
+  validateStatementName(statementName);
+  if (state.statements.has(statementName)) {
+    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
+  }
+
+  const statement: PreparedStatement = { text: undefined };
+  state.statements.set(statementName, statement);
+
+  const prepared = (...args: Arguments): Query<Row, Params> => {
+    const query = factory(...args);
+    const existing = state.queries.get(query);
+    if (existing !== undefined && existing.statementName !== statementName) {
+      throw new TypeError(
+        `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
+      );
+    }
+
+    const rendered = existing?.rendered ?? renderQuery(query, renderer);
+    if (statement.text === undefined) statement.text = rendered.text;
+    else if (statement.text !== rendered.text) {
+      throw new TypeError(`Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text`);
+    }
+
+    if (existing === undefined) state.queries.set(query, { statementName, rendered });
+    return query;
+  };
+
+  return Object.freeze(Object.assign(prepared, { statementName }));
+}

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,6 +1,8 @@
 import {
   type Database,
   type Query,
+  type QueryBatch,
+  type QueryResults,
   type QueryStream,
   renderQuery,
   type SqlRenderer,
@@ -47,6 +49,7 @@ export interface MySqlPoolLike {
 }
 
 export interface MySqlTransaction extends Database<MySqlTransaction> {
+  batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>>;
   stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
@@ -55,6 +58,7 @@ export interface MySqlTransaction extends Database<MySqlTransaction> {
 }
 
 export interface MySqlDatabase extends Database<MySqlTransaction> {
+  batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>>;
   stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
@@ -71,6 +75,7 @@ export interface MySqlDatabaseOptions {
 }
 
 const defaultRuntimeTypePolicy: MySqlRuntimeTypePolicy = defaultMySqlTypePolicy;
+const emptyBatchResults = Object.freeze([]);
 
 export const mysqlRenderer: SqlRenderer = Object.freeze({
   placeholder: () => "?",
@@ -79,7 +84,21 @@ export const mysqlRenderer: SqlRenderer = Object.freeze({
 
 interface MySqlTransactionConnectionState {
   active: QueryStream<unknown> | undefined;
+  batch: MySqlBatchOperation | undefined;
   usable: boolean;
+}
+
+interface MySqlBatchOperation {
+  readonly completion: Promise<void>;
+  finish(): void;
+}
+
+function createMySqlBatchOperation(): MySqlBatchOperation {
+  let finish!: () => void;
+  const completion = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  return { completion, finish };
 }
 
 class MySqlDatabaseImplementation implements MySqlDatabase {
@@ -118,12 +137,66 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
     this.#assertScopeOpen();
     this.#assertConnectionAvailable("execute a query");
+    return this.#executeOn(this.#connection ?? this.#pool, query);
+  }
+
+  async #executeOn<Row, Params extends readonly unknown[]>(
+    executor: Pick<MySqlConnectionLike, "execute">,
+    query: Query<Row, Params>,
+  ): Promise<readonly Row[]> {
     const prepared = this.#prepared.queries.get(query);
     const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
-    const result = await (this.#connection ?? this.#pool).execute(rendered.text, rendered.values.map(encodeMySqlValue));
+    const result = await executor.execute(rendered.text, rendered.values.map(encodeMySqlValue));
     if (!Array.isArray(result.rows)) return [];
     const decoders = compileMySqlRowDecoders(result.fields ?? [], this.#typePolicy, this.#decimal);
     return decodeMySqlRows(result.rows, decoders) as unknown as readonly Row[];
+  }
+
+  async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
+    this.#assertScopeOpen();
+    this.#assertConnectionAvailable("execute a batch");
+    if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
+    const orderedQueries = [...queries] as unknown as QueryBatch<Queries>;
+
+    if (this.#connection !== undefined) {
+      const operation = createMySqlBatchOperation();
+      this.#transactionState!.batch = operation;
+      try {
+        return await this.#executeBatchOn(this.#connection, orderedQueries, () =>
+          this.#assertBatchCanContinue(operation),
+        );
+      } finally {
+        if (this.#transactionState?.batch === operation) this.#transactionState.batch = undefined;
+        operation.finish();
+      }
+    }
+    const connection = await this.#pool.getConnection();
+    let results: QueryResults<Queries>;
+    try {
+      results = await this.#executeBatchOn(connection, orderedQueries);
+    } catch (error) {
+      try {
+        connection.release();
+      } catch {
+        /* Preserve the batch execution failure. */
+      }
+      throw error;
+    }
+    connection.release();
+    return results;
+  }
+
+  async #executeBatchOn<const Queries extends readonly unknown[]>(
+    connection: MySqlConnectionLike,
+    queries: QueryBatch<Queries>,
+    beforeEach?: () => void,
+  ): Promise<QueryResults<Queries>> {
+    const results: unknown[] = [];
+    for (const query of queries) {
+      beforeEach?.();
+      results.push(await this.#executeOn(connection, query));
+    }
+    return results as QueryResults<Queries>;
   }
 
   stream<Row, Params extends readonly unknown[]>(
@@ -183,7 +256,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         this.#decimal,
         1,
         this.#prepared,
-        { active: undefined, usable: true },
+        { active: undefined, batch: undefined, usable: true },
       );
       result = await fn(transaction);
       transaction.#scopeOpen = false;
@@ -268,15 +341,23 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async #invalidateScope(): Promise<void> {
     this.#scopeOpen = false;
     await this.#closeStreams();
+    await this.#settleBatch();
   }
 
   async #assertTransactionReadyForFinalize(connectionFinalizing = false): Promise<void> {
+    const leakedBatch = this.#transactionState?.batch;
     await this.#rejectActiveStreams();
     const active = this.#transactionState?.active;
     if (active !== undefined) {
       await Promise.allSettled([active.close()]);
       throw new Error(
         "MySQL transaction callback returned while a nested query stream owned its connection; await nested work and close every stream before returning",
+      );
+    }
+    if (leakedBatch !== undefined) {
+      await leakedBatch.completion;
+      throw new Error(
+        "MySQL transaction callback returned while an ordered batch owned its connection; await the batch before returning",
       );
     }
     if (!connectionFinalizing && this.#transactionState?.usable === false)
@@ -286,6 +367,19 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   #assertConnectionAvailable(action: string): void {
     if (this.#transactionState?.active !== undefined)
       throw new Error(`Cannot ${action} while a MySQL query stream owns the transaction connection`);
+    if (this.#transactionState?.batch !== undefined)
+      throw new Error(`Cannot ${action} while a MySQL ordered batch owns the transaction connection`);
+  }
+
+  #assertBatchCanContinue(operation: MySqlBatchOperation): void {
+    this.#assertScopeOpen();
+    if (this.#transactionState?.batch !== operation)
+      throw new Error("This MySQL ordered batch no longer owns the transaction connection");
+  }
+
+  async #settleBatch(): Promise<void> {
+    const batch = this.#transactionState?.batch;
+    if (batch !== undefined) await batch.completion;
   }
 
   #assertScopeOpen(): void {

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -84,16 +84,17 @@ export const mysqlRenderer: SqlRenderer = Object.freeze({
 
 interface MySqlTransactionConnectionState {
   active: QueryStream<unknown> | undefined;
-  batch: MySqlBatchOperation | undefined;
+  batch: MySqlConnectionOperation | undefined;
+  execute: MySqlConnectionOperation | undefined;
   usable: boolean;
 }
 
-interface MySqlBatchOperation {
+interface MySqlConnectionOperation {
   readonly completion: Promise<void>;
   finish(): void;
 }
 
-function createMySqlBatchOperation(): MySqlBatchOperation {
+function createMySqlConnectionOperation(): MySqlConnectionOperation {
   let finish!: () => void;
   const completion = new Promise<void>((resolve) => {
     finish = resolve;
@@ -109,6 +110,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #decimal: ((value: string) => unknown) | undefined;
   readonly #depth: number;
   readonly #prepared: MySqlPreparedQueryState;
+  readonly #executes: Set<MySqlConnectionOperation> | undefined;
   readonly #streams: Set<QueryStream<unknown>> | undefined;
   readonly #transactionState: MySqlTransactionConnectionState | undefined;
   #scopeOpen = true;
@@ -130,6 +132,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     this.#decimal = decimal;
     this.#depth = depth;
     this.#prepared = prepared;
+    this.#executes = connection === undefined ? undefined : new Set();
     this.#streams = connection === undefined ? undefined : new Set();
     this.#transactionState = transactionState;
   }
@@ -137,7 +140,17 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
     this.#assertScopeOpen();
     this.#assertConnectionAvailable("execute a query");
-    return this.#executeOn(this.#connection ?? this.#pool, query);
+    if (this.#connection === undefined) return this.#executeOn(this.#pool, query);
+    const operation = createMySqlConnectionOperation();
+    this.#executes!.add(operation);
+    this.#transactionState!.execute = operation;
+    try {
+      return await this.#executeOn(this.#connection, query);
+    } finally {
+      this.#executes!.delete(operation);
+      if (this.#transactionState?.execute === operation) this.#transactionState.execute = undefined;
+      operation.finish();
+    }
   }
 
   async #executeOn<Row, Params extends readonly unknown[]>(
@@ -159,7 +172,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     const orderedQueries = [...queries] as unknown as QueryBatch<Queries>;
 
     if (this.#connection !== undefined) {
-      const operation = createMySqlBatchOperation();
+      const operation = createMySqlConnectionOperation();
       this.#transactionState!.batch = operation;
       try {
         return await this.#executeBatchOn(this.#connection, orderedQueries, () =>
@@ -256,7 +269,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         this.#decimal,
         1,
         this.#prepared,
-        { active: undefined, batch: undefined, usable: true },
+        { active: undefined, batch: undefined, execute: undefined, usable: true },
       );
       result = await fn(transaction);
       transaction.#scopeOpen = false;
@@ -341,10 +354,13 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async #invalidateScope(): Promise<void> {
     this.#scopeOpen = false;
     await this.#closeStreams();
+    await this.#settleExecutes();
     await this.#settleBatch();
   }
 
   async #assertTransactionReadyForFinalize(connectionFinalizing = false): Promise<void> {
+    const leakedExecutes = new Set(this.#executes);
+    if (this.#transactionState?.execute !== undefined) leakedExecutes.add(this.#transactionState.execute);
     const leakedBatch = this.#transactionState?.batch;
     await this.#rejectActiveStreams();
     const active = this.#transactionState?.active;
@@ -352,6 +368,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       await Promise.allSettled([active.close()]);
       throw new Error(
         "MySQL transaction callback returned while a nested query stream owned its connection; await nested work and close every stream before returning",
+      );
+    }
+    if (leakedExecutes.size > 0) {
+      await this.#settleExecuteOperations(leakedExecutes);
+      throw new Error(
+        "MySQL transaction callback returned while an execute operation owned its connection; await execute before returning",
       );
     }
     if (leakedBatch !== undefined) {
@@ -369,9 +391,11 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       throw new Error(`Cannot ${action} while a MySQL query stream owns the transaction connection`);
     if (this.#transactionState?.batch !== undefined)
       throw new Error(`Cannot ${action} while a MySQL ordered batch owns the transaction connection`);
+    if (this.#transactionState?.execute !== undefined)
+      throw new Error(`Cannot ${action} while a MySQL execute operation owns the transaction connection`);
   }
 
-  #assertBatchCanContinue(operation: MySqlBatchOperation): void {
+  #assertBatchCanContinue(operation: MySqlConnectionOperation): void {
     this.#assertScopeOpen();
     if (this.#transactionState?.batch !== operation)
       throw new Error("This MySQL ordered batch no longer owns the transaction connection");
@@ -380,6 +404,18 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async #settleBatch(): Promise<void> {
     const batch = this.#transactionState?.batch;
     if (batch !== undefined) await batch.completion;
+  }
+
+  async #settleExecutes(): Promise<void> {
+    const operations = new Set(this.#executes);
+    if (this.#transactionState?.execute !== undefined) operations.add(this.#transactionState.execute);
+    await this.#settleExecuteOperations(operations);
+  }
+
+  async #settleExecuteOperations(operations: ReadonlySet<MySqlConnectionOperation>): Promise<void> {
+    for (const operation of operations) {
+      await operation.completion;
+    }
   }
 
   #assertScopeOpen(): void {

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,5 +1,13 @@
 import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
+import {
+  createMySqlPreparedQueryState,
+  type MySqlPreparedQueryFactory,
+  type MySqlPreparedQueryState,
+  prepareMySqlQuery,
+} from "./prepared.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
+
+export type { MySqlPreparedQueryFactory } from "./prepared.js";
 
 export interface MySqlFieldLike {
   readonly name: string;
@@ -27,9 +35,18 @@ export interface MySqlPoolLike {
   end(): Promise<void>;
 }
 
-export interface MySqlTransaction extends Database<MySqlTransaction> {}
+export interface MySqlTransaction extends Database<MySqlTransaction> {
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): MySqlPreparedQueryFactory<Arguments, Row, Params>;
+}
 
 export interface MySqlDatabase extends Database<MySqlTransaction> {
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): MySqlPreparedQueryFactory<Arguments, Row, Params>;
   close(): Promise<void>;
 }
 
@@ -162,6 +179,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #typePolicy: ResolvedMySqlRuntimeTypePolicy;
   readonly #decimal: ((value: string) => unknown) | undefined;
   readonly #depth: number;
+  readonly #prepared: MySqlPreparedQueryState;
 
   constructor(
     pool: MySqlPoolLike,
@@ -170,6 +188,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     typePolicy: ResolvedMySqlRuntimeTypePolicy,
     decimal: ((value: string) => unknown) | undefined,
     depth: number,
+    prepared: MySqlPreparedQueryState,
   ) {
     this.#pool = pool;
     this.#connection = connection;
@@ -177,14 +196,23 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     this.#typePolicy = typePolicy;
     this.#decimal = decimal;
     this.#depth = depth;
+    this.#prepared = prepared;
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
-    const rendered = renderQuery(query, mysqlRenderer);
+    const prepared = this.#prepared.queries.get(query);
+    const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
     const result = await (this.#connection ?? this.#pool).execute(rendered.text, rendered.values.map(encoded));
     if (!Array.isArray(result.rows)) return [];
     const decoders = compileRowDecoders(result.fields ?? [], this.#typePolicy, this.#decimal);
     return decodeRows(result.rows, decoders) as unknown as readonly Row[];
+  }
+
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): MySqlPreparedQueryFactory<Arguments, Row, Params> {
+    return prepareMySqlQuery(this.#prepared, mysqlRenderer, statementName, factory);
   }
 
   async transaction<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
@@ -194,7 +222,15 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     try {
       await connection.beginTransaction();
       result = await fn(
-        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#typePolicy, this.#decimal, 1),
+        new MySqlDatabaseImplementation(
+          this.#pool,
+          connection,
+          false,
+          this.#typePolicy,
+          this.#decimal,
+          1,
+          this.#prepared,
+        ),
       );
       await connection.commit();
     } catch (error) {
@@ -221,7 +257,15 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     await connection.query(`SAVEPOINT ${savepoint}`);
     try {
       const result = await fn(
-        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#typePolicy, this.#decimal, depth),
+        new MySqlDatabaseImplementation(
+          this.#pool,
+          connection,
+          false,
+          this.#typePolicy,
+          this.#decimal,
+          depth,
+          this.#prepared,
+        ),
       );
       await connection.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
@@ -252,5 +296,6 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     typePolicy,
     options.decimal,
     0,
+    createMySqlPreparedQueryState(),
   );
 }

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -27,7 +27,9 @@ export interface MySqlPoolLike {
   end(): Promise<void>;
 }
 
-export interface MySqlDatabase extends Database {
+export interface MySqlTransaction extends Database<MySqlTransaction> {}
+
+export interface MySqlDatabase extends Database<MySqlTransaction> {
   close(): Promise<void>;
 }
 
@@ -185,7 +187,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     return decodeRows(result.rows, decoders) as unknown as readonly Row[];
   }
 
-  async transaction<T>(fn: (database: Database) => Promise<T>): Promise<T> {
+  async transaction<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
     if (this.#connection !== undefined) return this.#nested(fn);
     const connection = await this.#pool.getConnection();
     let result: T;
@@ -212,7 +214,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     return result;
   }
 
-  async #nested<T>(fn: (database: Database) => Promise<T>): Promise<T> {
+  async #nested<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
     const connection = this.#connection!;
     const depth = this.#depth + 1;
     const savepoint = `typed_sql_${depth}`;

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,26 +1,37 @@
-import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
+import {
+  type Database,
+  type Query,
+  type QueryStream,
+  renderQuery,
+  type SqlRenderer,
+  type StreamOptions,
+} from "@typed-sql/core";
+import {
+  compileMySqlRowDecoders,
+  decodeMySqlRows,
+  encodeMySqlValue,
+  type MySqlFieldLike,
+  type MySqlRuntimeTypePolicy,
+} from "./decoding.js";
 import {
   createMySqlPreparedQueryState,
   type MySqlPreparedQueryFactory,
   type MySqlPreparedQueryState,
   prepareMySqlQuery,
 } from "./prepared.js";
+import { createMySqlQueryStream, type MySqlStreamingConnection, validateMySqlStreamBatchSize } from "./stream.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
 
+export type { MySqlFieldLike } from "./decoding.js";
 export type { MySqlPreparedQueryFactory } from "./prepared.js";
-
-export interface MySqlFieldLike {
-  readonly name: string;
-  readonly columnType: number;
-  readonly columnLength?: number;
-}
+export type { MySqlProtocolStream } from "./stream.js";
 
 export interface MySqlExecutionResult {
   readonly rows: readonly Record<string, unknown>[] | Record<string, unknown>;
   readonly fields?: readonly MySqlFieldLike[];
 }
 
-export interface MySqlConnectionLike {
+export interface MySqlConnectionLike extends MySqlStreamingConnection {
   execute(sql: string, values?: readonly unknown[]): Promise<MySqlExecutionResult>;
   query(sql: string): Promise<MySqlExecutionResult>;
   beginTransaction(): Promise<void>;
@@ -36,6 +47,7 @@ export interface MySqlPoolLike {
 }
 
 export interface MySqlTransaction extends Database<MySqlTransaction> {
+  stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
@@ -43,6 +55,7 @@ export interface MySqlTransaction extends Database<MySqlTransaction> {
 }
 
 export interface MySqlDatabase extends Database<MySqlTransaction> {
+  stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
@@ -57,138 +70,39 @@ export interface MySqlDatabaseOptions {
   readonly decimal?: (value: string) => unknown;
 }
 
-type ResolvedMySqlRuntimeTypePolicy = Pick<MySqlTypePolicy, "bigint" | "decimal" | "date" | "json" | "tinyint1">;
-
-type ValueDecoder = (value: unknown) => unknown;
-
-interface ColumnDecoder {
-  readonly name: string;
-  readonly decode: ValueDecoder;
-}
-
-const defaultRuntimeTypePolicy: ResolvedMySqlRuntimeTypePolicy = defaultMySqlTypePolicy;
-
-const mysqlTypes = { tiny: 1, longlong: 8, date: 10, datetime: 12, timestamp: 7, json: 245, decimal: 246 } as const;
+const defaultRuntimeTypePolicy: MySqlRuntimeTypePolicy = defaultMySqlTypePolicy;
 
 export const mysqlRenderer: SqlRenderer = Object.freeze({
   placeholder: () => "?",
   quoteIdentifier: (identifier: string) => `\`${identifier.replaceAll("`", "``")}\``,
 });
 
-function encoded(value: unknown): unknown {
-  return typeof value === "bigint" ? value.toString() : Array.isArray(value) ? value.map(encoded) : value;
-}
-
-function finite(value: string, label: string): number {
-  const result = Number(value);
-  if (!Number.isFinite(result))
-    throw new RangeError(`${label} value ${value} cannot be represented as a finite number`);
-  return result;
-}
-
-function nullable(decoder: ValueDecoder): ValueDecoder {
-  return (value) => (value === null || value === undefined ? value : decoder(value));
-}
-
-function compileValueDecoder(
-  field: MySqlFieldLike,
-  typePolicy: ResolvedMySqlRuntimeTypePolicy,
-  decimal?: (value: string) => unknown,
-): ValueDecoder | undefined {
-  if (field.columnType === mysqlTypes.longlong) {
-    if (typePolicy.bigint === "bigint") return nullable((value) => BigInt(String(value)));
-    if (typePolicy.bigint === "number")
-      return nullable((value) => {
-        const result = finite(String(value), "bigint");
-        if (!Number.isSafeInteger(result))
-          throw new RangeError(`bigint value ${value} exceeds JavaScript's safe integer range`);
-        return result;
-      });
-    return nullable((value) => String(value));
-  }
-  if (field.columnType === mysqlTypes.decimal) {
-    if (typePolicy.decimal === "number") return nullable((value) => finite(String(value), "decimal"));
-    if (typePolicy.decimal === "Decimal") {
-      if (decimal === undefined) throw new TypeError("decimal=Decimal requires a decimal(value) codec");
-      return nullable((value) => decimal(String(value)));
-    }
-    return nullable((value) => String(value));
-  }
-  if (
-    field.columnType === mysqlTypes.date ||
-    field.columnType === mysqlTypes.datetime ||
-    field.columnType === mysqlTypes.timestamp
-  ) {
-    return typePolicy.date === "string"
-      ? nullable((value) => String(value))
-      : nullable((value) => (value instanceof Date ? value : new Date(String(value))));
-  }
-  if (field.columnType === mysqlTypes.json && typePolicy.json === "string")
-    return nullable((value) => (typeof value === "string" ? value : JSON.stringify(value)));
-  if (field.columnType === mysqlTypes.tiny && field.columnLength === 1 && typePolicy.tinyint1 === "boolean")
-    return nullable((value) => value === true || value === 1 || value === "1");
-  return undefined;
-}
-
-function compileRowDecoders(
-  fields: readonly MySqlFieldLike[],
-  typePolicy: ResolvedMySqlRuntimeTypePolicy,
-  decimal?: (value: string) => unknown,
-): readonly ColumnDecoder[] {
-  const decoders: ColumnDecoder[] = [];
-  const visited = new Set<string>();
-  for (const field of fields) {
-    // Preserve established behavior: the first metadata entry for a row property owns its decoding.
-    if (visited.has(field.name)) continue;
-    visited.add(field.name);
-    const decode = compileValueDecoder(field, typePolicy, decimal);
-    if (decode !== undefined) decoders.push({ name: field.name, decode });
-  }
-  return decoders;
-}
-
-function decodeRows(
-  rows: readonly Record<string, unknown>[],
-  decoders: readonly ColumnDecoder[],
-): readonly Record<string, unknown>[] {
-  if (decoders.length === 0) return rows;
-  // Keep driver objects intact until a codec produces a different value for that specific row.
-  let decodedRows: Record<string, unknown>[] | undefined;
-  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
-    const row = rows[rowIndex]!;
-    let decodedRow: Record<string, unknown> | undefined;
-    for (const column of decoders) {
-      if (!Object.prototype.propertyIsEnumerable.call(row, column.name)) continue;
-      const value = row[column.name];
-      const decoded = column.decode(value);
-      if (Object.is(decoded, value)) continue;
-      decodedRow ??= { ...row };
-      decodedRow[column.name] = decoded;
-    }
-    if (decodedRow === undefined) continue;
-    decodedRows ??= rows.slice() as Record<string, unknown>[];
-    decodedRows[rowIndex] = decodedRow;
-  }
-  return decodedRows ?? rows;
+interface MySqlTransactionConnectionState {
+  active: QueryStream<unknown> | undefined;
+  usable: boolean;
 }
 
 class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #pool: MySqlPoolLike;
   readonly #connection: MySqlConnectionLike | undefined;
   readonly #ownsPool: boolean;
-  readonly #typePolicy: ResolvedMySqlRuntimeTypePolicy;
+  readonly #typePolicy: MySqlRuntimeTypePolicy;
   readonly #decimal: ((value: string) => unknown) | undefined;
   readonly #depth: number;
   readonly #prepared: MySqlPreparedQueryState;
+  readonly #streams: Set<QueryStream<unknown>> | undefined;
+  readonly #transactionState: MySqlTransactionConnectionState | undefined;
+  #scopeOpen = true;
 
   constructor(
     pool: MySqlPoolLike,
     connection: MySqlConnectionLike | undefined,
     ownsPool: boolean,
-    typePolicy: ResolvedMySqlRuntimeTypePolicy,
+    typePolicy: MySqlRuntimeTypePolicy,
     decimal: ((value: string) => unknown) | undefined,
     depth: number,
     prepared: MySqlPreparedQueryState,
+    transactionState?: MySqlTransactionConnectionState,
   ) {
     this.#pool = pool;
     this.#connection = connection;
@@ -197,43 +111,91 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     this.#decimal = decimal;
     this.#depth = depth;
     this.#prepared = prepared;
+    this.#streams = connection === undefined ? undefined : new Set();
+    this.#transactionState = transactionState;
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
+    this.#assertScopeOpen();
+    this.#assertConnectionAvailable("execute a query");
     const prepared = this.#prepared.queries.get(query);
     const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
-    const result = await (this.#connection ?? this.#pool).execute(rendered.text, rendered.values.map(encoded));
+    const result = await (this.#connection ?? this.#pool).execute(rendered.text, rendered.values.map(encodeMySqlValue));
     if (!Array.isArray(result.rows)) return [];
-    const decoders = compileRowDecoders(result.fields ?? [], this.#typePolicy, this.#decimal);
-    return decodeRows(result.rows, decoders) as unknown as readonly Row[];
+    const decoders = compileMySqlRowDecoders(result.fields ?? [], this.#typePolicy, this.#decimal);
+    return decodeMySqlRows(result.rows, decoders) as unknown as readonly Row[];
+  }
+
+  stream<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    options: StreamOptions = {},
+  ): QueryStream<Row> {
+    this.#assertScopeOpen();
+    const prepared = this.#prepared.queries.get(query);
+    const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
+    const batchSize = validateMySqlStreamBatchSize(options.batchSize);
+    let queryStream: QueryStream<Row>;
+    queryStream = createMySqlQueryStream<Row>({
+      openConnection: async () => {
+        if (this.#connection !== undefined) {
+          this.#assertScopeOpen();
+          this.#assertConnectionAvailable("start another query stream");
+          this.#transactionState!.active = queryStream as QueryStream<unknown>;
+          return { connection: this.#connection, release: false };
+        }
+        return { connection: await this.#pool.getConnection(), release: true };
+      },
+      text: rendered.text,
+      values: rendered.values.map(encodeMySqlValue),
+      batchSize,
+      typePolicy: this.#typePolicy,
+      ...(this.#decimal === undefined ? {} : { decimal: this.#decimal }),
+      onClose: () => {
+        this.#streams?.delete(queryStream as QueryStream<unknown>);
+        if (this.#transactionState?.active === queryStream) this.#transactionState.active = undefined;
+      },
+    });
+    this.#streams?.add(queryStream as QueryStream<unknown>);
+    return queryStream;
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
   ): MySqlPreparedQueryFactory<Arguments, Row, Params> {
+    this.#assertScopeOpen();
     return prepareMySqlQuery(this.#prepared, mysqlRenderer, statementName, factory);
   }
 
   async transaction<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
+    this.#assertScopeOpen();
     if (this.#connection !== undefined) return this.#nested(fn);
     const connection = await this.#pool.getConnection();
+    let transaction: MySqlDatabaseImplementation | undefined;
     let result: T;
     try {
       await connection.beginTransaction();
-      result = await fn(
-        new MySqlDatabaseImplementation(
-          this.#pool,
-          connection,
-          false,
-          this.#typePolicy,
-          this.#decimal,
-          1,
-          this.#prepared,
-        ),
+      transaction = new MySqlDatabaseImplementation(
+        this.#pool,
+        connection,
+        false,
+        this.#typePolicy,
+        this.#decimal,
+        1,
+        this.#prepared,
+        { active: undefined, usable: true },
       );
+      result = await fn(transaction);
+      transaction.#scopeOpen = false;
+      transaction.#transactionState!.usable = false;
+      await transaction.#assertTransactionReadyForFinalize(true);
       await connection.commit();
     } catch (error) {
+      if (transaction !== undefined) {
+        transaction.#scopeOpen = false;
+        transaction.#transactionState!.usable = false;
+        await transaction.#invalidateScope();
+      }
       try {
         await connection.rollback();
       } catch {
@@ -251,32 +213,84 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async #nested<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
+    this.#assertScopeOpen();
+    this.#assertConnectionAvailable("start a nested transaction");
     const connection = this.#connection!;
     const depth = this.#depth + 1;
     const savepoint = `typed_sql_${depth}`;
     await connection.query(`SAVEPOINT ${savepoint}`);
+    let transaction: MySqlDatabaseImplementation | undefined;
     try {
-      const result = await fn(
-        new MySqlDatabaseImplementation(
-          this.#pool,
-          connection,
-          false,
-          this.#typePolicy,
-          this.#decimal,
-          depth,
-          this.#prepared,
-        ),
+      transaction = new MySqlDatabaseImplementation(
+        this.#pool,
+        connection,
+        false,
+        this.#typePolicy,
+        this.#decimal,
+        depth,
+        this.#prepared,
+        this.#transactionState,
       );
+      const result = await fn(transaction);
+      transaction.#scopeOpen = false;
+      await transaction.#assertTransactionReadyForFinalize();
       await connection.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
-      try {
-        await connection.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
-      } catch {
-        /* Preserve the original failure. */
+      if (transaction !== undefined) await transaction.#invalidateScope();
+      if (this.#transactionState?.usable !== false) {
+        try {
+          await connection.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+        } catch {
+          /* Preserve the original failure. */
+        }
       }
       throw error;
     }
+  }
+
+  async #rejectActiveStreams(): Promise<void> {
+    if (this.#streams === undefined || this.#streams.size === 0) return;
+    const active = [...this.#streams];
+    await Promise.allSettled(active.map((stream) => stream.close()));
+    throw new Error(
+      `MySQL transaction callback returned with ${active.length} active query stream${active.length === 1 ? "" : "s"}; consume or close every stream before returning`,
+    );
+  }
+
+  async #closeStreams(): Promise<void> {
+    const streams = new Set(this.#streams);
+    if (this.#transactionState?.active !== undefined) streams.add(this.#transactionState.active);
+    if (streams.size === 0) return;
+    await Promise.allSettled([...streams].map((stream) => stream.close()));
+  }
+
+  async #invalidateScope(): Promise<void> {
+    this.#scopeOpen = false;
+    await this.#closeStreams();
+  }
+
+  async #assertTransactionReadyForFinalize(connectionFinalizing = false): Promise<void> {
+    await this.#rejectActiveStreams();
+    const active = this.#transactionState?.active;
+    if (active !== undefined) {
+      await Promise.allSettled([active.close()]);
+      throw new Error(
+        "MySQL transaction callback returned while a nested query stream owned its connection; await nested work and close every stream before returning",
+      );
+    }
+    if (!connectionFinalizing && this.#transactionState?.usable === false)
+      throw new Error("This MySQL transaction connection is no longer active");
+  }
+
+  #assertConnectionAvailable(action: string): void {
+    if (this.#transactionState?.active !== undefined)
+      throw new Error(`Cannot ${action} while a MySQL query stream owns the transaction connection`);
+  }
+
+  #assertScopeOpen(): void {
+    if (this.#connection !== undefined && (!this.#scopeOpen || this.#transactionState?.usable === false))
+      throw new Error("This MySQL transaction scope is no longer active");
   }
 
   async close(): Promise<void> {
@@ -286,7 +300,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
 }
 
 export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabase {
-  const typePolicy: ResolvedMySqlRuntimeTypePolicy = { ...defaultRuntimeTypePolicy, ...options.typePolicy };
+  const typePolicy: MySqlRuntimeTypePolicy = { ...defaultRuntimeTypePolicy, ...options.typePolicy };
   if (typePolicy.decimal === "Decimal" && options.decimal === undefined)
     throw new TypeError("decimal=Decimal requires a decimal(value) codec");
   return new MySqlDatabaseImplementation(

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -38,7 +38,16 @@ export interface MySqlDatabaseOptions {
   readonly decimal?: (value: string) => unknown;
 }
 
-const defaultRuntimePolicy = defaultMySqlTypePolicy;
+type ResolvedMySqlRuntimeTypePolicy = Pick<MySqlTypePolicy, "bigint" | "decimal" | "date" | "json" | "tinyint1">;
+
+type ValueDecoder = (value: unknown) => unknown;
+
+interface ColumnDecoder {
+  readonly name: string;
+  readonly decode: ValueDecoder;
+}
+
+const defaultRuntimeTypePolicy: ResolvedMySqlRuntimeTypePolicy = defaultMySqlTypePolicy;
 
 const mysqlTypes = { tiny: 1, longlong: 8, date: 10, datetime: 12, timestamp: 7, json: 245, decimal: 246 } as const;
 
@@ -58,46 +67,97 @@ function finite(value: string, label: string): number {
   return result;
 }
 
-function decode(
-  value: unknown,
+function nullable(decoder: ValueDecoder): ValueDecoder {
+  return (value) => (value === null || value === undefined ? value : decoder(value));
+}
+
+function compileValueDecoder(
   field: MySqlFieldLike,
-  policy: MySqlDatabaseOptions["typePolicy"] & {},
+  typePolicy: ResolvedMySqlRuntimeTypePolicy,
   decimal?: (value: string) => unknown,
-): unknown {
-  if (value === null || value === undefined) return value;
+): ValueDecoder | undefined {
   if (field.columnType === mysqlTypes.longlong) {
-    if (policy.bigint === "bigint") return BigInt(String(value));
-    if (policy.bigint === "number") {
-      const result = finite(String(value), "bigint");
-      if (!Number.isSafeInteger(result))
-        throw new RangeError(`bigint value ${value} exceeds JavaScript's safe integer range`);
-      return result;
-    }
-    return String(value);
+    if (typePolicy.bigint === "bigint") return nullable((value) => BigInt(String(value)));
+    if (typePolicy.bigint === "number")
+      return nullable((value) => {
+        const result = finite(String(value), "bigint");
+        if (!Number.isSafeInteger(result))
+          throw new RangeError(`bigint value ${value} exceeds JavaScript's safe integer range`);
+        return result;
+      });
+    return nullable((value) => String(value));
   }
   if (field.columnType === mysqlTypes.decimal) {
-    if (policy.decimal === "number") return finite(String(value), "decimal");
-    if (policy.decimal === "Decimal") {
+    if (typePolicy.decimal === "number") return nullable((value) => finite(String(value), "decimal"));
+    if (typePolicy.decimal === "Decimal") {
       if (decimal === undefined) throw new TypeError("decimal=Decimal requires a decimal(value) codec");
-      return decimal(String(value));
+      return nullable((value) => decimal(String(value)));
     }
-    return String(value);
+    return nullable((value) => String(value));
   }
-  if ([mysqlTypes.date, mysqlTypes.datetime, mysqlTypes.timestamp].includes(field.columnType as 7 | 10 | 12)) {
-    return policy.date === "string" ? String(value) : value instanceof Date ? value : new Date(String(value));
+  if (
+    field.columnType === mysqlTypes.date ||
+    field.columnType === mysqlTypes.datetime ||
+    field.columnType === mysqlTypes.timestamp
+  ) {
+    return typePolicy.date === "string"
+      ? nullable((value) => String(value))
+      : nullable((value) => (value instanceof Date ? value : new Date(String(value))));
   }
-  if (field.columnType === mysqlTypes.json && policy.json === "string")
-    return typeof value === "string" ? value : JSON.stringify(value);
-  if (field.columnType === mysqlTypes.tiny && field.columnLength === 1 && policy.tinyint1 === "boolean")
-    return value === true || value === 1 || value === "1";
-  return value;
+  if (field.columnType === mysqlTypes.json && typePolicy.json === "string")
+    return nullable((value) => (typeof value === "string" ? value : JSON.stringify(value)));
+  if (field.columnType === mysqlTypes.tiny && field.columnLength === 1 && typePolicy.tinyint1 === "boolean")
+    return nullable((value) => value === true || value === 1 || value === "1");
+  return undefined;
+}
+
+function compileRowDecoders(
+  fields: readonly MySqlFieldLike[],
+  typePolicy: ResolvedMySqlRuntimeTypePolicy,
+  decimal?: (value: string) => unknown,
+): readonly ColumnDecoder[] {
+  const decoders: ColumnDecoder[] = [];
+  const visited = new Set<string>();
+  for (const field of fields) {
+    // Preserve established behavior: the first metadata entry for a row property owns its decoding.
+    if (visited.has(field.name)) continue;
+    visited.add(field.name);
+    const decode = compileValueDecoder(field, typePolicy, decimal);
+    if (decode !== undefined) decoders.push({ name: field.name, decode });
+  }
+  return decoders;
+}
+
+function decodeRows(
+  rows: readonly Record<string, unknown>[],
+  decoders: readonly ColumnDecoder[],
+): readonly Record<string, unknown>[] {
+  if (decoders.length === 0) return rows;
+  // Keep driver objects intact until a codec produces a different value for that specific row.
+  let decodedRows: Record<string, unknown>[] | undefined;
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex]!;
+    let decodedRow: Record<string, unknown> | undefined;
+    for (const column of decoders) {
+      if (!Object.prototype.propertyIsEnumerable.call(row, column.name)) continue;
+      const value = row[column.name];
+      const decoded = column.decode(value);
+      if (Object.is(decoded, value)) continue;
+      decodedRow ??= { ...row };
+      decodedRow[column.name] = decoded;
+    }
+    if (decodedRow === undefined) continue;
+    decodedRows ??= rows.slice() as Record<string, unknown>[];
+    decodedRows[rowIndex] = decodedRow;
+  }
+  return decodedRows ?? rows;
 }
 
 class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #pool: MySqlPoolLike;
   readonly #connection: MySqlConnectionLike | undefined;
   readonly #ownsPool: boolean;
-  readonly #policy: NonNullable<MySqlDatabaseOptions["typePolicy"]>;
+  readonly #typePolicy: ResolvedMySqlRuntimeTypePolicy;
   readonly #decimal: ((value: string) => unknown) | undefined;
   readonly #depth: number;
 
@@ -105,14 +165,14 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     pool: MySqlPoolLike,
     connection: MySqlConnectionLike | undefined,
     ownsPool: boolean,
-    policy: NonNullable<MySqlDatabaseOptions["typePolicy"]>,
+    typePolicy: ResolvedMySqlRuntimeTypePolicy,
     decimal: ((value: string) => unknown) | undefined,
     depth: number,
   ) {
     this.#pool = pool;
     this.#connection = connection;
     this.#ownsPool = ownsPool;
-    this.#policy = policy;
+    this.#typePolicy = typePolicy;
     this.#decimal = decimal;
     this.#depth = depth;
   }
@@ -121,15 +181,8 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     const rendered = renderQuery(query, mysqlRenderer);
     const result = await (this.#connection ?? this.#pool).execute(rendered.text, rendered.values.map(encoded));
     if (!Array.isArray(result.rows)) return [];
-    const fields = result.fields ?? [];
-    return result.rows.map((row) =>
-      Object.fromEntries(
-        Object.entries(row).map(([key, value]) => {
-          const field = fields.find((candidate) => candidate.name === key);
-          return [key, field === undefined ? value : decode(value, field, this.#policy, this.#decimal)];
-        }),
-      ),
-    ) as unknown as readonly Row[];
+    const decoders = compileRowDecoders(result.fields ?? [], this.#typePolicy, this.#decimal);
+    return decodeRows(result.rows, decoders) as unknown as readonly Row[];
   }
 
   async transaction<T>(fn: (database: Database) => Promise<T>): Promise<T> {
@@ -138,7 +191,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     try {
       await connection.beginTransaction();
       const result = await fn(
-        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#policy, this.#decimal, 1),
+        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#typePolicy, this.#decimal, 1),
       );
       await connection.commit();
       return result;
@@ -161,7 +214,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     await connection.query(`SAVEPOINT ${savepoint}`);
     try {
       const result = await fn(
-        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#policy, this.#decimal, depth),
+        new MySqlDatabaseImplementation(this.#pool, connection, false, this.#typePolicy, this.#decimal, depth),
       );
       await connection.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
@@ -178,14 +231,14 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
 }
 
 export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabase {
-  const policy = { ...defaultRuntimePolicy, ...options.typePolicy };
-  if (policy.decimal === "Decimal" && options.decimal === undefined)
+  const typePolicy: ResolvedMySqlRuntimeTypePolicy = { ...defaultRuntimeTypePolicy, ...options.typePolicy };
+  if (typePolicy.decimal === "Decimal" && options.decimal === undefined)
     throw new TypeError("decimal=Decimal requires a decimal(value) codec");
   return new MySqlDatabaseImplementation(
     options.pool,
     undefined,
     options.ownsPool ?? false,
-    policy,
+    typePolicy,
     options.decimal,
     0,
   );

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -188,23 +188,28 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async transaction<T>(fn: (database: Database) => Promise<T>): Promise<T> {
     if (this.#connection !== undefined) return this.#nested(fn);
     const connection = await this.#pool.getConnection();
+    let result: T;
     try {
       await connection.beginTransaction();
-      const result = await fn(
+      result = await fn(
         new MySqlDatabaseImplementation(this.#pool, connection, false, this.#typePolicy, this.#decimal, 1),
       );
       await connection.commit();
-      return result;
     } catch (error) {
       try {
         await connection.rollback();
       } catch {
         /* Preserve the original failure. */
       }
+      try {
+        connection.release();
+      } catch {
+        /* Preserve the original failure. */
+      }
       throw error;
-    } finally {
-      connection.release();
     }
+    connection.release();
+    return result;
   }
 
   async #nested<T>(fn: (database: Database) => Promise<T>): Promise<T> {
@@ -219,7 +224,11 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       await connection.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
-      await connection.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      try {
+        await connection.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      } catch {
+        /* Preserve the original failure. */
+      }
       throw error;
     }
   }

--- a/packages/mysql/src/stream.ts
+++ b/packages/mysql/src/stream.ts
@@ -1,0 +1,226 @@
+import type { QueryStream } from "@typed-sql/core";
+import {
+  compileMySqlRowDecoders,
+  decodeMySqlRow,
+  type MySqlFieldLike,
+  type MySqlRuntimeTypePolicy,
+} from "./decoding.js";
+
+/** A protocol-level MySQL row stream supplied by an execution adapter. */
+export interface MySqlProtocolStream extends AsyncIterableIterator<Record<string, unknown>> {
+  /** Resolves once result metadata is available, before the first row is decoded. */
+  readonly fields: Promise<readonly MySqlFieldLike[]>;
+  /** Whether the leased connection may safely return to its pool after close. */
+  readonly connectionReusable: boolean;
+  /** Stops row delivery and resolves only after the underlying protocol operation terminates. */
+  close(): Promise<void>;
+}
+
+export interface MySqlStreamingConnection {
+  stream?(sql: string, values: readonly unknown[], options: { readonly batchSize: number }): MySqlProtocolStream;
+  release(): void;
+}
+
+interface OpenMySqlStream {
+  readonly connection: MySqlStreamingConnection;
+  readonly release: boolean;
+}
+
+interface ActiveMySqlStream extends OpenMySqlStream {
+  readonly source: MySqlProtocolStream;
+  readonly decoders: ReturnType<typeof compileMySqlRowDecoders>;
+  readonly hasRows: boolean;
+}
+
+export function validateMySqlStreamBatchSize(value: number | undefined): number {
+  const batchSize = value ?? 100;
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0)
+    throw new RangeError("MySQL stream batchSize must be a positive safe integer");
+  return batchSize;
+}
+
+export function createMySqlQueryStream<Row>(options: {
+  readonly openConnection: () => Promise<OpenMySqlStream>;
+  readonly text: string;
+  readonly values: readonly unknown[];
+  readonly batchSize: number;
+  readonly typePolicy: MySqlRuntimeTypePolicy;
+  readonly decimal?: (value: string) => unknown;
+  readonly onClose: () => void;
+}): QueryStream<Row> {
+  return new MySqlQueryStream(options);
+}
+
+class MySqlQueryStream<Row> implements QueryStream<Row> {
+  readonly #openConnection: () => Promise<OpenMySqlStream>;
+  readonly #text: string;
+  readonly #values: readonly unknown[];
+  readonly #batchSize: number;
+  readonly #typePolicy: MySqlRuntimeTypePolicy;
+  readonly #decimal: ((value: string) => unknown) | undefined;
+  readonly #onClose: () => void;
+  #active: ActiveMySqlStream | undefined;
+  #opening: Promise<ActiveMySqlStream> | undefined;
+  #finishing: Promise<void> | undefined;
+  #closed = false;
+  #notifiedClosed = false;
+  #queue = Promise.resolve();
+
+  constructor(options: {
+    readonly openConnection: () => Promise<OpenMySqlStream>;
+    readonly text: string;
+    readonly values: readonly unknown[];
+    readonly batchSize: number;
+    readonly typePolicy: MySqlRuntimeTypePolicy;
+    readonly decimal?: (value: string) => unknown;
+    readonly onClose: () => void;
+  }) {
+    this.#openConnection = options.openConnection;
+    this.#text = options.text;
+    this.#values = options.values;
+    this.#batchSize = options.batchSize;
+    this.#typePolicy = options.typePolicy;
+    this.#decimal = options.decimal;
+    this.#onClose = options.onClose;
+  }
+
+  [Symbol.asyncIterator](): QueryStream<Row> {
+    return this;
+  }
+
+  next(): Promise<IteratorResult<Row>> {
+    return this.#enqueue(() => this.#next());
+  }
+
+  return(): Promise<IteratorResult<Row>> {
+    return this.#enqueue(async () => {
+      await this.#finish();
+      return { done: true, value: undefined };
+    });
+  }
+
+  async throw(error?: unknown): Promise<IteratorResult<Row>> {
+    await this.close();
+    throw error;
+  }
+
+  close(): Promise<void> {
+    return this.#enqueue(() => this.#finish());
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  #enqueue<Value>(operation: () => Promise<Value>): Promise<Value> {
+    const result = this.#queue.then(operation, operation);
+    this.#queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  async #next(): Promise<IteratorResult<Row>> {
+    if (this.#closed) return { done: true, value: undefined };
+    let active: ActiveMySqlStream;
+    try {
+      active = await this.#start();
+      if (!active.hasRows) {
+        await this.#finish();
+        return { done: true, value: undefined };
+      }
+      const result = await active.source.next();
+      if (result.done) {
+        await this.#finish();
+        return { done: true, value: undefined };
+      }
+      const decoded = decodeMySqlRow(result.value, active.decoders) as Row;
+      return { done: false, value: decoded };
+    } catch (error) {
+      try {
+        await this.#finish();
+      } catch {
+        /* Preserve the query or decoding failure. */
+      }
+      throw error;
+    }
+  }
+
+  #start(): Promise<ActiveMySqlStream> {
+    if (this.#opening !== undefined) return this.#opening;
+    this.#opening = this.#open();
+    return this.#opening;
+  }
+
+  async #open(): Promise<ActiveMySqlStream> {
+    const opened = await this.#openConnection();
+    const stream = opened.connection.stream;
+    if (stream === undefined) {
+      if (opened.release) opened.connection.release();
+      this.#closed = true;
+      this.#notifyClosed();
+      throw new Error("This MySQL execution adapter does not support protocol row streaming");
+    }
+    let source: MySqlProtocolStream | undefined;
+    try {
+      source = stream.call(opened.connection, this.#text, this.#values, { batchSize: this.#batchSize });
+      const fields = await source.fields;
+      const decoders = compileMySqlRowDecoders(fields, this.#typePolicy, this.#decimal);
+      const active = { source, decoders, hasRows: fields.length > 0, ...opened };
+      this.#active = active;
+      return active;
+    } catch (error) {
+      if (source !== undefined) {
+        this.#active = { source, decoders: [], hasRows: false, ...opened };
+        try {
+          await this.#finish();
+        } catch {
+          /* Preserve the stream startup failure. */
+        }
+      } else {
+        if (opened.release) {
+          try {
+            opened.connection.release();
+          } catch {
+            /* Preserve the stream startup failure. */
+          }
+        }
+        this.#closed = true;
+        this.#notifyClosed();
+      }
+      throw error;
+    }
+  }
+
+  #finish(): Promise<void> {
+    if (this.#finishing !== undefined) return this.#finishing;
+    this.#closed = true;
+    this.#finishing = this.#cleanup();
+    return this.#finishing;
+  }
+
+  async #cleanup(): Promise<void> {
+    let failure: unknown;
+    try {
+      if (this.#active !== undefined) await this.#active.source.close();
+    } catch (error) {
+      failure = error;
+    } finally {
+      try {
+        if (this.#active?.release && this.#active.source.connectionReusable) this.#active.connection.release();
+      } catch (error) {
+        failure ??= error;
+      } finally {
+        this.#notifyClosed();
+      }
+    }
+    if (failure !== undefined) throw failure;
+  }
+
+  #notifyClosed(): void {
+    if (this.#notifiedClosed) return;
+    this.#notifiedClosed = true;
+    this.#onClose();
+  }
+}

--- a/packages/mysql/test/batch.test.ts
+++ b/packages/mysql/test/batch.test.ts
@@ -1,0 +1,402 @@
+import { type Query, type QueryResults, sql } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import {
+  createMySqlDatabase,
+  type MySqlConnectionLike,
+  type MySqlExecutionResult,
+  type MySqlPoolLike,
+  type MySqlProtocolStream,
+} from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+
+interface Account {
+  readonly id: bigint;
+  readonly email: string;
+}
+
+interface Project {
+  readonly id: bigint;
+  readonly budget: string | null;
+}
+
+const accountQuery = sql.__typed<Account, readonly [bigint]>()`SELECT id, email FROM accounts WHERE id >= ${1n}`;
+const projectQuery = sql.__typed<Project, readonly []>()`SELECT id, budget FROM projects`;
+const commandQuery = sql.__typed<never, readonly []>()`UPDATE accounts SET active = 1`;
+
+class SingleRowStream implements MySqlProtocolStream {
+  readonly fields = Promise.resolve([{ name: "id", columnType: 8 }]);
+  readonly connectionReusable = true;
+  closeCount = 0;
+  #read = false;
+
+  [Symbol.asyncIterator](): MySqlProtocolStream {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<Record<string, unknown>>> {
+    if (this.#read) return { done: true, value: undefined };
+    this.#read = true;
+    return { done: false, value: { id: "1" } };
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+class BatchConnection implements MySqlConnectionLike {
+  readonly events: string[] = [];
+  readonly calls: { readonly sql: string; readonly values?: readonly unknown[] }[] = [];
+  releaseCount = 0;
+  executeCount = 0;
+  failAt: number | undefined;
+  failRelease = false;
+  executeHook: ((index: number) => Promise<void>) | undefined;
+  readonly failure = new Error("batch query failed");
+  readonly streamSource = new SingleRowStream();
+
+  async execute(sqlText: string, values?: readonly unknown[]): Promise<MySqlExecutionResult> {
+    const index = this.executeCount;
+    this.executeCount += 1;
+    this.calls.push({ sql: sqlText, ...(values === undefined ? {} : { values }) });
+    this.events.push(`EXECUTE ${sqlText}`);
+    await this.executeHook?.(index);
+    if (this.failAt === index) throw this.failure;
+    if (sqlText.startsWith("UPDATE")) return { rows: { affectedRows: 1 } };
+    if (sqlText.includes("projects"))
+      return {
+        rows: [{ id: "9", budget: "12.50" }],
+        fields: [
+          { name: "id", columnType: 8 },
+          { name: "budget", columnType: 246 },
+        ],
+      };
+    return {
+      rows: [{ id: "2", email: "alice@example.com" }],
+      fields: [{ name: "id", columnType: 8 }],
+    };
+  }
+
+  stream(): MySqlProtocolStream {
+    this.events.push("STREAM");
+    return this.streamSource;
+  }
+
+  async query(sqlText: string): Promise<MySqlExecutionResult> {
+    this.events.push(sqlText);
+    return { rows: [] };
+  }
+
+  async beginTransaction(): Promise<void> {
+    this.events.push("BEGIN");
+  }
+
+  async commit(): Promise<void> {
+    this.events.push("COMMIT");
+  }
+
+  async rollback(): Promise<void> {
+    this.events.push("ROLLBACK");
+  }
+
+  release(): void {
+    this.releaseCount += 1;
+    this.events.push("RELEASE");
+    if (this.failRelease) throw new Error("release failed");
+  }
+}
+
+class BatchPool implements MySqlPoolLike {
+  readonly connection = new BatchConnection();
+  getConnectionCount = 0;
+  poolExecuteCount = 0;
+
+  async execute(): Promise<MySqlExecutionResult> {
+    this.poolExecuteCount += 1;
+    throw new Error("batch must not execute through the pool");
+  }
+
+  async getConnection(): Promise<MySqlConnectionLike> {
+    this.getConnectionCount += 1;
+    return this.connection;
+  }
+
+  async end(): Promise<void> {}
+}
+
+await describe("MySQL ordered batches", async () => {
+  await it("preserves exact heterogeneous tuple and homogeneous array result types", async () => {
+    const database = createMySqlDatabase({ pool: new BatchPool() });
+    const tuple = await database.batch([accountQuery, projectQuery]);
+    const exactTuple: Assert<Equal<typeof tuple, readonly [readonly Account[], readonly Project[]]>> = true;
+    strict.strictEqual(exactTuple, true);
+
+    const queries = [1n, 2n].map(
+      (id): Query<Account, readonly [bigint]> =>
+        sql.__typed<Account, readonly [bigint]>()`SELECT id, email FROM accounts WHERE id >= ${id}`,
+    );
+    const array = await database.batch(queries);
+    const exactArray: Assert<Equal<typeof array, readonly (readonly Account[])[]>> = true;
+    strict.strictEqual(exactArray, true);
+
+    const invalidBatchInput = async () => {
+      // @ts-expect-error batches accept only typed Query values
+      await database.batch([accountQuery, "not a query"]);
+    };
+    void invalidBatchInput;
+  });
+
+  await it("returns one shared frozen empty tuple without acquiring a connection", async () => {
+    const pool = new BatchPool();
+    const result = await createMySqlDatabase({ pool }).batch([]);
+    const second = await createMySqlDatabase({ pool }).batch([]);
+    const exact: Assert<Equal<typeof result, readonly []>> = true;
+    strict.strictEqual(exact, true);
+    strict.deepStrictEqual(result, []);
+    strict.strictEqual(result, second);
+    strict.ok(Object.isFrozen(result));
+    strict.strictEqual(pool.getConnectionCount, 0);
+  });
+
+  await it("leases one connection, executes in order, decodes rows, and supports command results", async () => {
+    const pool = new BatchPool();
+    const results = await createMySqlDatabase({ pool }).batch([accountQuery, projectQuery, commandQuery]);
+    strict.deepStrictEqual(results, [
+      [{ id: 2n, email: "alice@example.com" }],
+      [{ id: 9n, budget: "12.50" }],
+      [],
+    ] satisfies QueryResults<[typeof accountQuery, typeof projectQuery, typeof commandQuery]>);
+    strict.strictEqual(pool.getConnectionCount, 1);
+    strict.strictEqual(pool.poolExecuteCount, 0);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+    strict.deepStrictEqual(pool.connection.calls, [
+      { sql: "SELECT id, email FROM accounts WHERE id >= ?", values: ["1"] },
+      { sql: "SELECT id, budget FROM projects", values: [] },
+      { sql: "UPDATE accounts SET active = 1", values: [] },
+    ]);
+    strict.ok(!pool.connection.events.includes("BEGIN"));
+  });
+
+  await it("stops at the first failure and preserves it over release cleanup", async () => {
+    const pool = new BatchPool();
+    pool.connection.failAt = 1;
+    pool.connection.failRelease = true;
+    await strict.rejects(
+      () => createMySqlDatabase({ pool }).batch([accountQuery, projectQuery, commandQuery]),
+      pool.connection.failure,
+    );
+    strict.strictEqual(pool.connection.executeCount, 2);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+    strict.ok(!pool.connection.events.includes("BEGIN"));
+  });
+
+  await it("surfaces a release failure after a successful batch without releasing twice", async () => {
+    const pool = new BatchPool();
+    pool.connection.failRelease = true;
+    await strict.rejects(() => createMySqlDatabase({ pool }).batch([accountQuery]), /release failed/);
+    strict.strictEqual(pool.connection.executeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("reuses a transaction connection and rolls back failed transactional batches", async () => {
+    const successfulPool = new BatchPool();
+    const results = await createMySqlDatabase({ pool: successfulPool }).transaction((transaction) =>
+      transaction.batch([accountQuery, projectQuery]),
+    );
+    strict.strictEqual(results[0]?.[0]?.id, 2n);
+    strict.strictEqual(results[1]?.[0]?.budget, "12.50");
+    strict.strictEqual(successfulPool.getConnectionCount, 1);
+    strict.strictEqual(successfulPool.connection.releaseCount, 1);
+    strict.deepStrictEqual(successfulPool.connection.events, [
+      "BEGIN",
+      "EXECUTE SELECT id, email FROM accounts WHERE id >= ?",
+      "EXECUTE SELECT id, budget FROM projects",
+      "COMMIT",
+      "RELEASE",
+    ]);
+
+    const failedPool = new BatchPool();
+    failedPool.connection.failAt = 1;
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool: failedPool }).transaction((transaction) =>
+          transaction.batch([accountQuery, projectQuery, commandQuery]),
+        ),
+      failedPool.connection.failure,
+    );
+    strict.strictEqual(failedPool.connection.executeCount, 2);
+    strict.ok(failedPool.connection.events.includes("ROLLBACK"));
+    strict.ok(!failedPool.connection.events.includes("COMMIT"));
+  });
+
+  await it("rejects a transaction batch while a stream owns the connection", async () => {
+    const pool = new BatchPool();
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      const stream = transaction.stream(sql<{ id: bigint }>`SELECT id FROM accounts`);
+      await stream.next();
+      const dispatched = pool.connection.executeCount;
+      await strict.rejects(() => transaction.batch([accountQuery]), /stream owns the transaction connection/);
+      strict.strictEqual(pool.connection.executeCount, dispatched);
+      await stream.close();
+    });
+  });
+
+  await it("exclusively owns a transaction connection while executing", async () => {
+    const pool = new BatchPool();
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      queryStarted = resolve;
+    });
+    let resumeQuery!: () => void;
+    const resume = new Promise<void>((resolve) => {
+      resumeQuery = resolve;
+    });
+    pool.connection.executeHook = async (index) => {
+      if (index !== 0) return;
+      queryStarted();
+      await resume;
+    };
+
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      const batch = transaction.batch([accountQuery, projectQuery]);
+      await started;
+      await strict.rejects(() => transaction.execute(accountQuery), /ordered batch owns the transaction connection/);
+      await strict.rejects(() => transaction.batch([projectQuery]), /ordered batch owns the transaction connection/);
+      await strict.rejects(
+        () => transaction.transaction(async () => undefined),
+        /ordered batch owns the transaction connection/,
+      );
+      const stream = transaction.stream(accountQuery);
+      await strict.rejects(() => stream.next(), /ordered batch owns the transaction connection/);
+      strict.strictEqual(pool.connection.executeCount, 1);
+      resumeQuery();
+      const results = await batch;
+      strict.strictEqual(results[0]?.[0]?.id, 2n);
+      strict.strictEqual(results[1]?.[0]?.id, 9n);
+    });
+  });
+
+  await it("snapshots the ordered query list before asynchronous work", async () => {
+    const pool = new BatchPool();
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      queryStarted = resolve;
+    });
+    let resumeQuery!: () => void;
+    const resume = new Promise<void>((resolve) => {
+      resumeQuery = resolve;
+    });
+    pool.connection.executeHook = async (index) => {
+      if (index !== 0) return;
+      queryStarted();
+      await resume;
+    };
+    const queries: (typeof accountQuery)[] = [accountQuery, accountQuery];
+    const batch = createMySqlDatabase({ pool }).batch(queries);
+    await started;
+    queries[1] = sql.__typed<Account, readonly [bigint]>()`SELECT id, email FROM archived_accounts WHERE id >= ${2n}`;
+    resumeQuery();
+    await batch;
+    strict.strictEqual(pool.connection.calls[1]?.sql, "SELECT id, email FROM accounts WHERE id >= ?");
+  });
+
+  await it("stops an unawaited outer transaction batch before its second query and rolls back", async () => {
+    const pool = new BatchPool();
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      queryStarted = resolve;
+    });
+    let resumeQuery!: () => void;
+    const resume = new Promise<void>((resolve) => {
+      resumeQuery = resolve;
+    });
+    pool.connection.executeHook = async (index) => {
+      if (index !== 0) return;
+      queryStarted();
+      await resume;
+    };
+    let escapedBatch!: Promise<QueryResults<readonly [typeof accountQuery, typeof projectQuery]>>;
+
+    const transaction = createMySqlDatabase({ pool }).transaction(async (scope) => {
+      escapedBatch = scope.batch([accountQuery, projectQuery]);
+      void escapedBatch.catch(() => undefined);
+      await started;
+    });
+    void transaction.catch(() => undefined);
+    await started;
+    await Promise.resolve();
+    resumeQuery();
+
+    await strict.rejects(() => transaction, /await the batch before returning/);
+    await strict.rejects(() => escapedBatch, /scope is no longer active/);
+    strict.strictEqual(pool.connection.executeCount, 1);
+    strict.ok(pool.connection.events.includes("ROLLBACK"));
+    strict.ok(!pool.connection.events.includes("COMMIT"));
+    strict.ok(pool.connection.events.indexOf("ROLLBACK") < pool.connection.events.indexOf("RELEASE"));
+  });
+
+  await it("stops an unawaited nested batch before outer finalization releases the connection", async () => {
+    const pool = new BatchPool();
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      queryStarted = resolve;
+    });
+    let resumeQuery!: () => void;
+    const resume = new Promise<void>((resolve) => {
+      resumeQuery = resolve;
+    });
+    pool.connection.executeHook = async (index) => {
+      if (index !== 0) return;
+      queryStarted();
+      await resume;
+    };
+    let nestedWork!: Promise<void>;
+    let escapedBatch!: Promise<QueryResults<readonly [typeof accountQuery, typeof projectQuery]>>;
+
+    const outer = createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      nestedWork = transaction.transaction(async (nested) => {
+        escapedBatch = nested.batch([accountQuery, projectQuery]);
+        void escapedBatch.catch(() => undefined);
+        await started;
+      });
+      void nestedWork.catch(() => undefined);
+      await started;
+    });
+    void outer.catch(() => undefined);
+    await started;
+    await Promise.resolve();
+    resumeQuery();
+
+    await strict.rejects(() => outer, /await the batch before returning/);
+    await strict.rejects(() => nestedWork, /await the batch before returning/);
+    await strict.rejects(() => escapedBatch, /scope is no longer active/);
+    strict.strictEqual(pool.connection.executeCount, 1);
+    strict.ok(pool.connection.events.includes("ROLLBACK"));
+    strict.ok(!pool.connection.events.includes("COMMIT"));
+    strict.ok(!pool.connection.events.some((event) => event.startsWith("RELEASE SAVEPOINT")));
+    const releaseIndex = pool.connection.events.indexOf("RELEASE");
+    strict.ok(pool.connection.events.slice(releaseIndex + 1).every((event) => !event.startsWith("EXECUTE")));
+  });
+
+  await it("retains prepared rendering metadata and shared decoding", async () => {
+    const pool = new BatchPool();
+    const database = createMySqlDatabase({ pool });
+    const source = sql<Account>`SELECT id, email FROM accounts WHERE id >= ${1n}`;
+    let segmentReads = 0;
+    const observed = new Proxy(source, {
+      get(target, property, receiver) {
+        if (property === "segments") segmentReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const prepared = database.prepare("batch-accounts", () => observed);
+    const query = prepared();
+    strict.strictEqual(segmentReads, 1);
+    const [rows] = await database.batch([query]);
+    strict.strictEqual(segmentReads, 1);
+    strict.deepStrictEqual(rows, [{ id: 2n, email: "alice@example.com" }]);
+  });
+});

--- a/packages/mysql/test/execute-lifecycle.test.ts
+++ b/packages/mysql/test/execute-lifecycle.test.ts
@@ -1,0 +1,308 @@
+import { sql } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import {
+  createMySqlDatabase,
+  type MySqlConnectionLike,
+  type MySqlExecutionResult,
+  type MySqlPoolLike,
+  type MySqlTransaction,
+} from "../src/runtime.js";
+
+interface Deferred<Value> {
+  readonly promise: Promise<Value>;
+  reject(reason: unknown): void;
+  resolve(value: Value): void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+interface BlockedExecute {
+  readonly result: Deferred<MySqlExecutionResult>;
+  readonly started: Promise<void>;
+  markStarted(): void;
+}
+
+function blockedExecute(): BlockedExecute {
+  const started = deferred<void>();
+  return { result: deferred<MySqlExecutionResult>(), started: started.promise, markStarted: () => started.resolve() };
+}
+
+const accountQuery = sql<{ id: bigint }>`SELECT id FROM accounts`;
+
+function accountResult(id = "1"): MySqlExecutionResult {
+  return { rows: [{ id }], fields: [{ name: "id", columnType: 8 }] };
+}
+
+class ExecuteConnection implements MySqlConnectionLike {
+  readonly events: string[] = [];
+  releaseCount = 0;
+  blockedText: string | undefined;
+  blocked: BlockedExecute | undefined;
+
+  block(sqlText: string): BlockedExecute {
+    const blocked = blockedExecute();
+    this.blockedText = sqlText;
+    this.blocked = blocked;
+    return blocked;
+  }
+
+  execute(sqlText: string): Promise<MySqlExecutionResult> {
+    this.events.push(`EXECUTE ${sqlText}`);
+    if (sqlText === this.blockedText && this.blocked !== undefined) {
+      this.blocked.markStarted();
+      return this.blocked.result.promise;
+    }
+    return Promise.resolve(accountResult());
+  }
+
+  query(sqlText: string): Promise<MySqlExecutionResult> {
+    this.events.push(sqlText);
+    return Promise.resolve({ rows: [] });
+  }
+
+  beginTransaction(): Promise<void> {
+    this.events.push("BEGIN");
+    return Promise.resolve();
+  }
+
+  commit(): Promise<void> {
+    this.events.push("COMMIT");
+    return Promise.resolve();
+  }
+
+  rollback(): Promise<void> {
+    this.events.push("ROLLBACK");
+    return Promise.resolve();
+  }
+
+  release(): void {
+    this.releaseCount += 1;
+    this.events.push("RELEASE");
+  }
+}
+
+class ExecutePool implements MySqlPoolLike {
+  readonly connection = new ExecuteConnection();
+
+  execute(): Promise<MySqlExecutionResult> {
+    throw new Error("transaction tests must use their leased connection");
+  }
+
+  getConnection(): Promise<MySqlConnectionLike> {
+    return Promise.resolve(this.connection);
+  }
+
+  end(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const nextTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+await describe("MySQL transaction execute ownership", async () => {
+  await it("owns the connection synchronously and rejects concurrent transaction work", async () => {
+    const pool = new ExecutePool();
+    const blocked = pool.connection.block("SELECT id FROM accounts");
+
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      const execute = transaction.execute(accountQuery);
+      strict.deepStrictEqual(pool.connection.events, ["BEGIN", "EXECUTE SELECT id FROM accounts"]);
+      await blocked.started;
+
+      await strict.rejects(
+        () => transaction.execute(accountQuery),
+        /execute operation owns the transaction connection/,
+      );
+      await strict.rejects(
+        () => transaction.batch([accountQuery]),
+        /execute operation owns the transaction connection/,
+      );
+      await strict.rejects(
+        () => transaction.transaction(async () => undefined),
+        /execute operation owns the transaction connection/,
+      );
+      const stream = transaction.stream(accountQuery);
+      await strict.rejects(() => stream.next(), /execute operation owns the transaction connection/);
+      strict.strictEqual(pool.connection.events.length, 2);
+
+      blocked.result.resolve(accountResult("2"));
+      strict.deepStrictEqual(await execute, [{ id: 2n }]);
+    });
+
+    strict.deepStrictEqual(pool.connection.events, ["BEGIN", "EXECUTE SELECT id FROM accounts", "COMMIT", "RELEASE"]);
+  });
+
+  await it("settles an unawaited outer execute before reporting misuse and rolling back", async () => {
+    const pool = new ExecutePool();
+    const blocked = pool.connection.block("SELECT id FROM accounts");
+    let escapedExecute!: Promise<readonly { id: bigint }[]>;
+
+    const transaction = createMySqlDatabase({ pool }).transaction(async (scope) => {
+      escapedExecute = scope.execute(accountQuery);
+      void escapedExecute.catch(() => undefined);
+      await blocked.started;
+    });
+    void transaction.catch(() => undefined);
+    await blocked.started;
+    await nextTurn();
+    strict.deepStrictEqual(pool.connection.events, ["BEGIN", "EXECUTE SELECT id FROM accounts"]);
+
+    blocked.result.resolve(accountResult("3"));
+    strict.deepStrictEqual(await escapedExecute, [{ id: 3n }]);
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(pool.connection.events, ["BEGIN", "EXECUTE SELECT id FROM accounts", "ROLLBACK", "RELEASE"]);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("keeps execute misuse primary when the unawaited command rejects late", async () => {
+    const pool = new ExecutePool();
+    const blocked = pool.connection.block("SELECT id FROM accounts");
+    const queryError = new Error("late execute failure");
+    let escapedExecute!: Promise<readonly { id: bigint }[]>;
+
+    const transaction = createMySqlDatabase({ pool }).transaction(async (scope) => {
+      escapedExecute = scope.execute(accountQuery);
+      void escapedExecute.catch(() => undefined);
+      await blocked.started;
+    });
+    void transaction.catch(() => undefined);
+    await blocked.started;
+    await nextTurn();
+    blocked.result.reject(queryError);
+
+    await strict.rejects(() => escapedExecute, queryError);
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(pool.connection.events, ["BEGIN", "EXECUTE SELECT id FROM accounts", "ROLLBACK", "RELEASE"]);
+  });
+
+  await it("preserves callback and awaited-query errors while settling before rollback", async () => {
+    const callbackPool = new ExecutePool();
+    const callbackBlocked = callbackPool.connection.block("SELECT id FROM accounts");
+    const callbackError = new Error("callback failed first");
+    const lateQueryError = new Error("late query failure");
+    let escapedExecute!: Promise<readonly { id: bigint }[]>;
+
+    const callbackTransaction = createMySqlDatabase({ pool: callbackPool }).transaction(async (scope) => {
+      escapedExecute = scope.execute(accountQuery);
+      void escapedExecute.catch(() => undefined);
+      await callbackBlocked.started;
+      throw callbackError;
+    });
+    void callbackTransaction.catch(() => undefined);
+    await callbackBlocked.started;
+    await nextTurn();
+    strict.ok(!callbackPool.connection.events.includes("ROLLBACK"));
+    callbackBlocked.result.reject(lateQueryError);
+    await strict.rejects(() => escapedExecute, lateQueryError);
+    await strict.rejects(() => callbackTransaction, callbackError);
+    strict.deepStrictEqual(callbackPool.connection.events, [
+      "BEGIN",
+      "EXECUTE SELECT id FROM accounts",
+      "ROLLBACK",
+      "RELEASE",
+    ]);
+
+    const queryPool = new ExecutePool();
+    const queryBlocked = queryPool.connection.block("SELECT id FROM accounts");
+    const queryError = new Error("awaited query failure");
+    const queryTransaction = createMySqlDatabase({ pool: queryPool }).transaction((scope) =>
+      scope.execute(accountQuery),
+    );
+    void queryTransaction.catch(() => undefined);
+    await queryBlocked.started;
+    queryBlocked.result.reject(queryError);
+    await strict.rejects(() => queryTransaction, queryError);
+    strict.deepStrictEqual(queryPool.connection.events, [
+      "BEGIN",
+      "EXECUTE SELECT id FROM accounts",
+      "ROLLBACK",
+      "RELEASE",
+    ]);
+  });
+
+  await it("rolls back an unawaited nested execute before releasing its savepoint", async () => {
+    const pool = new ExecutePool();
+    const blocked = pool.connection.block("SELECT id FROM accounts");
+    let escapedExecute!: Promise<readonly { id: bigint }[]>;
+
+    const transaction = createMySqlDatabase({ pool }).transaction(async (parent) => {
+      const nested = parent.transaction(async (scope) => {
+        escapedExecute = scope.execute(accountQuery);
+        void escapedExecute.catch(() => undefined);
+        await blocked.started;
+      });
+      void nested.catch(() => undefined);
+      await blocked.started;
+      await nextTurn();
+      strict.ok(
+        !pool.connection.events.some((event) => event.includes("SAVEPOINT") && event !== "SAVEPOINT typed_sql_2"),
+      );
+      blocked.result.resolve(accountResult("4"));
+      strict.deepStrictEqual(await escapedExecute, [{ id: 4n }]);
+      await strict.rejects(() => nested, /await execute before returning/);
+      await parent.execute(sql`SELECT parent_after_nested`);
+    });
+
+    await transaction;
+    strict.deepStrictEqual(pool.connection.events, [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "EXECUTE SELECT id FROM accounts",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "EXECUTE SELECT parent_after_nested",
+      "COMMIT",
+      "RELEASE",
+    ]);
+  });
+
+  await it("lets the parent settle an execute owned by an unawaited nested scope before release", async () => {
+    const pool = new ExecutePool();
+    const blocked = pool.connection.block("SELECT id FROM accounts");
+    let nestedWork!: Promise<void>;
+    let escapedExecute!: Promise<readonly { id: bigint }[]>;
+    let escapedNested!: MySqlTransaction;
+
+    const transaction = createMySqlDatabase({ pool }).transaction(async (parent) => {
+      nestedWork = parent.transaction(async (nested) => {
+        escapedNested = nested;
+        escapedExecute = nested.execute(accountQuery);
+        void escapedExecute.catch(() => undefined);
+        await blocked.started;
+      });
+      void nestedWork.catch(() => undefined);
+      await blocked.started;
+    });
+    void transaction.catch(() => undefined);
+    await blocked.started;
+    await nextTurn();
+    strict.deepStrictEqual(pool.connection.events, [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "EXECUTE SELECT id FROM accounts",
+    ]);
+
+    blocked.result.resolve(accountResult("5"));
+    strict.deepStrictEqual(await escapedExecute, [{ id: 5n }]);
+    await strict.rejects(() => nestedWork, /await execute before returning/);
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(pool.connection.events, [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "EXECUTE SELECT id FROM accounts",
+      "ROLLBACK",
+      "RELEASE",
+    ]);
+
+    const beforeEscapedDispatch = [...pool.connection.events];
+    await strict.rejects(() => escapedNested.execute(sql`SELECT too_late`), /scope is no longer active/);
+    strict.deepStrictEqual(pool.connection.events, beforeEscapedDispatch);
+  });
+});

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -1,10 +1,35 @@
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 import { sql } from "@typed-sql/core";
 import type { Pool } from "mysql2/promise";
 import { describe, it, strict } from "poku";
 import { adaptMySql2Pool, createMySql2Database, loadMySql2Driver, mysql2 } from "../src/mysql2.js";
 import type { MySqlQueryable, MySqlQueryResult } from "../src/provider.js";
 
+class FakeCallbackCommand extends EventEmitter {
+  readonly readable = new Readable({ objectMode: true, read() {} });
+  highWaterMark: number | undefined;
+
+  stream(options: { readonly highWaterMark?: number }): Readable {
+    this.highWaterMark = options.highWaterMark;
+    return this.readable;
+  }
+}
+
+class FakeCallbackConnection extends EventEmitter {
+  readonly commands: FakeCallbackCommand[] = [];
+  readonly calls: { readonly sql: string; readonly values: readonly unknown[] }[] = [];
+
+  execute(sql: string, values: readonly unknown[]): FakeCallbackCommand {
+    const command = new FakeCallbackCommand();
+    this.commands.push(command);
+    this.calls.push({ sql, values });
+    return command;
+  }
+}
+
 class FakeRawConnection {
+  readonly connection = new FakeCallbackConnection();
   released = false;
   readonly calls: string[] = [];
   executeCount = 0;
@@ -38,10 +63,10 @@ class FakeRawConnection {
 class FakeRawPool extends FakeRawConnection {
   ended = false;
   getConnectionCount = 0;
-  readonly connection = new FakeRawConnection();
+  readonly pooledConnection = new FakeRawConnection();
   async getConnection(): Promise<FakeRawConnection> {
     this.getConnectionCount += 1;
-    return this.connection;
+    return this.pooledConnection;
   }
   async end(): Promise<void> {
     this.ended = true;
@@ -74,7 +99,7 @@ await describe("application-owned mysql2 integration", async () => {
     await connection.commit();
     connection.release();
     await pool.end();
-    strict.strictEqual(raw.connection.released, true);
+    strict.strictEqual(raw.pooledConnection.released, true);
     strict.strictEqual(raw.ended, true);
   });
 
@@ -95,6 +120,90 @@ await describe("application-owned mysql2 integration", async () => {
     await database.close();
     strict.strictEqual(raw.ended, true);
     await strict.rejects(() => createMySql2Database({ connectionUri: "" }), /must not be empty/);
+  });
+
+  await it("streams mysql2 execute protocol rows and waits for the command terminal event before reuse", async () => {
+    const raw = new FakeRawPool();
+    const pool = adaptMySql2Pool(raw as unknown as Pool);
+    const connection = await pool.getConnection();
+    const source = connection.stream!("SELECT ?", [1], { batchSize: 3 });
+    const command = raw.pooledConnection.connection.commands[0]!;
+    strict.strictEqual(command.highWaterMark, 3);
+    strict.deepStrictEqual(raw.pooledConnection.connection.calls, [{ sql: "SELECT ?", values: [1] }]);
+
+    command.emit("fields", [{ name: "value", columnType: 8 }]);
+    command.readable.push({ value: "1" });
+    command.readable.push(null);
+    command.emit("end");
+    strict.deepStrictEqual(await source.fields, [{ name: "value", columnType: 8 }]);
+    strict.deepStrictEqual(await source.next(), { done: false, value: { value: "1" } });
+    strict.deepStrictEqual(await source.next(), { done: true, value: undefined });
+    await source.close();
+    strict.strictEqual(source.connectionReusable, true);
+
+    const draining = connection.stream!("SELECT many", [], { batchSize: 1 });
+    const drainingCommand = raw.pooledConnection.connection.commands[1]!;
+    let closed = false;
+    const close = draining.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    strict.strictEqual(drainingCommand.readable.destroyed, true);
+    strict.strictEqual(closed, false);
+    drainingCommand.emit("end");
+    await close;
+    strict.strictEqual(closed, true);
+    strict.strictEqual(draining.connectionReusable, true);
+  });
+
+  await it("preserves mysql2 protocol failures while making terminal cleanup awaitable", async () => {
+    const raw = new FakeRawPool();
+    const connection = await adaptMySql2Pool(raw as unknown as Pool).getConnection();
+    const source = connection.stream!("SELECT broken", [], { batchSize: 2 });
+    const command = raw.pooledConnection.connection.commands[0]!;
+    const failure = new Error("mysql protocol failed");
+    command.emit("error", failure);
+    command.emit("end");
+    await strict.rejects(() => source.fields, failure);
+    await strict.rejects(() => source.close(), failure);
+    strict.strictEqual(source.connectionReusable, true);
+  });
+
+  await it("normalizes mysql2 command metadata without fields for streamed DML", async () => {
+    const raw = new FakeRawPool();
+    const connection = await adaptMySql2Pool(raw as unknown as Pool).getConnection();
+    const source = connection.stream!("UPDATE accounts SET active = 1", [], { batchSize: 2 });
+    const command = raw.pooledConnection.connection.commands[0]!;
+    command.emit("fields", undefined);
+    command.emit("end");
+    strict.deepStrictEqual(await source.fields, []);
+    await source.close();
+    strict.strictEqual(source.connectionReusable, true);
+  });
+
+  await it("settles fatal connection failures as non-reusable and handles early Readable errors", async () => {
+    const raw = new FakeRawPool();
+    const connection = await adaptMySql2Pool(raw as unknown as Pool).getConnection();
+    const source = connection.stream!("SELECT disconnected", [], { batchSize: 2 });
+    const command = raw.pooledConnection.connection.commands[0]!;
+    const failure = new Error("connection lost");
+    command.emit("fields", [{ name: "value", columnType: 8 }]);
+    const next = source.next();
+    raw.pooledConnection.connection.emit("error", failure);
+    strict.deepStrictEqual(await source.fields, [{ name: "value", columnType: 8 }]);
+    await strict.rejects(() => next, failure);
+    await strict.rejects(() => source.close(), failure);
+    strict.strictEqual(source.connectionReusable, false);
+  });
+
+  await it("rejects metadata and settles cleanup when a connection ends before fields", async () => {
+    const raw = new FakeRawPool();
+    const connection = await adaptMySql2Pool(raw as unknown as Pool).getConnection();
+    const source = connection.stream!("SELECT interrupted", [], { batchSize: 2 });
+    raw.pooledConnection.connection.emit("end");
+    await strict.rejects(() => source.fields, /connection ended before.*completed/);
+    await strict.rejects(() => source.close(), /connection ended before.*completed/);
+    strict.strictEqual(source.connectionReusable, false);
   });
 
   await it("rejects mysql2 settings that would invalidate the runtime type policy", async () => {

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -5,6 +5,7 @@ import type { Pool } from "mysql2/promise";
 import { describe, it, strict } from "poku";
 import { adaptMySql2Pool, createMySql2Database, loadMySql2Driver, mysql2 } from "../src/mysql2.js";
 import type { MySqlQueryable, MySqlQueryResult } from "../src/provider.js";
+import { createMySqlDatabase } from "../src/runtime.js";
 
 class FakeCallbackCommand extends EventEmitter {
   readonly readable = new Readable({ objectMode: true, read() {} });
@@ -34,11 +35,10 @@ class FakeRawConnection {
   readonly calls: string[] = [];
   executeCount = 0;
   queryCount = 0;
-  async execute(
-    sql: string,
-  ): Promise<readonly [readonly Record<string, unknown>[], readonly { name: string; columnType: number }[]]> {
+  async execute(sql: string): Promise<readonly [unknown, (readonly { name: string; columnType: number }[])?]> {
     this.executeCount += 1;
     this.calls.push(sql);
+    if (sql.startsWith("UPDATE")) return [{ affectedRows: 1 }];
     return [[{ value: "1" }], [{ name: "value", columnType: 8 }]];
   }
   async query(sql: string): Promise<readonly [readonly Record<string, unknown>[], readonly never[]]> {
@@ -101,6 +101,19 @@ await describe("application-owned mysql2 integration", async () => {
     await pool.end();
     strict.strictEqual(raw.pooledConnection.released, true);
     strict.strictEqual(raw.ended, true);
+  });
+
+  await it("normalizes native mysql2 DML metadata in an ordered batch", async () => {
+    const raw = new FakeRawPool();
+    const database = createMySqlDatabase({ pool: adaptMySql2Pool(raw as unknown as Pool) });
+    const results = await database.batch([
+      sql<{ value: bigint }>`SELECT 1 AS value`,
+      sql<never>`UPDATE accounts SET active = 1`,
+    ]);
+    strict.deepStrictEqual(results, [[{ value: 1n }], []]);
+    strict.strictEqual(raw.getConnectionCount, 1);
+    strict.strictEqual(raw.pooledConnection.released, true);
+    strict.deepStrictEqual(raw.pooledConnection.calls, ["SELECT 1 AS value", "UPDATE accounts SET active = 1"]);
   });
 
   await it("creates and owns a mysql2 pool without opening a connection", async () => {

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -1,19 +1,23 @@
+import { sql } from "@typed-sql/core";
 import type { Pool } from "mysql2/promise";
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
 import { adaptMySql2Pool, createMySql2Database, loadMySql2Driver, mysql2 } from "../src/mysql2.js";
 import type { MySqlQueryable, MySqlQueryResult } from "../src/provider.js";
 
 class FakeRawConnection {
   released = false;
   readonly calls: string[] = [];
+  executeCount = 0;
+  queryCount = 0;
   async execute(
     sql: string,
   ): Promise<readonly [readonly Record<string, unknown>[], readonly { name: string; columnType: number }[]]> {
+    this.executeCount += 1;
     this.calls.push(sql);
     return [[{ value: "1" }], [{ name: "value", columnType: 8 }]];
   }
   async query(sql: string): Promise<readonly [readonly Record<string, unknown>[], readonly never[]]> {
+    this.queryCount += 1;
     this.calls.push(sql);
     return [[], []];
   }
@@ -33,8 +37,10 @@ class FakeRawConnection {
 
 class FakeRawPool extends FakeRawConnection {
   ended = false;
+  getConnectionCount = 0;
   readonly connection = new FakeRawConnection();
   async getConnection(): Promise<FakeRawConnection> {
+    this.getConnectionCount += 1;
     return this.connection;
   }
   async end(): Promise<void> {
@@ -79,7 +85,13 @@ await describe("application-owned mysql2 integration", async () => {
       poolConfig: { connectionLimit: 2 },
       driverImporter: async () => fakeDriver(raw),
     });
-    strict.deepStrictEqual(await database.execute(sql`SELECT ${1n}`), [{ value: 1n }]);
+    const prepared = database.prepare("select-value", (value: bigint) => sql`SELECT ${value}`);
+    strict.strictEqual(raw.calls.length, 0);
+    strict.strictEqual(raw.getConnectionCount, 0);
+    strict.deepStrictEqual(await database.execute(prepared(1n)), [{ value: 1n }]);
+    strict.strictEqual(raw.executeCount, 1);
+    strict.strictEqual(raw.queryCount, 0);
+    strict.strictEqual(raw.getConnectionCount, 0);
     await database.close();
     strict.strictEqual(raw.ended, true);
     await strict.rejects(() => createMySql2Database({ connectionUri: "" }), /must not be empty/);

--- a/packages/mysql/test/provider-runtime.test.ts
+++ b/packages/mysql/test/provider-runtime.test.ts
@@ -10,10 +10,24 @@ import {
 import {
   createMySqlDatabase,
   type MySqlConnectionLike,
+  type MySqlDatabase,
   type MySqlExecutionResult,
   type MySqlPoolLike,
+  type MySqlTransaction,
   mysqlRenderer,
 } from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+type TransactionCallbackScope = Parameters<Parameters<MySqlDatabase["transaction"]>[0]>[0];
+type NestedTransactionCallbackScope = Parameters<Parameters<MySqlTransaction["transaction"]>[0]>[0];
+
+const transactionScopeIsExact: Assert<Equal<TransactionCallbackScope, MySqlTransaction>> = true;
+const nestedTransactionScopeIsExact: Assert<Equal<NestedTransactionCallbackScope, MySqlTransaction>> = true;
+const transactionScopeOmitsClose: Assert<Equal<Extract<keyof MySqlTransaction, "close">, never>> = true;
+const rootDatabaseRetainsClose: Assert<Equal<Extract<keyof MySqlDatabase, "close">, "close">> = true;
+void [transactionScopeIsExact, nestedTransactionScopeIsExact, transactionScopeOmitsClose, rootDatabaseRetainsClose];
 
 class CatalogClient implements MySqlQueryable {
   readonly calls: { readonly sql: string; readonly values?: readonly unknown[] }[] = [];

--- a/packages/mysql/test/provider-runtime.test.ts
+++ b/packages/mysql/test/provider-runtime.test.ts
@@ -1,5 +1,5 @@
+import { type Query, type QueryParameters, type QueryRow, sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
 import {
   introspectMySql,
   type MySqlQueryable,
@@ -13,6 +13,7 @@ import {
   type MySqlDatabase,
   type MySqlExecutionResult,
   type MySqlPoolLike,
+  type MySqlPreparedQueryFactory,
   type MySqlTransaction,
   mysqlRenderer,
 } from "../src/runtime.js";
@@ -140,9 +141,11 @@ function resultRows(): MySqlExecutionResult {
 
 class FakePool implements MySqlPoolLike {
   readonly connection = new FakeConnection();
+  readonly calls: { readonly sql: string; readonly values?: readonly unknown[] }[] = [];
   ended = false;
   commandResult = false;
-  async execute(): Promise<MySqlExecutionResult> {
+  async execute(sqlText: string, values?: readonly unknown[]): Promise<MySqlExecutionResult> {
+    this.calls.push({ sql: sqlText, ...(values === undefined ? {} : { values }) });
     return this.commandResult ? { rows: { affectedRows: 1 } } : resultRows();
   }
   async getConnection(): Promise<MySqlConnectionLike> {
@@ -204,6 +207,130 @@ await describe("MySQL provider and runtime", async () => {
     await database.close();
     strict.strictEqual(pool.ended, true);
     strict.strictEqual(mysqlRenderer.quoteIdentifier("a`b"), "`a``b`");
+  });
+
+  await it("creates lazy prepared factories that retain exact query types", async () => {
+    const pool = new FakePool();
+    const database = createMySqlDatabase({ pool });
+    const accountById = database.prepare(
+      "account-by-id",
+      (id: bigint, active: boolean) =>
+        sql.__typed<
+          { id: bigint },
+          readonly [bigint, boolean]
+        >()`SELECT id FROM users WHERE id = ${id} AND active = ${active}`,
+    );
+    const exactFactory: Assert<
+      Equal<
+        typeof accountById,
+        MySqlPreparedQueryFactory<[id: bigint, active: boolean], { id: bigint }, readonly [bigint, boolean]>
+      >
+    > = true;
+    const exactRow: Assert<Equal<QueryRow<ReturnType<typeof accountById>>, { id: bigint }>> = true;
+    const exactParameters: Assert<Equal<QueryParameters<ReturnType<typeof accountById>>, readonly [bigint, boolean]>> =
+      true;
+    void [exactFactory, exactRow, exactParameters];
+
+    strict.strictEqual(accountById.statementName, "account-by-id");
+    strict.strictEqual(pool.calls.length, 0);
+    strict.throws(() => {
+      // @ts-expect-error Prepared factory metadata is readonly.
+      accountById.statementName = "changed";
+    }, /read only|Cannot assign/);
+
+    const rows = await database.execute(accountById(7n, true));
+    strict.strictEqual(rows[0]?.id, 9_007_199_254_740_993n);
+    strict.deepStrictEqual(pool.calls, [
+      { sql: "SELECT id FROM users WHERE id = ? AND active = ?", values: ["7", true] },
+    ]);
+  });
+
+  await it("validates prepared names and reserves them at declaration", () => {
+    const database = createMySqlDatabase({ pool: new FakePool() });
+    strict.throws(() => database.prepare("", () => sql`SELECT 1`), /non-empty.*NUL/);
+    strict.throws(() => database.prepare("bad\0name", () => sql`SELECT 1`), /non-empty.*NUL/);
+    strict.throws(() => database.prepare(1 as unknown as string, () => sql`SELECT 1`), /non-empty.*NUL/);
+    database.prepare("one", () => sql`SELECT 1`);
+    strict.throws(() => database.prepare("one", () => sql`SELECT 1`), /already registered/);
+  });
+
+  await it("rejects structural shape changes before driver dispatch", async () => {
+    const pool = new FakePool();
+    const database = createMySqlDatabase({ pool });
+    const dynamic = database.prepare(
+      "dynamic-account",
+      (projection: "id" | "email") =>
+        sql.__typed<{ id?: bigint; email?: string }, readonly []>()`SELECT ${sql.raw(projection)} FROM users`,
+    );
+
+    await database.execute(dynamic("id"));
+    strict.strictEqual(pool.calls.length, 1);
+    strict.throws(() => dynamic("email"), /must always render the same SQL text/);
+    strict.strictEqual(pool.calls.length, 1);
+  });
+
+  await it("rejects one query object carrying conflicting prepared names", () => {
+    const database = createMySqlDatabase({ pool: new FakePool() });
+    const shared: Query<{ id: bigint }, readonly []> = sql.__typed<{ id: bigint }, readonly []>()`SELECT id FROM users`;
+    const first = database.prepare("first", () => shared);
+    const second = database.prepare("second", () => shared);
+    strict.strictEqual(first(), shared);
+    strict.throws(() => second(), /cannot use both prepared statement "first" and "second"/);
+  });
+
+  await it("shares prepared metadata through transactions and nested transactions", async () => {
+    const pool = new FakePool();
+    const database = createMySqlDatabase({ pool });
+    const rootPrepared = database.prepare("root-prepared", (id: bigint) => sql`SELECT id FROM users WHERE id = ${id}`);
+    let transactionPrepared: MySqlPreparedQueryFactory<[email: string], unknown, readonly [string]> | undefined;
+
+    await database.transaction(async (transaction) => {
+      await transaction.execute(rootPrepared(1n));
+      transactionPrepared = transaction.prepare(
+        "transaction-prepared",
+        (email: string) => sql`SELECT id FROM users WHERE email = ${email}`,
+      );
+      await transaction.transaction(async (nested) => {
+        await nested.execute(transactionPrepared!("a@example.com"));
+      });
+    });
+
+    await database.execute(transactionPrepared!("b@example.com"));
+    strict.deepStrictEqual(pool.connection.commands, [
+      "BEGIN",
+      "SELECT id FROM users WHERE id = ?",
+      "SAVEPOINT typed_sql_2",
+      "SELECT id FROM users WHERE email = ?",
+      "RELEASE SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+    strict.deepStrictEqual(pool.calls, [{ sql: "SELECT id FROM users WHERE email = ?", values: ["b@example.com"] }]);
+    strict.throws(() => database.prepare("transaction-prepared", () => sql`SELECT 1`), /already registered/);
+  });
+
+  await it("caches rendering only in the database instance that prepared the query", async () => {
+    const firstPool = new FakePool();
+    const secondPool = new FakePool();
+    const firstDatabase = createMySqlDatabase({ pool: firstPool });
+    const secondDatabase = createMySqlDatabase({ pool: secondPool });
+    const source = sql<{ id: bigint }>`SELECT id FROM users WHERE id = ${1n}`;
+    let segmentReads = 0;
+    const observed = new Proxy(source, {
+      get(target, property, receiver) {
+        if (property === "segments") segmentReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const prepared = firstDatabase.prepare("database-local", () => observed);
+    const query = prepared();
+    strict.strictEqual(segmentReads, 1);
+
+    await firstDatabase.execute(query);
+    strict.strictEqual(segmentReads, 1);
+    await secondDatabase.execute(query);
+    strict.strictEqual(segmentReads, 2);
+    strict.deepStrictEqual(firstPool.calls, [{ sql: "SELECT id FROM users WHERE id = ?", values: ["1"] }]);
+    strict.deepStrictEqual(secondPool.calls, [{ sql: "SELECT id FROM users WHERE id = ?", values: ["1"] }]);
   });
 
   await it("supports transactions, nested savepoints, rollback, and connection lifecycle", async () => {

--- a/packages/mysql/test/provider-runtime.test.ts
+++ b/packages/mysql/test/provider-runtime.test.ts
@@ -71,14 +71,19 @@ class CatalogClient implements MySqlQueryable {
 
 class FakeConnection implements MySqlConnectionLike {
   readonly commands: string[] = [];
-  released = false;
+  releaseCount = 0;
+  rollbackCount = 0;
+  failRelease = false;
   failRollback = false;
+  failRollbackToSavepoint = false;
   async execute(sqlText: string): Promise<MySqlExecutionResult> {
     this.commands.push(sqlText);
     return resultRows();
   }
   async query(sqlText: string): Promise<MySqlExecutionResult> {
     this.commands.push(sqlText);
+    if (this.failRollbackToSavepoint && sqlText.startsWith("ROLLBACK TO SAVEPOINT"))
+      throw new Error("savepoint rollback failed");
     return { rows: [] };
   }
   async beginTransaction(): Promise<void> {
@@ -89,10 +94,12 @@ class FakeConnection implements MySqlConnectionLike {
   }
   async rollback(): Promise<void> {
     this.commands.push("ROLLBACK");
+    this.rollbackCount += 1;
     if (this.failRollback) throw new Error("rollback failed");
   }
   release(): void {
-    this.released = true;
+    this.releaseCount += 1;
+    if (this.failRelease) throw new Error("release failed");
   }
 }
 
@@ -224,13 +231,79 @@ await describe("MySQL provider and runtime", async () => {
         }),
       /original/,
     );
-    strict.strictEqual(pool.connection.released, true);
+    strict.ok(pool.connection.releaseCount > 0);
     await strict.rejects(
       () => database.transaction(async (transaction) => (transaction as typeof database).close()),
       /Cannot close/,
     );
     await database.close();
     strict.strictEqual(pool.ended, false);
+  });
+
+  await it("preserves nested failures when rolling back a savepoint also fails", async () => {
+    const pool = new FakePool();
+    pool.connection.failRollbackToSavepoint = true;
+    pool.connection.failRelease = true;
+    const database = createMySqlDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) =>
+          transaction.transaction(async () => {
+            throw new Error("original nested failure");
+          }),
+        ),
+      /original nested failure/,
+    );
+
+    strict.deepStrictEqual(pool.connection.commands, [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "ROLLBACK",
+    ]);
+    strict.strictEqual(pool.connection.rollbackCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("preserves decoder failures across outer and nested transaction cleanup", async () => {
+    const createUnsafeDatabase = (pool: FakePool) =>
+      createMySqlDatabase({
+        pool,
+        typePolicy: { bigint: "number", decimal: "string", date: "Date", json: "unknown", tinyint1: "boolean" },
+      });
+
+    const outerPool = new FakePool();
+    outerPool.connection.failRelease = true;
+    outerPool.connection.failRollback = true;
+    await strict.rejects(
+      () => createUnsafeDatabase(outerPool).transaction(async (transaction) => transaction.execute(sql`SELECT 1`)),
+      /safe integer range/,
+    );
+    strict.deepStrictEqual(outerPool.connection.commands, ["BEGIN", "SELECT 1", "ROLLBACK"]);
+    strict.strictEqual(outerPool.connection.rollbackCount, 1);
+    strict.strictEqual(outerPool.connection.releaseCount, 1);
+
+    const nestedPool = new FakePool();
+    nestedPool.connection.failRelease = true;
+    nestedPool.connection.failRollbackToSavepoint = true;
+    nestedPool.connection.failRollback = true;
+    await strict.rejects(
+      () =>
+        createUnsafeDatabase(nestedPool).transaction(async (transaction) =>
+          transaction.transaction(async (nested) => nested.execute(sql`SELECT 1`)),
+        ),
+      /safe integer range/,
+    );
+    strict.deepStrictEqual(nestedPool.connection.commands, [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "SELECT 1",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "ROLLBACK",
+    ]);
+    strict.strictEqual(nestedPool.connection.rollbackCount, 1);
+    strict.strictEqual(nestedPool.connection.releaseCount, 1);
   });
 
   await it("enforces lossless numeric policies and explicit decimal codecs", async () => {

--- a/packages/mysql/test/runtime-decoding.test.ts
+++ b/packages/mysql/test/runtime-decoding.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, strict } from "poku";
+import { sql } from "../../core/src/index.js";
+import {
+  createMySqlDatabase,
+  type MySqlConnectionLike,
+  type MySqlExecutionResult,
+  type MySqlPoolLike,
+} from "../src/runtime.js";
+
+class ResultPool implements MySqlPoolLike {
+  constructor(readonly result: MySqlExecutionResult) {}
+
+  async execute(): Promise<MySqlExecutionResult> {
+    return this.result;
+  }
+
+  async getConnection(): Promise<MySqlConnectionLike> {
+    throw new Error("not used by decoding tests");
+  }
+
+  async end(): Promise<void> {}
+}
+
+async function decode<Row extends Record<string, unknown>>(
+  result: MySqlExecutionResult,
+  options: Omit<Parameters<typeof createMySqlDatabase>[0], "pool"> = {},
+): Promise<readonly Row[]> {
+  return createMySqlDatabase({ pool: new ResultPool(result), ...options }).execute(sql<Row>`SELECT values`);
+}
+
+await describe("MySQL buffered row decoding", async () => {
+  await it("returns the driver result by identity when metadata requires no decoding", async () => {
+    const profile = { plan: "pro" };
+    const row = { profile, ordinary_tinyint: 1, unknown_type: "unchanged" };
+    const rows = [row];
+    const decoded = await decode({
+      rows,
+      fields: [
+        { name: "unknown_type", columnType: 999 },
+        { name: "profile", columnType: 245 },
+        { name: "ordinary_tinyint", columnType: 1, columnLength: 4 },
+      ],
+    });
+    strict.strictEqual(decoded, rows);
+    strict.strictEqual(decoded[0], row);
+    strict.strictEqual(decoded[0]?.profile, profile);
+
+    const withoutMetadata = [{ id: "42" }];
+    strict.strictEqual(await decode({ rows: withoutMetadata }), withoutMetadata);
+  });
+
+  await it("uses reordered metadata, ignores missing metadata, and only copies changed rows", async () => {
+    const nested = { stable: true };
+    const changedRow = { id: "42", already: 7n, untyped: "preserved", nested };
+    const stableRow = { id: 8n, already: 9n, untyped: "also preserved", nested };
+    const rows = [changedRow, stableRow];
+    const decoded = await decode<{
+      id: bigint;
+      already: bigint;
+      untyped: string;
+      nested: { stable: boolean };
+    }>({
+      rows,
+      fields: [
+        { name: "ghost", columnType: 8 },
+        { name: "already", columnType: 8 },
+        { name: "id", columnType: 8 },
+      ],
+    });
+    strict.notStrictEqual(decoded, rows);
+    strict.notStrictEqual(decoded[0], changedRow);
+    strict.strictEqual(decoded[1], stableRow);
+    strict.strictEqual(decoded[0]?.id, 42n);
+    strict.strictEqual(decoded[0]?.already, 7n);
+    strict.strictEqual(decoded[0]?.untyped, "preserved");
+    strict.strictEqual(decoded[0]?.nested, nested);
+  });
+
+  await it("applies every scalar policy codec", async () => {
+    const date = new Date("2026-01-02T03:04:05Z");
+    const numbers = await decode<{
+      id: number;
+      budget: number;
+      created_at: string;
+      profile: string;
+      yes_number: boolean;
+      yes_string: boolean;
+      yes_boolean: boolean;
+      no: boolean;
+    }>(
+      {
+        rows: [
+          {
+            id: "42",
+            budget: "12.50",
+            created_at: date,
+            profile: { plan: "pro" },
+            yes_number: 1,
+            yes_string: "1",
+            yes_boolean: true,
+            no: 0,
+          },
+        ],
+        fields: [
+          { name: "id", columnType: 8 },
+          { name: "budget", columnType: 246 },
+          { name: "created_at", columnType: 7 },
+          { name: "profile", columnType: 245 },
+          { name: "yes_number", columnType: 1, columnLength: 1 },
+          { name: "yes_string", columnType: 1, columnLength: 1 },
+          { name: "yes_boolean", columnType: 1, columnLength: 1 },
+          { name: "no", columnType: 1, columnLength: 1 },
+        ],
+      },
+      {
+        typePolicy: {
+          bigint: "number",
+          decimal: "number",
+          date: "string",
+          json: "string",
+          tinyint1: "boolean",
+        },
+      },
+    );
+    strict.deepStrictEqual(numbers, [
+      {
+        id: 42,
+        budget: 12.5,
+        created_at: String(date),
+        profile: '{"plan":"pro"}',
+        yes_number: true,
+        yes_string: true,
+        yes_boolean: true,
+        no: false,
+      },
+    ]);
+
+    const strings = await decode<{ id: string; budget: string; created_at: Date; active: number }>(
+      {
+        rows: [{ id: 42, budget: 12.5, created_at: "2026-01-02T03:04:05Z", active: 1 }],
+        fields: [
+          { name: "active", columnType: 1, columnLength: 1 },
+          { name: "created_at", columnType: 12 },
+          { name: "budget", columnType: 246 },
+          { name: "id", columnType: 8 },
+        ],
+      },
+      {
+        typePolicy: {
+          bigint: "string",
+          decimal: "string",
+          date: "Date",
+          json: "JsonValue",
+          tinyint1: "number",
+        },
+      },
+    );
+    strict.strictEqual(strings[0]?.id, "42");
+    strict.strictEqual(strings[0]?.budget, "12.5");
+    strict.ok(strings[0]?.created_at instanceof Date);
+    strict.strictEqual(strings[0]?.active, 1);
+
+    const decimals = await decode<{ budget: { readonly source: string } }>(
+      { rows: [{ budget: "98.76" }], fields: [{ name: "budget", columnType: 246 }] },
+      {
+        typePolicy: {
+          bigint: "bigint",
+          decimal: "Decimal",
+          date: "Date",
+          json: "unknown",
+          tinyint1: "boolean",
+        },
+        decimal: (source) => ({ source }),
+      },
+    );
+    strict.deepStrictEqual(decimals, [{ budget: { source: "98.76" } }]);
+  });
+
+  await it("preserves nullish values and their row identities across active decoders", async () => {
+    const nulls = {
+      id: null,
+      budget: undefined,
+      created_at: null,
+      profile: undefined,
+      active: null,
+    };
+    const rows = [nulls];
+    const decoded = await decode({
+      rows,
+      fields: [
+        { name: "id", columnType: 8 },
+        { name: "budget", columnType: 246 },
+        { name: "created_at", columnType: 10 },
+        { name: "profile", columnType: 245 },
+        { name: "active", columnType: 1, columnLength: 1 },
+      ],
+    });
+    strict.strictEqual(decoded, rows);
+    strict.strictEqual(decoded[0], nulls);
+  });
+
+  await it("decodes wide rows in metadata-independent linear passes", async () => {
+    const width = 128;
+    const row: Record<string, unknown> = { passthrough: "kept" };
+    const fields = [];
+    for (let index = 0; index < width; index += 1) {
+      row[`column_${index}`] = String(index);
+      fields.push({ name: `column_${index}`, columnType: 8 });
+    }
+    fields.reverse();
+    const decoded = await decode<Record<string, bigint | string>>({ rows: [row], fields });
+    strict.strictEqual(decoded[0]?.passthrough, "kept");
+    for (let index = 0; index < width; index += 1) strict.strictEqual(decoded[0]?.[`column_${index}`], BigInt(index));
+  });
+
+  await it("decodes special and case-sensitive aliases without changing object prototypes", async () => {
+    const row = Object.fromEntries([
+      ["__proto__", "1"],
+      ["constructor", "2"],
+      ["0", "3"],
+      ["Value", "4"],
+      ["value", "5"],
+    ]);
+    const decoded = await decode<Record<string, bigint>>({
+      rows: [row],
+      fields: [
+        { name: "value", columnType: 8 },
+        { name: "Value", columnType: 8 },
+        { name: "0", columnType: 8 },
+        { name: "constructor", columnType: 8 },
+        { name: "__proto__", columnType: 8 },
+      ],
+    });
+    strict.strictEqual(Object.getPrototypeOf(decoded[0]), Object.prototype);
+    strict.strictEqual(Object.hasOwn(decoded[0]!, "__proto__"), true);
+    strict.deepStrictEqual(decoded[0], {
+      "0": 3n,
+      ["__proto__"]: 1n,
+      constructor: 2n,
+      Value: 4n,
+      value: 5n,
+    });
+  });
+
+  await it("preserves the first metadata entry for duplicate field names", async () => {
+    const row = { value: "42" };
+    const rows = [row];
+    const decoded = await decode({
+      rows,
+      fields: [
+        { name: "value", columnType: 245 },
+        { name: "value", columnType: 8 },
+      ],
+    });
+    strict.strictEqual(decoded, rows);
+    strict.strictEqual(decoded[0]?.value, "42");
+  });
+});

--- a/packages/mysql/test/streaming.test.ts
+++ b/packages/mysql/test/streaming.test.ts
@@ -1,0 +1,495 @@
+import { type QueryStream, sql } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import {
+  createMySqlDatabase,
+  type MySqlConnectionLike,
+  type MySqlExecutionResult,
+  type MySqlPoolLike,
+  type MySqlProtocolStream,
+} from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+
+interface AccountRow {
+  readonly id: bigint;
+  readonly active: boolean;
+}
+
+class FakeProtocolStream implements MySqlProtocolStream {
+  readonly fields;
+  readonly rows: readonly Record<string, unknown>[];
+  connectionReusable = true;
+  closeCount = 0;
+  nextCount = 0;
+  failAt: number | undefined;
+  failClose = false;
+  readonly events: string[];
+
+  constructor(
+    rows: readonly Record<string, unknown>[] = [
+      { id: "9007199254740993", active: 1 },
+      { id: "2", active: 0 },
+    ],
+    events: string[] = [],
+    fields: readonly { readonly name: string; readonly columnType: number; readonly columnLength?: number }[] = [
+      { name: "id", columnType: 8 },
+      { name: "active", columnType: 1, columnLength: 1 },
+    ],
+  ) {
+    this.rows = rows;
+    this.events = events;
+    this.fields = Promise.resolve(fields);
+  }
+
+  [Symbol.asyncIterator](): MySqlProtocolStream {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<Record<string, unknown>>> {
+    const index = this.nextCount;
+    this.nextCount += 1;
+    if (this.failAt === index) throw new Error("protocol failed");
+    const value = this.rows[index];
+    return value === undefined ? { done: true, value: undefined } : { done: false, value };
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+    this.events.push("STREAM CLOSE");
+    if (this.failClose) throw new Error("stream close failed");
+  }
+}
+
+class FakeStreamingConnection implements MySqlConnectionLike {
+  readonly commands: string[] = [];
+  readonly streamCalls: {
+    readonly sql: string;
+    readonly values: readonly unknown[];
+    readonly batchSize: number;
+  }[] = [];
+  readonly sources: FakeProtocolStream[] = [];
+  releaseCount = 0;
+  executeCount = 0;
+  nextSource: (() => FakeProtocolStream) | undefined;
+
+  async execute(sqlText: string): Promise<MySqlExecutionResult> {
+    this.executeCount += 1;
+    this.commands.push(sqlText);
+    return { rows: [] };
+  }
+
+  stream(sqlText: string, values: readonly unknown[], options: { readonly batchSize: number }): MySqlProtocolStream {
+    const source = this.nextSource?.() ?? new FakeProtocolStream(undefined, this.commands);
+    this.nextSource = undefined;
+    this.sources.push(source);
+    this.streamCalls.push({ sql: sqlText, values, batchSize: options.batchSize });
+    this.commands.push(`STREAM ${sqlText}`);
+    return source;
+  }
+
+  async query(sqlText: string): Promise<MySqlExecutionResult> {
+    this.commands.push(sqlText);
+    return { rows: [] };
+  }
+
+  async beginTransaction(): Promise<void> {
+    this.commands.push("BEGIN");
+  }
+
+  async commit(): Promise<void> {
+    this.commands.push("COMMIT");
+  }
+
+  async rollback(): Promise<void> {
+    this.commands.push("ROLLBACK");
+  }
+
+  release(): void {
+    this.releaseCount += 1;
+    this.commands.push("RELEASE");
+  }
+}
+
+class FakeStreamingPool implements MySqlPoolLike {
+  readonly connection = new FakeStreamingConnection();
+  getConnectionCount = 0;
+
+  async execute(): Promise<MySqlExecutionResult> {
+    return { rows: [] };
+  }
+
+  async getConnection(): Promise<MySqlConnectionLike> {
+    this.getConnectionCount += 1;
+    return this.connection;
+  }
+
+  async end(): Promise<void> {}
+}
+
+const accountsQuery = sql.__typed<AccountRow, readonly [bigint]>()`SELECT id, active FROM accounts WHERE id >= ${1n}`;
+
+await describe("MySQL protocol streaming", async () => {
+  await it("is lazy, typed, decoded, bounded, and releases a root lease after natural completion", async () => {
+    const pool = new FakeStreamingPool();
+    const database = createMySqlDatabase({ pool });
+    const stream = database.stream(accountsQuery, { batchSize: 7 });
+    const exactType: Assert<Equal<typeof stream, QueryStream<AccountRow>>> = true;
+    void exactType;
+
+    strict.strictEqual(pool.getConnectionCount, 0);
+    strict.deepStrictEqual(await stream.next(), {
+      done: false,
+      value: { id: 9_007_199_254_740_993n, active: true },
+    });
+    strict.strictEqual(pool.getConnectionCount, 1);
+    strict.deepStrictEqual(pool.connection.streamCalls, [
+      { sql: "SELECT id, active FROM accounts WHERE id >= ?", values: ["1"], batchSize: 7 },
+    ]);
+    strict.deepStrictEqual(await stream.next(), { done: false, value: { id: 2n, active: false } });
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+    await stream.close();
+    await stream[Symbol.asyncDispose]();
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("closes for-await early returns and explicit close without acquiring an idle stream", async () => {
+    const pool = new FakeStreamingPool();
+    const database = createMySqlDatabase({ pool });
+    const idle = database.stream(accountsQuery);
+    await idle.close();
+    await idle.close();
+    strict.strictEqual(pool.getConnectionCount, 0);
+
+    const active = database.stream(accountsQuery, { batchSize: 1 });
+    for await (const row of active) {
+      strict.strictEqual(row.id, 9_007_199_254_740_993n);
+      break;
+    }
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("preserves a consumer-body failure while closing and releasing exactly once", async () => {
+    const pool = new FakeStreamingPool();
+    const failure = new Error("consumer failed");
+    await strict.rejects(async () => {
+      for await (const _row of createMySqlDatabase({ pool }).stream(accountsQuery)) throw failure;
+    }, failure);
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("validates batchSize before connection acquisition", () => {
+    const pool = new FakeStreamingPool();
+    const database = createMySqlDatabase({ pool });
+    for (const batchSize of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN])
+      strict.throws(() => database.stream(accountsQuery, { batchSize }), /positive safe integer/);
+    strict.strictEqual(pool.getConnectionCount, 0);
+  });
+
+  await it("releases exactly once after protocol and decoder failures", async () => {
+    const protocolPool = new FakeStreamingPool();
+    protocolPool.connection.nextSource = () => {
+      const source = new FakeProtocolStream();
+      source.failAt = 0;
+      return source;
+    };
+    const protocol = createMySqlDatabase({ pool: protocolPool }).stream(accountsQuery);
+    await strict.rejects(() => protocol.next(), /protocol failed/);
+    strict.strictEqual(protocolPool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(protocolPool.connection.releaseCount, 1);
+
+    const decoderPool = new FakeStreamingPool();
+    const decoder = createMySqlDatabase({
+      pool: decoderPool,
+      typePolicy: { bigint: "number", decimal: "string", date: "Date", json: "unknown", tinyint1: "boolean" },
+    }).stream(accountsQuery);
+    await strict.rejects(() => decoder.next(), /safe integer range/);
+    strict.strictEqual(decoderPool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(decoderPool.connection.releaseCount, 1);
+  });
+
+  await it("fails an unsupported custom adapter after releasing its lease", async () => {
+    const pool = new FakeStreamingPool();
+    Object.defineProperty(pool.connection, "stream", { value: undefined });
+    const stream = createMySqlDatabase({ pool }).stream(accountsQuery);
+    await strict.rejects(() => stream.next(), /does not support protocol row streaming/);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("releases a root lease when protocol stream construction throws synchronously", async () => {
+    const pool = new FakeStreamingPool();
+    pool.connection.stream = () => {
+      throw new Error("stream construction failed");
+    };
+    const stream = createMySqlDatabase({ pool }).stream(accountsQuery);
+    await strict.rejects(() => stream.next(), /stream construction failed/);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("does not release a root lease that the native source marks non-reusable", async () => {
+    const pool = new FakeStreamingPool();
+    pool.connection.nextSource = () => {
+      const source = new FakeProtocolStream();
+      source.connectionReusable = false;
+      return source;
+    };
+    const stream = createMySqlDatabase({ pool }).stream(accountsQuery);
+    await stream.next();
+    await stream.close();
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 0);
+  });
+
+  await it("drains command headers without exposing them as rows", async () => {
+    const pool = new FakeStreamingPool();
+    pool.connection.nextSource = () => new FakeProtocolStream([{ affectedRows: 1 }], [], []);
+    const stream = createMySqlDatabase({ pool }).stream(sql<never>`UPDATE accounts SET active = 1`);
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+    strict.strictEqual(pool.connection.sources[0]?.nextCount, 0);
+    strict.strictEqual(pool.connection.sources[0]?.closeCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+  });
+
+  await it("reuses the transaction connection and commits only after a stream completes", async () => {
+    const pool = new FakeStreamingPool();
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      const rows: AccountRow[] = [];
+      for await (const row of transaction.stream(accountsQuery)) rows.push(row);
+      strict.strictEqual(rows.length, 2);
+      strict.strictEqual(pool.connection.releaseCount, 0);
+    });
+    strict.deepStrictEqual(pool.connection.commands, [
+      "BEGIN",
+      "STREAM SELECT id, active FROM accounts WHERE id >= ?",
+      "STREAM CLOSE",
+      "COMMIT",
+      "RELEASE",
+    ]);
+  });
+
+  await it("drains an early transaction break before allowing buffered execution and commit", async () => {
+    const pool = new FakeStreamingPool();
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      for await (const _row of transaction.stream(accountsQuery)) break;
+      await transaction.execute(sql`SELECT 2`);
+    });
+    strict.deepStrictEqual(pool.connection.commands, [
+      "BEGIN",
+      "STREAM SELECT id, active FROM accounts WHERE id >= ?",
+      "STREAM CLOSE",
+      "SELECT 2",
+      "COMMIT",
+      "RELEASE",
+    ]);
+  });
+
+  await it("drains started streams before rollback when callbacks fail", async () => {
+    const pool = new FakeStreamingPool();
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool }).transaction(async (transaction) => {
+          await transaction.stream(accountsQuery).next();
+          throw new Error("callback failed");
+        }),
+      /callback failed/,
+    );
+    strict.deepStrictEqual(pool.connection.commands, [
+      "BEGIN",
+      "STREAM SELECT id, active FROM accounts WHERE id >= ?",
+      "STREAM CLOSE",
+      "ROLLBACK",
+      "RELEASE",
+    ]);
+  });
+
+  await it("preserves callback failure when closing the active stream also fails", async () => {
+    const pool = new FakeStreamingPool();
+    pool.connection.nextSource = () => {
+      const source = new FakeProtocolStream(undefined, pool.connection.commands);
+      source.failClose = true;
+      return source;
+    };
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool }).transaction(async (transaction) => {
+          await transaction.stream(accountsQuery).next();
+          throw new Error("original callback failure");
+        }),
+      /original callback failure/,
+    );
+    strict.ok(pool.connection.commands.indexOf("STREAM CLOSE") < pool.connection.commands.indexOf("ROLLBACK"));
+  });
+
+  await it("rolls back leaked started and unstarted streams before commit", async () => {
+    const startedPool = new FakeStreamingPool();
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool: startedPool }).transaction(async (transaction) => {
+          await transaction.stream(accountsQuery).next();
+        }),
+      /returned with 1 active query stream/,
+    );
+    strict.ok(!startedPool.connection.commands.includes("COMMIT"));
+    strict.ok(
+      startedPool.connection.commands.indexOf("STREAM CLOSE") < startedPool.connection.commands.indexOf("ROLLBACK"),
+    );
+
+    const idlePool = new FakeStreamingPool();
+    let escaped: QueryStream<AccountRow> | undefined;
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool: idlePool }).transaction(async (transaction) => {
+          escaped = transaction.stream(accountsQuery);
+        }),
+      /returned with 1 active query stream/,
+    );
+    strict.strictEqual(idlePool.connection.streamCalls.length, 0);
+    strict.deepStrictEqual(await escaped!.next(), { done: true, value: undefined });
+    strict.strictEqual(idlePool.connection.streamCalls.length, 0);
+  });
+
+  await it("rejects concurrent transaction work before driver dispatch", async () => {
+    const pool = new FakeStreamingPool();
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool }).transaction(async (transaction) => {
+          const first = transaction.stream(accountsQuery);
+          await first.next();
+          await strict.rejects(() => transaction.execute(sql`SELECT 2`), /stream owns the transaction connection/);
+          const second = transaction.stream(accountsQuery);
+          await strict.rejects(() => second.next(), /stream owns the transaction connection/);
+          await strict.rejects(
+            () => transaction.transaction(async () => undefined),
+            /stream owns the transaction connection/,
+          );
+        }),
+      /returned with 1 active query stream/,
+    );
+    strict.strictEqual(pool.connection.executeCount, 0);
+    strict.strictEqual(pool.connection.commands.filter((value) => value.startsWith("SAVEPOINT")).length, 0);
+    strict.strictEqual(pool.connection.streamCalls.length, 1);
+  });
+
+  await it("shares active ownership across nested scopes and invalidates escaped transaction scopes", async () => {
+    const pool = new FakeStreamingPool();
+    let escapedTransaction:
+      | Parameters<Parameters<ReturnType<typeof createMySqlDatabase>["transaction"]>[0]>[0]
+      | undefined;
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      await transaction.transaction(async (nested) => {
+        escapedTransaction = nested;
+        const stream = nested.stream(accountsQuery);
+        await stream.next();
+        await strict.rejects(() => transaction.execute(sql`SELECT 2`), /stream owns the transaction connection/);
+        await stream.close();
+      });
+    });
+    await strict.rejects(() => escapedTransaction!.execute(sql`SELECT 3`), /scope is no longer active/);
+    await strict.rejects(() => escapedTransaction!.transaction(async () => undefined), /scope is no longer active/);
+    strict.strictEqual(pool.connection.executeCount, 0);
+
+    let escapedOuter: typeof escapedTransaction;
+    await createMySqlDatabase({ pool: new FakeStreamingPool() }).transaction(async (transaction) => {
+      escapedOuter = transaction;
+    });
+    await strict.rejects(() => escapedOuter!.execute(sql`SELECT 4`), /scope is no longer active/);
+    strict.throws(() => escapedOuter!.stream(accountsQuery), /scope is no longer active/);
+    strict.throws(() => escapedOuter!.prepare("late", () => sql`SELECT 1`), /scope is no longer active/);
+
+    let failedScope: typeof escapedOuter;
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool: new FakeStreamingPool() }).transaction(async (transaction) => {
+          failedScope = transaction;
+          throw new Error("transaction callback failed");
+        }),
+      /transaction callback failed/,
+    );
+    await strict.rejects(() => failedScope!.execute(sql`SELECT 5`), /scope is no longer active/);
+  });
+
+  await it("closes an active unawaited nested stream before outer rollback and forbids savepoint release", async () => {
+    const pool = new FakeStreamingPool();
+    let nestedStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      nestedStarted = resolve;
+    });
+    let finishNested!: () => void;
+    const finish = new Promise<void>((resolve) => {
+      finishNested = resolve;
+    });
+    let nestedWork!: Promise<void>;
+
+    await strict.rejects(
+      () =>
+        createMySqlDatabase({ pool }).transaction(async (transaction) => {
+          nestedWork = transaction.transaction(async (nested) => {
+            await nested.stream(accountsQuery).next();
+            nestedStarted();
+            await finish;
+          });
+          await started;
+        }),
+      /nested query stream owned its connection/,
+    );
+    strict.ok(pool.connection.commands.indexOf("STREAM CLOSE") < pool.connection.commands.indexOf("ROLLBACK"));
+    const finalizedCommands = [...pool.connection.commands];
+    finishNested();
+    await strict.rejects(() => nestedWork, /connection is no longer active/);
+    strict.deepStrictEqual(pool.connection.commands, finalizedCommands);
+  });
+
+  await it("forbids an unstarted nested stream from dispatching after its outer transaction releases", async () => {
+    const pool = new FakeStreamingPool();
+    let nestedCreated!: () => void;
+    const created = new Promise<void>((resolve) => {
+      nestedCreated = resolve;
+    });
+    let resumeNested!: () => void;
+    const resume = new Promise<void>((resolve) => {
+      resumeNested = resolve;
+    });
+    let nestedWork!: Promise<void>;
+
+    await createMySqlDatabase({ pool }).transaction(async (transaction) => {
+      nestedWork = transaction.transaction(async (nested) => {
+        const stream = nested.stream(accountsQuery);
+        nestedCreated();
+        await resume;
+        await stream.next();
+      });
+      await created;
+    });
+
+    strict.deepStrictEqual(pool.connection.commands, ["BEGIN", "SAVEPOINT typed_sql_2", "COMMIT", "RELEASE"]);
+    resumeNested();
+    await strict.rejects(() => nestedWork, /scope is no longer active/);
+    strict.strictEqual(pool.connection.streamCalls.length, 0);
+    strict.deepStrictEqual(pool.connection.commands, ["BEGIN", "SAVEPOINT typed_sql_2", "COMMIT", "RELEASE"]);
+  });
+
+  await it("reuses prepared rendering metadata for stream execution", async () => {
+    const pool = new FakeStreamingPool();
+    const database = createMySqlDatabase({ pool });
+    const source = sql<AccountRow>`SELECT id, active FROM accounts WHERE id >= ${1n}`;
+    let segmentReads = 0;
+    const observed = new Proxy(source, {
+      get(target, property, receiver) {
+        if (property === "segments") segmentReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const prepared = database.prepare("stream-accounts", () => observed);
+    const stream = database.stream(prepared());
+    strict.strictEqual(segmentReads, 1);
+    await stream.next();
+    strict.strictEqual(segmentReads, 1);
+    await stream.close();
+  });
+});

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -10,7 +10,11 @@ pnpm add -D @typed-sql/cli typescript@7.0.2
 ```
 
 `pg` is loaded only through `@typed-sql/postgres/pg`; it is not a dependency or peer dependency of
-the grammar.
+the grammar. Applications that stream rows also install the optional application-owned cursor:
+
+```sh
+pnpm add pg-cursor
+```
 
 ```ts
 import { sql, typePolicy } from "@typed-sql/postgres";
@@ -28,6 +32,16 @@ const database = await createPgDatabase({
 });
 
 const rows = await database.execute(query);
+
+const accountById = database.prepare("account-by-id", (id: bigint) => sql`
+  SELECT account.id, account.email
+  FROM users AS account
+  WHERE account.id = ${id}
+`);
+
+for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
+  // account retains the query's inferred row type
+}
 ```
 
 The package root exports `sql`, `postgres`, and the PostgreSQL type policy. The `/pg` entrypoint
@@ -35,6 +49,7 @@ exports the schema provider and execution adapter; `/runtime` exposes driver-neu
 rendering and codecs.
 
 Read the [PostgreSQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/postgresql.md),
+[execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
 [configuration](https://github.com/Lojhan/typed-sql/blob/main/docs/getting-started/configuration.md), and
 [database type mappings](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/type-mappings.md).
 

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -39,6 +39,8 @@ const accountById = database.prepare("account-by-id", (id: bigint) => sql`
   WHERE account.id = ${id}
 `);
 
+const [selectedAccounts, allAccounts] = await database.batch([accountById(42n), query]);
+
 for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
   // account retains the query's inferred row type
 }

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -4,17 +4,65 @@ import { type PostgresQueryable, PostgresSchemaProvider } from "./provider.js";
 import {
   createPostgresDatabase,
   type PostgresClientLike,
+  type PostgresCursorLike,
   type PostgresDatabase,
   type PostgresPoolLike,
   type PostgresQueryConfig,
   type PostgresQueryResult,
 } from "./runtime.js";
 
+export interface PgCursorConstructor {
+  new (
+    text: string,
+    values?: readonly unknown[],
+    config?: {
+      readonly types?: PostgresQueryConfig["types"];
+    },
+  ): unknown;
+}
+
+export type PgCursorImporter = () => Promise<unknown>;
+
+const pgCursorPackage = "pg-cursor";
+
+async function defaultPgCursorImporter(): Promise<unknown> {
+  return import(pgCursorPackage);
+}
+
+function pgCursorConstructor(module: unknown): PgCursorConstructor {
+  const candidate =
+    typeof module === "object" && module !== null && "default" in module
+      ? (module as { readonly default?: unknown }).default
+      : module;
+  if (typeof candidate !== "function") {
+    throw new TypeError("The application-owned pg-cursor package does not export a default Cursor constructor");
+  }
+  return candidate as PgCursorConstructor;
+}
+
+export async function loadPgCursorDriver(
+  importer: PgCursorImporter = defaultPgCursorImporter,
+): Promise<PgCursorConstructor> {
+  try {
+    return pgCursorConstructor(await importer());
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "@typed-sql/postgres/pg streaming requires the application-owned pg-cursor package. Install it with: pnpm add pg-cursor",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 export interface PgOptions {
   readonly connectionString: string | (() => string | Promise<string>);
   readonly poolConfig?: Omit<PoolConfig, "connectionString" | "types">;
   readonly typePolicy?: PostgresTypePolicy;
   readonly decimal?: (value: string) => unknown;
+  /** Host-injected loader for workspaces or runtimes with nonstandard package resolution. */
+  readonly cursorImporter?: PgCursorImporter;
 }
 
 export interface PgSchemaProviderOptions {
@@ -62,19 +110,68 @@ function queryConfig(config: PostgresQueryConfig): QueryConfig<unknown[]> {
   };
 }
 
-export function adaptPgPool(pool: PgPool): PostgresPoolLike {
-  const wrapClient = (client: PoolClient): PostgresClientLike => ({
-    async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
-      const result =
-        typeof config === "string"
-          ? await client.query<Record<string, unknown>>(config)
-          : await client.query<Record<string, unknown>, unknown[]>(queryConfig(config));
-      return { rows: result.rows };
-    },
-    release(): void {
-      client.release();
-    },
-  });
+export function adaptPgPool(
+  pool: PgPool,
+  cursorImporter: PgCursorImporter = defaultPgCursorImporter,
+): PostgresPoolLike {
+  let cursorConstructorPromise: Promise<PgCursorConstructor> | undefined;
+  const loadCursor = (): Promise<PgCursorConstructor> => {
+    cursorConstructorPromise ??= loadPgCursorDriver(cursorImporter);
+    return cursorConstructorPromise;
+  };
+  const wrapClient = (client: PoolClient): PostgresClientLike => {
+    let fatalError: Error | undefined;
+    let rejectFatal!: (error: Error) => void;
+    const fatalSettlement = new Promise<never>((_resolve, reject) => {
+      rejectFatal = reject;
+    });
+    // The promise intentionally remains pending for a healthy lease and must never be unhandled.
+    void fatalSettlement.catch(() => undefined);
+    const recordFatal = (error: Error): void => {
+      if (fatalError !== undefined) return;
+      fatalError = error;
+      rejectFatal(error);
+    };
+    const onError = (error: Error): void => recordFatal(error);
+    const onEnd = (): void => recordFatal(new Error("The PostgreSQL connection ended while it was leased"));
+    client.on("error", onError);
+    client.on("end", onEnd);
+
+    return {
+      async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
+        const result =
+          typeof config === "string"
+            ? await client.query<Record<string, unknown>>(config)
+            : await client.query<Record<string, unknown>, unknown[]>(queryConfig(config));
+        return { rows: result.rows };
+      },
+      async openCursor(config: PostgresQueryConfig): Promise<PostgresCursorLike> {
+        const Cursor = await loadCursor();
+        // pg-cursor always parses an unnamed statement. Keep the prepared name in typed-sql's
+        // driver-neutral config, but do not pretend the native cursor can honor it.
+        const cursor = new Cursor(config.text, config.values, {
+          ...(config.types === undefined ? {} : { types: config.types }),
+        });
+        const queryCursor = client.query.bind(client) as unknown as (value: unknown) => PostgresCursorLike;
+        const nativeCursor = queryCursor(cursor);
+        return {
+          read: (rowCount) => nativeCursor.read(rowCount),
+          async close(): Promise<void> {
+            if (fatalError !== undefined) throw fatalError;
+            const nativeClose = nativeCursor.close();
+            // Keep observing the native promise even when fatal settlement wins the race.
+            void nativeClose.catch(() => undefined);
+            await Promise.race([nativeClose, fatalSettlement]);
+          },
+        };
+      },
+      release(error?: Error | boolean): void {
+        client.removeListener("error", onError);
+        client.removeListener("end", onEnd);
+        client.release(error === undefined ? fatalError : error);
+      },
+    };
+  };
   return {
     async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
       const result =
@@ -82,6 +179,9 @@ export function adaptPgPool(pool: PgPool): PostgresPoolLike {
           ? await pool.query<Record<string, unknown>>(config)
           : await pool.query<Record<string, unknown>, unknown[]>(queryConfig(config));
       return { rows: result.rows };
+    },
+    async ensureCursor(): Promise<void> {
+      await loadCursor();
     },
     async connect(): Promise<PostgresClientLike> {
       return wrapClient(await pool.connect());
@@ -98,7 +198,7 @@ export async function createPgDatabase(options: PgOptions): Promise<PostgresData
   const { Pool } = driver;
   const pool = new Pool({ ...options.poolConfig, connectionString: await connectionString(options.connectionString) });
   return createPostgresDatabase({
-    pool: adaptPgPool(pool),
+    pool: adaptPgPool(pool, options.cursorImporter),
     ownsPool: true,
     fallbackTypeParsers: driver.types,
     ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -24,6 +24,8 @@ export interface PgCursorConstructor {
 export type PgCursorImporter = () => Promise<unknown>;
 
 const pgCursorPackage = "pg-cursor";
+const queryTimeoutError =
+  "@typed-sql/postgres/pg does not accept pg query_timeout because pg can reject before the connection is ready for reuse; use PostgreSQL statement_timeout instead";
 
 async function defaultPgCursorImporter(): Promise<unknown> {
   return import(pgCursorPackage);
@@ -58,7 +60,7 @@ export async function loadPgCursorDriver(
 
 export interface PgOptions {
   readonly connectionString: string | (() => string | Promise<string>);
-  readonly poolConfig?: Omit<PoolConfig, "connectionString" | "types">;
+  readonly poolConfig?: Omit<PoolConfig, "connectionString" | "query_timeout" | "types">;
   readonly typePolicy?: PostgresTypePolicy;
   readonly decimal?: (value: string) => unknown;
   /** Host-injected loader for workspaces or runtimes with nonstandard package resolution. */
@@ -94,10 +96,23 @@ async function connectionString(value: PgOptions["connectionString"]): Promise<s
 }
 
 function validatePoolConfig(poolConfig: PgOptions["poolConfig"]): void {
+  if (poolConfig !== undefined && "query_timeout" in poolConfig) throw new TypeError(queryTimeoutError);
   if (poolConfig !== undefined && "types" in poolConfig) {
     throw new TypeError(
       "@typed-sql/postgres/pg owns poolConfig.types so decoded values match typePolicy; remove that option",
     );
+  }
+}
+
+function validateConnectionStringQueryTimeout(value: string): void {
+  try {
+    const url = new URL(value);
+    for (const name of url.searchParams.keys()) {
+      if (name === "query_timeout") throw new TypeError(queryTimeoutError);
+    }
+  } catch (error) {
+    if (error instanceof TypeError && error.message === queryTimeoutError) throw error;
+    // Let pg report malformed or non-URL connection strings through its normal validation path.
   }
 }
 
@@ -114,6 +129,13 @@ export function adaptPgPool(
   pool: PgPool,
   cursorImporter: PgCursorImporter = defaultPgCursorImporter,
 ): PostgresPoolLike {
+  const options = (
+    pool as PgPool & {
+      readonly options?: { readonly connectionString?: unknown; readonly query_timeout?: unknown };
+    }
+  ).options;
+  if (options !== undefined && "query_timeout" in options) throw new TypeError(queryTimeoutError);
+  if (typeof options?.connectionString === "string") validateConnectionStringQueryTimeout(options.connectionString);
   let cursorConstructorPromise: Promise<PgCursorConstructor> | undefined;
   const loadCursor = (): Promise<PgCursorConstructor> => {
     cursorConstructorPromise ??= loadPgCursorDriver(cursorImporter);
@@ -194,9 +216,11 @@ export function adaptPgPool(
 
 export async function createPgDatabase(options: PgOptions): Promise<PostgresDatabase> {
   validatePoolConfig(options.poolConfig);
+  const resolvedConnectionString = await connectionString(options.connectionString);
+  validateConnectionStringQueryTimeout(resolvedConnectionString);
   const driver = await loadPgDriver();
   const { Pool } = driver;
-  const pool = new Pool({ ...options.poolConfig, connectionString: await connectionString(options.connectionString) });
+  const pool = new Pool({ ...options.poolConfig, connectionString: resolvedConnectionString });
   return createPostgresDatabase({
     pool: adaptPgPool(pool, options.cursorImporter),
     ownsPool: true,

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -55,6 +55,7 @@ function validatePoolConfig(poolConfig: PgOptions["poolConfig"]): void {
 
 function queryConfig(config: PostgresQueryConfig): QueryConfig<unknown[]> {
   return {
+    ...(config.name === undefined ? {} : { name: config.name }),
     text: config.text,
     ...(config.values === undefined ? {} : { values: [...config.values] }),
     ...(config.types === undefined ? {} : { types: config.types }),

--- a/packages/postgres/src/prepared.ts
+++ b/packages/postgres/src/prepared.ts
@@ -1,0 +1,73 @@
+import { type Query, type RenderedQuery, renderQuery, type SqlRenderer } from "@typed-sql/core";
+
+export interface PostgresPreparedQueryFactory<
+  Arguments extends readonly unknown[],
+  Row,
+  Params extends readonly unknown[],
+> {
+  (...args: Arguments): Query<Row, Params>;
+  readonly statementName: string;
+}
+
+export interface PostgresPreparedQueryMetadata {
+  readonly statementName: string;
+  readonly rendered: RenderedQuery;
+}
+
+interface PreparedStatement {
+  text: string | undefined;
+}
+
+export interface PostgresPreparedQueryState {
+  readonly statements: Map<string, PreparedStatement>;
+  readonly queries: WeakMap<object, PostgresPreparedQueryMetadata>;
+}
+
+export function createPostgresPreparedQueryState(): PostgresPreparedQueryState {
+  return {
+    statements: new Map(),
+    queries: new WeakMap(),
+  };
+}
+
+function validateStatementName(statementName: string): void {
+  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0")) {
+    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
+  }
+}
+
+export function preparePostgresQuery<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+  state: PostgresPreparedQueryState,
+  renderer: SqlRenderer,
+  statementName: string,
+  factory: (...args: Arguments) => Query<Row, Params>,
+): PostgresPreparedQueryFactory<Arguments, Row, Params> {
+  validateStatementName(statementName);
+  if (state.statements.has(statementName)) {
+    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
+  }
+
+  const statement: PreparedStatement = { text: undefined };
+  state.statements.set(statementName, statement);
+
+  const prepared = (...args: Arguments): Query<Row, Params> => {
+    const query = factory(...args);
+    const existing = state.queries.get(query);
+    if (existing !== undefined && existing.statementName !== statementName) {
+      throw new TypeError(
+        `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
+      );
+    }
+
+    const rendered = existing?.rendered ?? renderQuery(query, renderer);
+    if (statement.text === undefined) statement.text = rendered.text;
+    else if (statement.text !== rendered.text) {
+      throw new TypeError(`Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text`);
+    }
+
+    if (existing === undefined) state.queries.set(query, { statementName, rendered });
+    return query;
+  };
+
+  return Object.freeze(Object.assign(prepared, { statementName }));
+}

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,13 +1,22 @@
-import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
+import {
+  type Database,
+  type Query,
+  type QueryStream,
+  renderQuery,
+  type SqlRenderer,
+  type StreamOptions,
+} from "@typed-sql/core";
 import {
   createPostgresPreparedQueryState,
   type PostgresPreparedQueryFactory,
   type PostgresPreparedQueryState,
   preparePostgresQuery,
 } from "./prepared.js";
+import { type PostgresCursorLike, PostgresQueryStream, validatePostgresStreamBatchSize } from "./stream.js";
 import { defaultPostgresTypePolicy } from "./type-policy.js";
 
 export type { PostgresPreparedQueryFactory } from "./prepared.js";
+export type { PostgresCursorLike } from "./stream.js";
 
 export interface PostgresCodecPolicy {
   readonly bigint: "bigint" | "string" | "number";
@@ -33,11 +42,13 @@ export interface PostgresQueryResult {
 
 export interface PostgresClientLike {
   query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult>;
-  release(): void;
+  openCursor?(config: PostgresQueryConfig): PostgresCursorLike | Promise<PostgresCursorLike>;
+  release(error?: Error | boolean): void;
 }
 
 export interface PostgresPoolLike {
   query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult>;
+  ensureCursor?(): Promise<void>;
   connect(): Promise<PostgresClientLike>;
   end(): Promise<void>;
 }
@@ -47,6 +58,7 @@ export interface PostgresTransaction extends Database<PostgresTransaction> {
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
   ): PostgresPreparedQueryFactory<Arguments, Row, Params>;
+  stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
 }
 
 export interface PostgresDatabase extends Database<PostgresTransaction> {
@@ -54,6 +66,7 @@ export interface PostgresDatabase extends Database<PostgresTransaction> {
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
   ): PostgresPreparedQueryFactory<Arguments, Row, Params>;
+  stream<Row, Params extends readonly unknown[]>(query: Query<Row, Params>, options?: StreamOptions): QueryStream<Row>;
   close(): Promise<void>;
 }
 
@@ -184,6 +197,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #ownsPool: boolean;
   readonly #prepared: PostgresPreparedQueryState;
   readonly #transactionDepth: number;
+  #transactionScopeOpen = true;
+  readonly #transactionState: {
+    readonly activeStreams: Set<QueryStream<unknown>>;
+    valid: boolean;
+  };
+  readonly #transactionStreams = new Set<QueryStream<unknown>>();
 
   constructor(
     pool: PostgresPoolLike,
@@ -192,6 +211,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     ownsPool: boolean,
     depth: number,
     prepared: PostgresPreparedQueryState,
+    transactionState = { activeStreams: new Set<QueryStream<unknown>>(), valid: true },
   ) {
     this.#pool = pool;
     this.#client = client;
@@ -199,38 +219,108 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#ownsPool = ownsPool;
     this.#transactionDepth = depth;
     this.#prepared = prepared;
+    this.#transactionState = transactionState;
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
-    const prepared = this.#prepared.queries.get(query);
-    const rendered = prepared?.rendered ?? renderQuery(query, postgresRenderer);
-    const result = await (this.#client ?? this.#pool).query({
-      ...(prepared === undefined ? {} : { name: prepared.statementName }),
-      text: rendered.text,
-      values: rendered.values.map(encodeValue),
-      types: this.#parsers,
-    });
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("execute another query");
+    const config = this.#queryConfig(query);
+    const result = await (this.#client ?? this.#pool).query(config);
     return result.rows as readonly Row[];
+  }
+
+  stream<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    options: StreamOptions = {},
+  ): QueryStream<Row> {
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("start another query stream");
+    const batchSize = validatePostgresStreamBatchSize(options.batchSize);
+    const config = this.#queryConfig(query);
+    let stream: QueryStream<Row>;
+    stream = new PostgresQueryStream<Row>({
+      batchSize,
+      start: async () => {
+        await this.#pool.ensureCursor?.();
+        const client = this.#client ?? (await this.#pool.connect());
+        const release =
+          this.#client === undefined
+            ? (cleanupError?: unknown): void =>
+                client.release(
+                  cleanupError === undefined ? undefined : cleanupError instanceof Error ? cleanupError : true,
+                )
+            : undefined;
+        if (client.openCursor === undefined) {
+          try {
+            release?.();
+          } catch {
+            /* The missing-capability failure remains primary. */
+          }
+          throw new Error(
+            "PostgreSQL streaming requires the application-owned pg-cursor package. Install it with: pnpm add pg-cursor",
+          );
+        }
+        try {
+          const cursor = await client.openCursor(config);
+          return { cursor, ...(release === undefined ? {} : { release }) };
+        } catch (error) {
+          try {
+            release?.(error);
+          } catch {
+            /* Preserve cursor creation or optional-dependency failures. */
+          }
+          throw error;
+        }
+      },
+      ...(this.#client === undefined
+        ? {}
+        : {
+            onStart: () => {
+              this.#assertTransactionScopeOpen();
+              this.#rejectOperationDuringTransactionStream("start another query stream");
+              this.#transactionState.activeStreams.add(stream as QueryStream<unknown>);
+            },
+            onClose: () => {
+              this.#transactionState.activeStreams.delete(stream as QueryStream<unknown>);
+              this.#transactionStreams.delete(stream as QueryStream<unknown>);
+            },
+          }),
+    });
+    if (this.#client !== undefined) this.#transactionStreams.add(stream as QueryStream<unknown>);
+    return stream;
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
   ): PostgresPreparedQueryFactory<Arguments, Row, Params> {
+    this.#assertTransactionScopeOpen();
     return preparePostgresQuery(this.#prepared, postgresRenderer, statementName, factory);
   }
 
   async transaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("start a nested transaction");
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
+    const scope = new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared, {
+      activeStreams: new Set(),
+      valid: true,
+    });
     let result: T;
     try {
       await client.query("BEGIN");
-      result = await fn(
-        new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared),
-      );
+      try {
+        result = await fn(scope);
+      } finally {
+        scope.#transactionScopeOpen = false;
+        scope.#transactionState.valid = false;
+      }
+      await scope.#rejectLeakedTransactionStreams();
       await client.query("COMMIT");
     } catch (error) {
+      await scope.#closeTransactionStreamsPreservingError();
       try {
         await client.query("ROLLBACK");
       } catch {
@@ -252,19 +342,80 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     const depth = this.#transactionDepth + 1;
     const savepoint = `typed_sql_${depth}`;
     await client.query(`SAVEPOINT ${savepoint}`);
+    const scope = new PostgresDatabaseImplementation(
+      this.#pool,
+      client,
+      this.#parsers,
+      false,
+      depth,
+      this.#prepared,
+      this.#transactionState,
+    );
     try {
-      const result = await fn(
-        new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, depth, this.#prepared),
-      );
+      let result: T;
+      try {
+        result = await fn(scope);
+      } finally {
+        scope.#transactionScopeOpen = false;
+      }
+      if (!scope.#transactionState.valid) {
+        throw new Error("The parent PostgreSQL transaction scope ended before its nested transaction completed");
+      }
+      await scope.#rejectLeakedTransactionStreams();
       await client.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
-      try {
-        await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
-      } catch {
-        /* Preserve the original callback, query, or release error. */
+      await scope.#closeTransactionStreamsPreservingError();
+      if (scope.#transactionState.valid) {
+        try {
+          await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+        } catch {
+          /* Preserve the original callback, query, or release error. */
+        }
       }
       throw error;
+    }
+  }
+
+  #queryConfig<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): PostgresQueryConfig {
+    const prepared = this.#prepared.queries.get(query);
+    const rendered = prepared?.rendered ?? renderQuery(query, postgresRenderer);
+    return {
+      ...(prepared === undefined ? {} : { name: prepared.statementName }),
+      text: rendered.text,
+      values: rendered.values.map(encodeValue),
+      types: this.#parsers,
+    };
+  }
+
+  async #rejectLeakedTransactionStreams(): Promise<void> {
+    if (this.#transactionStreams.size === 0 && this.#transactionState.activeStreams.size === 0) return;
+    await this.#closeTransactionStreamsPreservingError();
+    throw new Error("A PostgreSQL transaction callback returned before all query streams were completed or closed");
+  }
+
+  async #closeTransactionStreamsPreservingError(): Promise<void> {
+    const streams = new Set([...this.#transactionStreams, ...this.#transactionState.activeStreams]);
+    for (const stream of streams) {
+      try {
+        await stream.close();
+      } catch {
+        /* The callback or transaction misuse error remains primary. */
+      }
+    }
+  }
+
+  #rejectOperationDuringTransactionStream(operation: string): void {
+    if (this.#client !== undefined && this.#transactionState.activeStreams.size > 0) {
+      throw new Error(
+        `Cannot ${operation} while a PostgreSQL transaction query stream is still open; complete or close the stream first`,
+      );
+    }
+  }
+
+  #assertTransactionScopeOpen(): void {
+    if (this.#client !== undefined && (!this.#transactionScopeOpen || !this.#transactionState.valid)) {
+      throw new Error("This PostgreSQL transaction scope has ended and can no longer be used");
     }
   }
 

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,5 +1,13 @@
 import { type Database, type Query, renderQuery, type SqlRenderer } from "@typed-sql/core";
+import {
+  createPostgresPreparedQueryState,
+  type PostgresPreparedQueryFactory,
+  type PostgresPreparedQueryState,
+  preparePostgresQuery,
+} from "./prepared.js";
 import { defaultPostgresTypePolicy } from "./type-policy.js";
+
+export type { PostgresPreparedQueryFactory } from "./prepared.js";
 
 export interface PostgresCodecPolicy {
   readonly bigint: "bigint" | "string" | "number";
@@ -13,6 +21,7 @@ export interface PostgresTypeParserSet {
 }
 
 export interface PostgresQueryConfig {
+  readonly name?: string;
   readonly text: string;
   readonly values?: readonly unknown[];
   readonly types?: PostgresTypeParserSet;
@@ -33,9 +42,18 @@ export interface PostgresPoolLike {
   end(): Promise<void>;
 }
 
-export interface PostgresTransaction extends Database<PostgresTransaction> {}
+export interface PostgresTransaction extends Database<PostgresTransaction> {
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): PostgresPreparedQueryFactory<Arguments, Row, Params>;
+}
 
 export interface PostgresDatabase extends Database<PostgresTransaction> {
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): PostgresPreparedQueryFactory<Arguments, Row, Params>;
   close(): Promise<void>;
 }
 
@@ -164,6 +182,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #client: PostgresClientLike | undefined;
   readonly #parsers: PostgresTypeParserSet;
   readonly #ownsPool: boolean;
+  readonly #prepared: PostgresPreparedQueryState;
   readonly #transactionDepth: number;
 
   constructor(
@@ -172,22 +191,33 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     parsers: PostgresTypeParserSet,
     ownsPool: boolean,
     depth: number,
+    prepared: PostgresPreparedQueryState,
   ) {
     this.#pool = pool;
     this.#client = client;
     this.#parsers = parsers;
     this.#ownsPool = ownsPool;
     this.#transactionDepth = depth;
+    this.#prepared = prepared;
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
-    const rendered = renderQuery(query, postgresRenderer);
+    const prepared = this.#prepared.queries.get(query);
+    const rendered = prepared?.rendered ?? renderQuery(query, postgresRenderer);
     const result = await (this.#client ?? this.#pool).query({
+      ...(prepared === undefined ? {} : { name: prepared.statementName }),
       text: rendered.text,
       values: rendered.values.map(encodeValue),
       types: this.#parsers,
     });
     return result.rows as readonly Row[];
+  }
+
+  prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
+    statementName: string,
+    factory: (...args: Arguments) => Query<Row, Params>,
+  ): PostgresPreparedQueryFactory<Arguments, Row, Params> {
+    return preparePostgresQuery(this.#prepared, postgresRenderer, statementName, factory);
   }
 
   async transaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
@@ -196,7 +226,9 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     let result: T;
     try {
       await client.query("BEGIN");
-      result = await fn(new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1));
+      result = await fn(
+        new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared),
+      );
       await client.query("COMMIT");
     } catch (error) {
       try {
@@ -221,7 +253,9 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     const savepoint = `typed_sql_${depth}`;
     await client.query(`SAVEPOINT ${savepoint}`);
     try {
-      const result = await fn(new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, depth));
+      const result = await fn(
+        new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, depth, this.#prepared),
+      );
       await client.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
@@ -247,5 +281,6 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     createPostgresTypeParsers(options.typePolicy ?? defaultPolicy, options.decimal, options.fallbackTypeParsers),
     options.ownsPool ?? false,
     0,
+    createPostgresPreparedQueryState(),
   );
 }

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -33,7 +33,9 @@ export interface PostgresPoolLike {
   end(): Promise<void>;
 }
 
-export interface PostgresDatabase extends Database {
+export interface PostgresTransaction extends Database<PostgresTransaction> {}
+
+export interface PostgresDatabase extends Database<PostgresTransaction> {
   close(): Promise<void>;
 }
 
@@ -188,7 +190,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     return result.rows as readonly Row[];
   }
 
-  async transaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  async transaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
     let result: T;
@@ -213,7 +215,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     return result;
   }
 
-  async #nestedTransaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  async #nestedTransaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
     const client = this.#client!;
     const depth = this.#transactionDepth + 1;
     const savepoint = `typed_sql_${depth}`;

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,6 +1,8 @@
 import {
   type Database,
   type Query,
+  type QueryBatch,
+  type QueryResults,
   type QueryStream,
   renderQuery,
   type SqlRenderer,
@@ -54,6 +56,7 @@ export interface PostgresPoolLike {
 }
 
 export interface PostgresTransaction extends Database<PostgresTransaction> {
+  batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
@@ -62,6 +65,7 @@ export interface PostgresTransaction extends Database<PostgresTransaction> {
 }
 
 export interface PostgresDatabase extends Database<PostgresTransaction> {
+  batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>>;
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
@@ -80,6 +84,7 @@ export interface PostgresDatabaseOptions {
 }
 
 const defaultPolicy: PostgresCodecPolicy = defaultPostgresTypePolicy;
+const emptyBatchResults = Object.freeze([]);
 
 const oids = {
   int8: 20,
@@ -199,6 +204,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #transactionDepth: number;
   #transactionScopeOpen = true;
   readonly #transactionState: {
+    activeBatch: Promise<unknown> | undefined;
     readonly activeStreams: Set<QueryStream<unknown>>;
     valid: boolean;
   };
@@ -211,7 +217,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     ownsPool: boolean,
     depth: number,
     prepared: PostgresPreparedQueryState,
-    transactionState = { activeStreams: new Set<QueryStream<unknown>>(), valid: true },
+    transactionState = {
+      activeBatch: undefined as Promise<unknown> | undefined,
+      activeStreams: new Set<QueryStream<unknown>>(),
+      valid: true,
+    },
   ) {
     this.#pool = pool;
     this.#client = client;
@@ -225,9 +235,42 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute another query");
+    this.#rejectOperationDuringTransactionBatch("execute another query");
     const config = this.#queryConfig(query);
     const result = await (this.#client ?? this.#pool).query(config);
     return result.rows as readonly Row[];
+  }
+
+  async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("execute a query batch");
+    this.#rejectOperationDuringTransactionBatch("execute another query batch");
+    if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
+    const querySnapshot = [...queries] as unknown as QueryBatch<Queries>;
+    if (this.#client !== undefined) {
+      const operation = this.#executeBatch(this.#client, querySnapshot);
+      this.#transactionState.activeBatch = operation;
+      try {
+        return await operation;
+      } finally {
+        if (this.#transactionState.activeBatch === operation) this.#transactionState.activeBatch = undefined;
+      }
+    }
+
+    const client = await this.#pool.connect();
+    let results: QueryResults<Queries>;
+    try {
+      results = await this.#executeBatch(client, querySnapshot);
+    } catch (error) {
+      try {
+        client.release();
+      } catch {
+        /* Preserve the first query failure. */
+      }
+      throw error;
+    }
+    client.release();
+    return results;
   }
 
   stream<Row, Params extends readonly unknown[]>(
@@ -236,6 +279,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   ): QueryStream<Row> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("start another query stream");
+    this.#rejectOperationDuringTransactionBatch("start a query stream");
     const batchSize = validatePostgresStreamBatchSize(options.batchSize);
     const config = this.#queryConfig(query);
     let stream: QueryStream<Row>;
@@ -279,6 +323,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
             onStart: () => {
               this.#assertTransactionScopeOpen();
               this.#rejectOperationDuringTransactionStream("start another query stream");
+              this.#rejectOperationDuringTransactionBatch("start a query stream");
               this.#transactionState.activeStreams.add(stream as QueryStream<unknown>);
             },
             onClose: () => {
@@ -302,9 +347,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   async transaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("start a nested transaction");
+    this.#rejectOperationDuringTransactionBatch("start a nested transaction");
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
     const scope = new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared, {
+      activeBatch: undefined,
       activeStreams: new Set(),
       valid: true,
     });
@@ -317,10 +364,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
         scope.#transactionScopeOpen = false;
         scope.#transactionState.valid = false;
       }
-      await scope.#rejectLeakedTransactionStreams();
+      await scope.#rejectLeakedTransactionWork();
       await client.query("COMMIT");
     } catch (error) {
       await scope.#closeTransactionStreamsPreservingError();
+      await scope.#settleTransactionBatchPreservingError();
       try {
         await client.query("ROLLBACK");
       } catch {
@@ -361,11 +409,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       if (!scope.#transactionState.valid) {
         throw new Error("The parent PostgreSQL transaction scope ended before its nested transaction completed");
       }
-      await scope.#rejectLeakedTransactionStreams();
+      await scope.#rejectLeakedTransactionWork();
       await client.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
       await scope.#closeTransactionStreamsPreservingError();
+      await scope.#settleTransactionBatchPreservingError();
       if (scope.#transactionState.valid) {
         try {
           await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
@@ -388,9 +437,31 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     };
   }
 
-  async #rejectLeakedTransactionStreams(): Promise<void> {
-    if (this.#transactionStreams.size === 0 && this.#transactionState.activeStreams.size === 0) return;
+  async #executeBatch<const Queries extends readonly unknown[]>(
+    client: PostgresClientLike,
+    queries: QueryBatch<Queries>,
+  ): Promise<QueryResults<Queries>> {
+    const results: (readonly Record<string, unknown>[])[] = [];
+    for (const value of queries) {
+      this.#assertTransactionScopeOpen();
+      const query = value as unknown as Query<unknown, readonly unknown[]>;
+      const result = await client.query(this.#queryConfig(query));
+      results.push(result.rows);
+    }
+    return results as QueryResults<Queries>;
+  }
+
+  async #rejectLeakedTransactionWork(): Promise<void> {
+    const leakedStreams = this.#transactionStreams.size > 0 || this.#transactionState.activeStreams.size > 0;
+    const leakedBatch = this.#transactionState.activeBatch !== undefined;
+    if (!leakedStreams && !leakedBatch) return;
     await this.#closeTransactionStreamsPreservingError();
+    await this.#settleTransactionBatchPreservingError();
+    if (leakedBatch) {
+      throw new Error(
+        "A PostgreSQL transaction callback returned before its query batch completed; await the batch before returning",
+      );
+    }
     throw new Error("A PostgreSQL transaction callback returned before all query streams were completed or closed");
   }
 
@@ -405,10 +476,28 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     }
   }
 
+  async #settleTransactionBatchPreservingError(): Promise<void> {
+    const operation = this.#transactionState.activeBatch;
+    if (operation === undefined) return;
+    try {
+      await operation;
+    } catch {
+      /* The callback or transaction misuse error remains primary. */
+    }
+  }
+
   #rejectOperationDuringTransactionStream(operation: string): void {
     if (this.#client !== undefined && this.#transactionState.activeStreams.size > 0) {
       throw new Error(
         `Cannot ${operation} while a PostgreSQL transaction query stream is still open; complete or close the stream first`,
+      );
+    }
+  }
+
+  #rejectOperationDuringTransactionBatch(operation: string): void {
+    if (this.#client !== undefined && this.#transactionState.activeBatch !== undefined) {
+      throw new Error(
+        `Cannot ${operation} while a PostgreSQL transaction query batch is still running; await the batch first`,
       );
     }
   }

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -203,11 +203,20 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #prepared: PostgresPreparedQueryState;
   readonly #transactionDepth: number;
   #transactionScopeOpen = true;
+  #transactionOperationFailed = false;
+  #transactionOperationError: unknown;
   readonly #transactionState: {
     activeBatch: Promise<unknown> | undefined;
+    readonly activeExecutes: Set<Promise<unknown>>;
     readonly activeStreams: Set<QueryStream<unknown>>;
+    discardLease: boolean;
+    firstDatabaseOperationError: unknown;
+    unsafe: boolean;
+    unsafeDepth: number | undefined;
+    unsafeError: unknown;
     valid: boolean;
   };
+  readonly #transactionExecutes = new Set<Promise<unknown>>();
   readonly #transactionStreams = new Set<QueryStream<unknown>>();
 
   constructor(
@@ -219,7 +228,13 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     prepared: PostgresPreparedQueryState,
     transactionState = {
       activeBatch: undefined as Promise<unknown> | undefined,
+      activeExecutes: new Set<Promise<unknown>>(),
       activeStreams: new Set<QueryStream<unknown>>(),
+      discardLease: false,
+      firstDatabaseOperationError: undefined as unknown,
+      unsafe: false,
+      unsafeDepth: undefined as number | undefined,
+      unsafeError: undefined as unknown,
       valid: true,
     },
   ) {
@@ -237,8 +252,27 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#rejectOperationDuringTransactionStream("execute another query");
     this.#rejectOperationDuringTransactionBatch("execute another query");
     const config = this.#queryConfig(query);
-    const result = await (this.#client ?? this.#pool).query(config);
-    return result.rows as readonly Row[];
+    let operation: Promise<PostgresQueryResult>;
+    try {
+      operation = (this.#client ?? this.#pool).query(config);
+    } catch (error) {
+      this.#recordTransactionOperationFailure(error);
+      throw error;
+    }
+    if (this.#client !== undefined) {
+      this.#transactionExecutes.add(operation);
+      this.#transactionState.activeExecutes.add(operation);
+    }
+    try {
+      const result = await operation;
+      return result.rows as readonly Row[];
+    } catch (error) {
+      this.#recordTransactionOperationFailure(error);
+      throw error;
+    } finally {
+      this.#transactionExecutes.delete(operation);
+      this.#transactionState.activeExecutes.delete(operation);
+    }
   }
 
   async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
@@ -252,6 +286,9 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       this.#transactionState.activeBatch = operation;
       try {
         return await operation;
+      } catch (error) {
+        this.#recordTransactionOperationFailure(error);
+        throw error;
       } finally {
         if (this.#transactionState.activeBatch === operation) this.#transactionState.activeBatch = undefined;
       }
@@ -263,7 +300,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       results = await this.#executeBatch(client, querySnapshot);
     } catch (error) {
       try {
-        client.release();
+        client.release(error instanceof Error ? error : true);
       } catch {
         /* Preserve the first query failure. */
       }
@@ -309,6 +346,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
           const cursor = await client.openCursor(config);
           return { cursor, ...(release === undefined ? {} : { release }) };
         } catch (error) {
+          this.#recordTransactionOperationFailure(error);
           try {
             release?.(error);
           } catch {
@@ -330,6 +368,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
               this.#transactionState.activeStreams.delete(stream as QueryStream<unknown>);
               this.#transactionStreams.delete(stream as QueryStream<unknown>);
             },
+            onError: (error: unknown) => this.#recordTransactionOperationFailure(error),
           }),
     });
     if (this.#client !== undefined) this.#transactionStreams.add(stream as QueryStream<unknown>);
@@ -352,36 +391,57 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     const client = await this.#pool.connect();
     const scope = new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared, {
       activeBatch: undefined,
+      activeExecutes: new Set(),
       activeStreams: new Set(),
+      discardLease: false,
+      firstDatabaseOperationError: undefined,
+      unsafe: false,
+      unsafeDepth: undefined,
+      unsafeError: undefined,
       valid: true,
     });
     let result: T;
     try {
-      await client.query("BEGIN");
+      try {
+        await client.query("BEGIN");
+      } catch (error) {
+        scope.#recordTransactionOperationFailure(error);
+        throw error;
+      }
       try {
         result = await fn(scope);
       } finally {
         scope.#transactionScopeOpen = false;
         scope.#transactionState.valid = false;
       }
+      scope.#throwIfTransactionCannotCommit();
       await scope.#rejectLeakedTransactionWork();
-      await client.query("COMMIT");
+      try {
+        await client.query("COMMIT");
+      } catch (error) {
+        scope.#recordTransactionOperationFailure(error);
+        throw error;
+      }
     } catch (error) {
+      scope.#transactionScopeOpen = false;
+      scope.#transactionState.valid = false;
+      await scope.#settleTransactionExecutesPreservingError();
       await scope.#closeTransactionStreamsPreservingError();
       await scope.#settleTransactionBatchPreservingError();
       try {
         await client.query("ROLLBACK");
-      } catch {
+      } catch (cleanupError) {
+        scope.#markTransactionStateUnsafe(cleanupError);
         /* Preserve the original error. */
       }
       try {
-        client.release();
+        client.release(scope.#transactionLeaseReleaseError());
       } catch {
         /* Preserve the original error. */
       }
       throw error;
     }
-    client.release();
+    client.release(scope.#transactionLeaseReleaseError());
     return result;
   }
 
@@ -389,7 +449,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     const client = this.#client!;
     const depth = this.#transactionDepth + 1;
     const savepoint = `typed_sql_${depth}`;
-    await client.query(`SAVEPOINT ${savepoint}`);
+    try {
+      await client.query(`SAVEPOINT ${savepoint}`);
+    } catch (error) {
+      this.#recordTransactionOperationFailure(error);
+      throw error;
+    }
     const scope = new PostgresDatabaseImplementation(
       this.#pool,
       client,
@@ -409,16 +474,25 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       if (!scope.#transactionState.valid) {
         throw new Error("The parent PostgreSQL transaction scope ended before its nested transaction completed");
       }
+      scope.#throwIfTransactionCannotCommit();
       await scope.#rejectLeakedTransactionWork();
-      await client.query(`RELEASE SAVEPOINT ${savepoint}`);
+      try {
+        await client.query(`RELEASE SAVEPOINT ${savepoint}`);
+      } catch (error) {
+        scope.#recordTransactionOperationFailure(error);
+        throw error;
+      }
       return result;
     } catch (error) {
+      await scope.#settleTransactionExecutesPreservingError();
       await scope.#closeTransactionStreamsPreservingError();
       await scope.#settleTransactionBatchPreservingError();
       if (scope.#transactionState.valid) {
         try {
           await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
-        } catch {
+          scope.#recoverTransactionStateAfterSavepoint(depth);
+        } catch (cleanupError) {
+          scope.#markTransactionStateUnsafe(cleanupError);
           /* Preserve the original callback, query, or release error. */
         }
       }
@@ -453,16 +527,34 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
 
   async #rejectLeakedTransactionWork(): Promise<void> {
     const leakedStreams = this.#transactionStreams.size > 0 || this.#transactionState.activeStreams.size > 0;
+    const leakedExecutes = this.#transactionExecutes.size > 0 || this.#transactionState.activeExecutes.size > 0;
     const leakedBatch = this.#transactionState.activeBatch !== undefined;
-    if (!leakedStreams && !leakedBatch) return;
+    if (!leakedStreams && !leakedExecutes && !leakedBatch) return;
+    await this.#settleTransactionExecutesPreservingError();
     await this.#closeTransactionStreamsPreservingError();
     await this.#settleTransactionBatchPreservingError();
+    if (leakedExecutes) {
+      throw new Error(
+        "A PostgreSQL transaction callback returned before an execute operation completed; await execute before returning",
+      );
+    }
     if (leakedBatch) {
       throw new Error(
         "A PostgreSQL transaction callback returned before its query batch completed; await the batch before returning",
       );
     }
     throw new Error("A PostgreSQL transaction callback returned before all query streams were completed or closed");
+  }
+
+  async #settleTransactionExecutesPreservingError(): Promise<void> {
+    const operations = new Set([...this.#transactionExecutes, ...this.#transactionState.activeExecutes]);
+    for (const operation of operations) {
+      try {
+        await operation;
+      } catch {
+        /* The callback or transaction misuse error remains primary. */
+      }
+    }
   }
 
   async #closeTransactionStreamsPreservingError(): Promise<void> {
@@ -502,9 +594,71 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     }
   }
 
+  #recordTransactionOperationFailure(error: unknown): void {
+    if (this.#client === undefined) return;
+    if (!this.#transactionOperationFailed) {
+      this.#transactionOperationFailed = true;
+      this.#transactionOperationError = error;
+    }
+    this.#markTransactionStateUnsafe(error);
+  }
+
+  #markTransactionStateUnsafe(error: unknown): void {
+    if (!this.#transactionState.discardLease) {
+      this.#transactionState.discardLease = true;
+      this.#transactionState.firstDatabaseOperationError = error;
+    }
+    if (
+      !this.#transactionState.unsafe ||
+      this.#transactionState.unsafeDepth === undefined ||
+      this.#transactionDepth < this.#transactionState.unsafeDepth
+    ) {
+      this.#transactionState.unsafe = true;
+      this.#transactionState.unsafeDepth = this.#transactionDepth;
+      this.#transactionState.unsafeError = error;
+    }
+  }
+
+  #recoverTransactionStateAfterSavepoint(depth: number): void {
+    if (this.#transactionState.unsafeDepth === undefined || this.#transactionState.unsafeDepth < depth) return;
+    this.#transactionState.unsafe = false;
+    this.#transactionState.unsafeDepth = undefined;
+    this.#transactionState.unsafeError = undefined;
+  }
+
+  #transactionLeaseReleaseError(): Error | boolean | undefined {
+    if (!this.#transactionState.discardLease) return undefined;
+    return this.#transactionState.firstDatabaseOperationError instanceof Error
+      ? this.#transactionState.firstDatabaseOperationError
+      : true;
+  }
+
+  #throwIfTransactionCannotCommit(): void {
+    if (this.#transactionOperationFailed) {
+      if (this.#transactionOperationError !== undefined) throw this.#transactionOperationError;
+      throw new Error("A PostgreSQL transaction operation failed and the transaction cannot be committed");
+    }
+    if (this.#transactionState.unsafe) {
+      throw new Error("The PostgreSQL transaction connection did not complete recovery and cannot be committed", {
+        cause: this.#transactionState.unsafeError,
+      });
+    }
+  }
+
   #assertTransactionScopeOpen(): void {
-    if (this.#client !== undefined && (!this.#transactionScopeOpen || !this.#transactionState.valid)) {
+    if (this.#client === undefined) return;
+    if (!this.#transactionScopeOpen || !this.#transactionState.valid) {
       throw new Error("This PostgreSQL transaction scope has ended and can no longer be used");
+    }
+    if (this.#transactionOperationFailed) {
+      throw new Error("This PostgreSQL transaction scope cannot continue after a database operation failed", {
+        cause: this.#transactionOperationError,
+      });
+    }
+    if (this.#transactionState.unsafe) {
+      throw new Error("The PostgreSQL transaction cannot continue until its failed operation is rolled back", {
+        cause: this.#transactionState.unsafeError,
+      });
     }
   }
 

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -191,21 +191,26 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   async transaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
+    let result: T;
     try {
       await client.query("BEGIN");
-      const result = await fn(new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1));
+      result = await fn(new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1));
       await client.query("COMMIT");
-      return result;
     } catch (error) {
       try {
         await client.query("ROLLBACK");
       } catch {
         /* Preserve the original error. */
       }
+      try {
+        client.release();
+      } catch {
+        /* Preserve the original error. */
+      }
       throw error;
-    } finally {
-      client.release();
     }
+    client.release();
+    return result;
   }
 
   async #nestedTransaction<T>(fn: (db: Database) => Promise<T>): Promise<T> {
@@ -218,7 +223,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       await client.query(`RELEASE SAVEPOINT ${savepoint}`);
       return result;
     } catch (error) {
-      await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      try {
+        await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      } catch {
+        /* Preserve the original callback, query, or release error. */
+      }
       throw error;
     }
   }

--- a/packages/postgres/src/stream.ts
+++ b/packages/postgres/src/stream.ts
@@ -13,6 +13,7 @@ export interface PostgresCursorLease {
 export interface PostgresQueryStreamOptions {
   readonly batchSize: number;
   readonly start: () => Promise<PostgresCursorLease>;
+  readonly onError?: (error: unknown) => void;
   readonly onStart?: () => void;
   readonly onClose?: () => void;
 }
@@ -32,6 +33,7 @@ export class PostgresQueryStream<Row> implements QueryStream<Row> {
   readonly #batchSize: number;
   readonly #start: () => Promise<PostgresCursorLease>;
   readonly #onClose: (() => void) | undefined;
+  readonly #onError: ((error: unknown) => void) | undefined;
   readonly #onStart: (() => void) | undefined;
   #buffer: readonly Row[] = [];
   #bufferIndex = 0;
@@ -44,6 +46,7 @@ export class PostgresQueryStream<Row> implements QueryStream<Row> {
     this.#start = options.start;
     this.#onStart = options.onStart;
     this.#onClose = options.onClose;
+    this.#onError = options.onError;
   }
 
   [Symbol.asyncIterator](): this {
@@ -106,6 +109,7 @@ export class PostgresQueryStream<Row> implements QueryStream<Row> {
     }
 
     this.#terminal = true;
+    const hadLease = this.#lease !== undefined;
     this.#buffer = [];
     this.#bufferIndex = 0;
     let cleanupError: unknown;
@@ -115,13 +119,21 @@ export class PostgresQueryStream<Row> implements QueryStream<Row> {
       cleanupError = error;
     }
     try {
-      await this.#lease?.release?.(cleanupError);
+      await this.#lease?.release?.(primaryError !== undefined ? primaryError : cleanupError);
     } catch (error) {
       cleanupError ??= error;
     } finally {
       this.#onClose?.();
     }
 
+    const terminalError = primaryError ?? cleanupError;
+    if (hadLease && terminalError !== undefined) {
+      try {
+        this.#onError?.(terminalError);
+      } catch {
+        /* Lifecycle observers cannot replace the stream's primary error. */
+      }
+    }
     if (primaryError !== undefined) throw primaryError;
     if (cleanupError !== undefined) throw cleanupError;
   }

--- a/packages/postgres/src/stream.ts
+++ b/packages/postgres/src/stream.ts
@@ -1,0 +1,136 @@
+import type { QueryStream } from "@typed-sql/core";
+
+export interface PostgresCursorLike {
+  read(rowCount: number): Promise<readonly Record<string, unknown>[]>;
+  close(): Promise<void>;
+}
+
+export interface PostgresCursorLease {
+  readonly cursor: PostgresCursorLike;
+  release?(cleanupError?: unknown): void | Promise<void>;
+}
+
+export interface PostgresQueryStreamOptions {
+  readonly batchSize: number;
+  readonly start: () => Promise<PostgresCursorLease>;
+  readonly onStart?: () => void;
+  readonly onClose?: () => void;
+}
+
+function done(): IteratorReturnResult<undefined> {
+  return { done: true, value: undefined };
+}
+
+/**
+ * A demand-driven row iterator over a cursor lease.
+ *
+ * Operations are serialized because native PostgreSQL cursors cannot safely process overlapping
+ * reads. Cleanup always attempts both cursor close and lease release, while keeping the first
+ * operation or cleanup error as the observable failure.
+ */
+export class PostgresQueryStream<Row> implements QueryStream<Row> {
+  readonly #batchSize: number;
+  readonly #start: () => Promise<PostgresCursorLease>;
+  readonly #onClose: (() => void) | undefined;
+  readonly #onStart: (() => void) | undefined;
+  #buffer: readonly Row[] = [];
+  #bufferIndex = 0;
+  #lease: PostgresCursorLease | undefined;
+  #operation: Promise<void> = Promise.resolve();
+  #terminal = false;
+
+  constructor(options: PostgresQueryStreamOptions) {
+    this.#batchSize = options.batchSize;
+    this.#start = options.start;
+    this.#onStart = options.onStart;
+    this.#onClose = options.onClose;
+  }
+
+  [Symbol.asyncIterator](): this {
+    return this;
+  }
+
+  next(): Promise<IteratorResult<Row, undefined>> {
+    return this.#enqueue(async () => {
+      if (this.#terminal) return done();
+      if (this.#bufferIndex < this.#buffer.length) {
+        return { done: false, value: this.#buffer[this.#bufferIndex++]! };
+      }
+
+      try {
+        if (this.#lease === undefined) this.#onStart?.();
+        this.#lease ??= await this.#start();
+        const rows = await this.#lease.cursor.read(this.#batchSize);
+        if (rows.length === 0) {
+          await this.#terminate();
+          return done();
+        }
+        this.#buffer = rows as readonly Row[];
+        this.#bufferIndex = 1;
+        return { done: false, value: this.#buffer[0]! };
+      } catch (error) {
+        await this.#terminate(error);
+        throw error;
+      }
+    });
+  }
+
+  return(): Promise<IteratorResult<Row, undefined>> {
+    return this.#enqueue(async () => {
+      await this.#terminate();
+      return done();
+    });
+  }
+
+  close(): Promise<void> {
+    return this.#enqueue(() => this.#terminate());
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  #enqueue<Value>(operation: () => Promise<Value>): Promise<Value> {
+    const result = this.#operation.then(operation);
+    this.#operation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  async #terminate(primaryError?: unknown): Promise<void> {
+    if (this.#terminal) {
+      if (primaryError !== undefined) throw primaryError;
+      return;
+    }
+
+    this.#terminal = true;
+    this.#buffer = [];
+    this.#bufferIndex = 0;
+    let cleanupError: unknown;
+    try {
+      if (this.#lease !== undefined) await this.#lease.cursor.close();
+    } catch (error) {
+      cleanupError = error;
+    }
+    try {
+      await this.#lease?.release?.(cleanupError);
+    } catch (error) {
+      cleanupError ??= error;
+    } finally {
+      this.#onClose?.();
+    }
+
+    if (primaryError !== undefined) throw primaryError;
+    if (cleanupError !== undefined) throw cleanupError;
+  }
+}
+
+export function validatePostgresStreamBatchSize(batchSize: number | undefined): number {
+  const resolved = batchSize ?? 100;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError("PostgreSQL stream batchSize must be a positive safe integer");
+  }
+  return resolved;
+}

--- a/packages/postgres/test/batch.test.ts
+++ b/packages/postgres/test/batch.test.ts
@@ -1,0 +1,385 @@
+import type { Query, QueryResults } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import { sql } from "../../core/src/index.js";
+import {
+  createPostgresDatabase,
+  type PostgresClientLike,
+  type PostgresCursorLike,
+  type PostgresPoolLike,
+  type PostgresQueryConfig,
+  type PostgresQueryResult,
+} from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+
+class BatchCursor implements PostgresCursorLike {
+  closeCount = 0;
+
+  async read(): Promise<readonly Record<string, unknown>[]> {
+    return [{ id: 1 }];
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+class BatchClient implements PostgresClientLike {
+  readonly calls: (PostgresQueryConfig | string)[] = [];
+  readonly releaseArguments: (Error | boolean | undefined)[] = [];
+  readonly rows = new Map<string, readonly Record<string, unknown>[]>();
+  readonly cursor = new BatchCursor();
+  failText: string | undefined;
+  releaseError: Error | undefined;
+  blockedText: string | undefined;
+  readonly #startedResolvers: (() => void)[] = [];
+  readonly #continueResolvers: (() => void)[] = [];
+
+  async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
+    this.calls.push(config);
+    const text = typeof config === "string" ? config : config.text;
+    if (text === this.blockedText) {
+      await new Promise<void>((resolve) => {
+        this.#startedResolvers.shift()?.();
+        this.#continueResolvers.push(resolve);
+      });
+    }
+    if (text === this.failText) throw new Error(`failed: ${text}`);
+    return { rows: this.rows.get(text) ?? [] };
+  }
+
+  async openCursor(): Promise<PostgresCursorLike> {
+    return this.cursor;
+  }
+
+  waitForBlockedQuery(): Promise<void> {
+    return new Promise((resolve) => this.#startedResolvers.push(resolve));
+  }
+
+  continueBlockedQuery(): void {
+    this.#continueResolvers.shift()?.();
+  }
+
+  release(error?: Error | boolean): void {
+    this.releaseArguments.push(error);
+    if (this.releaseError !== undefined) throw this.releaseError;
+  }
+}
+
+class BatchPool implements PostgresPoolLike {
+  readonly client = new BatchClient();
+  connectCount = 0;
+  directQueryCount = 0;
+  blockConnect = false;
+  #connectStarted: (() => void) | undefined;
+  #continueConnect: (() => void) | undefined;
+
+  async query(): Promise<PostgresQueryResult> {
+    this.directQueryCount += 1;
+    return { rows: [] };
+  }
+
+  async connect(): Promise<PostgresClientLike> {
+    this.connectCount += 1;
+    if (this.blockConnect) {
+      this.#connectStarted?.();
+      await new Promise<void>((resolve) => {
+        this.#continueConnect = resolve;
+      });
+    }
+    return this.client;
+  }
+
+  waitForConnect(): Promise<void> {
+    return new Promise((resolve) => {
+      this.#connectStarted = resolve;
+    });
+  }
+
+  continueConnect(): void {
+    this.#continueConnect?.();
+  }
+
+  async end(): Promise<void> {}
+}
+
+function commandText(client: BatchClient): string[] {
+  return client.calls.map((call) => (typeof call === "string" ? call : call.text));
+}
+
+const accountQuery = sql<{ id: bigint; email: string }>`SELECT id, email FROM account`;
+const projectQuery = sql<{ id: bigint; budget: string | null }>`SELECT id, budget FROM project`;
+
+await describe("PostgreSQL ordered query batches", async () => {
+  await it("preserves heterogeneous tuples, homogeneous arrays, and rejects non-query members", async () => {
+    const database = createPostgresDatabase({ pool: new BatchPool() });
+    const tuple = database.batch([accountQuery, projectQuery]);
+    const exactTuple: Assert<
+      Equal<
+        Awaited<typeof tuple>,
+        readonly [readonly { id: bigint; email: string }[], readonly { id: bigint; budget: string | null }[]]
+      >
+    > = true;
+    const queries = [1n, 2n].map(
+      (id): Query<{ id: bigint }, readonly [bigint]> => sql`SELECT id FROM account WHERE id = ${id}`,
+    );
+    const array = database.batch(queries);
+    const exactArray: Assert<Equal<Awaited<typeof array>, readonly (readonly { id: bigint }[])[]>> = true;
+    const mapper: Assert<
+      Equal<
+        QueryResults<readonly [typeof accountQuery, typeof projectQuery]>,
+        readonly [readonly { id: bigint; email: string }[], readonly { id: bigint; budget: string | null }[]]
+      >
+    > = true;
+    void exactTuple;
+    void exactArray;
+    void mapper;
+    await tuple;
+    await array;
+
+    const rejectNonQueryMember = (): Promise<unknown> => {
+      // @ts-expect-error Every batch member must be a typed Query.
+      return database.batch([accountQuery, "SELECT 1"]);
+    };
+    void rejectNonQueryMember;
+  });
+
+  await it("returns one shared frozen empty result without acquiring a connection", async () => {
+    const pool = new BatchPool();
+    const database = createPostgresDatabase({ pool });
+    const empty = database.batch([]);
+    const exactEmpty: Assert<Equal<Awaited<typeof empty>, readonly []>> = true;
+    void exactEmpty;
+    const first = await empty;
+    const second = await database.batch([]);
+    strict.deepStrictEqual(first, []);
+    strict.strictEqual(first, second);
+    strict.ok(Object.isFrozen(first));
+    strict.strictEqual(pool.connectCount, 0);
+    strict.strictEqual(pool.directQueryCount, 0);
+  });
+
+  await it("leases one client and executes every query sequentially in input order", async () => {
+    const pool = new BatchPool();
+    pool.client.rows.set("SELECT id, email FROM account", [{ id: 1n, email: "one@example.com" }]);
+    pool.client.rows.set("SELECT id, budget FROM project", [{ id: 2n, budget: "12.50" }]);
+    const database = createPostgresDatabase({ pool });
+
+    const results = await database.batch([accountQuery, projectQuery]);
+
+    strict.deepStrictEqual(results, [[{ id: 1n, email: "one@example.com" }], [{ id: 2n, budget: "12.50" }]]);
+    strict.deepStrictEqual(commandText(pool.client), [
+      "SELECT id, email FROM account",
+      "SELECT id, budget FROM project",
+    ]);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.strictEqual(pool.directQueryCount, 0);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("snapshots the ordered input before waiting for a root connection", async () => {
+    const pool = new BatchPool();
+    pool.blockConnect = true;
+    const connectStarted = pool.waitForConnect();
+    const queries: Query<unknown, readonly []>[] = [sql`SELECT first`];
+    const results = createPostgresDatabase({ pool }).batch(queries);
+    await connectStarted;
+    queries.push(sql`SELECT appended too late`);
+    pool.continueConnect();
+
+    await results;
+    strict.deepStrictEqual(commandText(pool.client), ["SELECT first"]);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("retains parameter codecs and prepared metadata for each entry", async () => {
+    const pool = new BatchPool();
+    const database = createPostgresDatabase({ pool });
+    const byId = database.prepare("batch-account-by-id", (id: bigint) => sql`SELECT id FROM account WHERE id = ${id}`);
+
+    await database.batch([byId(7n), sql`SELECT id FROM project WHERE owner_id = ${7n}`]);
+
+    const [prepared, ordinary] = pool.client.calls;
+    if (prepared === undefined || typeof prepared === "string") strict.fail("Expected a prepared query config");
+    if (ordinary === undefined || typeof ordinary === "string") strict.fail("Expected an ordinary query config");
+    strict.strictEqual(prepared.name, "batch-account-by-id");
+    strict.deepStrictEqual(prepared.values, ["7"]);
+    strict.strictEqual(ordinary.name, undefined);
+    strict.deepStrictEqual(ordinary.values, ["7"]);
+    strict.ok(prepared.types !== undefined);
+    strict.strictEqual(prepared.types, ordinary.types);
+  });
+
+  await it("stops at the first failure, releases once, and preserves that failure over cleanup", async () => {
+    const pool = new BatchPool();
+    pool.client.failText = "SELECT broken";
+    pool.client.releaseError = new Error("release failed");
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () => database.batch([sql`SELECT first`, sql`SELECT broken`, sql`SELECT never`]),
+      (error) => {
+        strict.match((error as Error).message, /failed: SELECT broken/);
+        return true;
+      },
+    );
+
+    strict.deepStrictEqual(commandText(pool.client), ["SELECT first", "SELECT broken"]);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("surfaces a release failure after a successful batch without releasing twice", async () => {
+    const pool = new BatchPool();
+    const releaseError = new Error("release failed");
+    pool.client.releaseError = releaseError;
+    await strict.rejects(
+      () => createPostgresDatabase({ pool }).batch([sql`SELECT one`]),
+      (error) => {
+        strict.strictEqual(error, releaseError);
+        return true;
+      },
+    );
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+});
+
+await describe("PostgreSQL transaction query batches", async () => {
+  await it("reuses the transaction client and gains atomicity only from the surrounding transaction", async () => {
+    const pool = new BatchPool();
+    pool.client.rows.set("SELECT first", [{ value: "first" }]);
+    pool.client.rows.set("SELECT second", [{ value: "second" }]);
+    const database = createPostgresDatabase({ pool });
+
+    const results = await database.transaction((transaction) =>
+      transaction.batch([sql<{ value: string }>`SELECT first`, sql<{ value: string }>`SELECT second`]),
+    );
+
+    strict.deepStrictEqual(results, [[{ value: "first" }], [{ value: "second" }]]);
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT first", "SELECT second", "COMMIT"]);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("rolls back a failed transaction batch before releasing its client", async () => {
+    const pool = new BatchPool();
+    pool.client.failText = "SELECT broken";
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction((transaction) =>
+          transaction.batch([sql`SELECT first`, sql`SELECT broken`, sql`SELECT never`]),
+        ),
+      /failed: SELECT broken/,
+    );
+
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT first", "SELECT broken", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+
+  await it("rejects a batch before dispatch while a transaction stream owns the client", async () => {
+    const pool = new BatchPool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      const stream = transaction.stream(sql`SELECT streamed`);
+      await stream.next();
+      await strict.rejects(() => transaction.batch([sql`SELECT buffered`]), /stream is still open/);
+      strict.deepStrictEqual(commandText(pool.client), ["BEGIN"]);
+      await stream.close();
+    });
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "COMMIT"]);
+  });
+
+  await it("rejects competing transaction work while a batch owns the shared client", async () => {
+    const pool = new BatchPool();
+    pool.client.blockedText = "SELECT batched";
+    const started = pool.client.waitForBlockedQuery();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      const batch = transaction.batch([sql`SELECT batched`]);
+      await started;
+      await strict.rejects(() => transaction.execute(sql`SELECT competing`), /batch is still running/);
+      await strict.rejects(() => transaction.batch([sql`SELECT competing`]), /batch is still running/);
+      strict.throws(() => transaction.stream(sql`SELECT competing`), /batch is still running/);
+      await strict.rejects(() => transaction.transaction(async () => undefined), /batch is still running/);
+      strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT batched"]);
+      pool.client.continueBlockedQuery();
+      await batch;
+    });
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT batched", "COMMIT"]);
+  });
+
+  await it("stops an unawaited outer batch before rollback, release, or a later dispatch", async () => {
+    const pool = new BatchPool();
+    pool.client.blockedText = "SELECT first";
+    const started = pool.client.waitForBlockedQuery();
+    let escapedBatch: Promise<unknown> | undefined;
+    const transaction = createPostgresDatabase({ pool }).transaction(async (scope) => {
+      escapedBatch = scope.batch([sql`SELECT first`, sql`SELECT never`]);
+      await started;
+    });
+    await started;
+    pool.client.continueBlockedQuery();
+
+    await strict.rejects(() => transaction, /returned before its query batch completed/);
+    await strict.rejects(() => escapedBatch!, /transaction scope has ended/);
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT first", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+
+  await it("preserves a callback failure while settling its unawaited batch before rollback", async () => {
+    const pool = new BatchPool();
+    pool.client.blockedText = "SELECT first";
+    const started = pool.client.waitForBlockedQuery();
+    const callbackError = new Error("callback failed");
+    let escapedBatch: Promise<unknown> | undefined;
+    const transaction = createPostgresDatabase({ pool }).transaction(async (scope) => {
+      escapedBatch = scope.batch([sql`SELECT first`, sql`SELECT never`]);
+      await started;
+      throw callbackError;
+    });
+    await started;
+    pool.client.continueBlockedQuery();
+
+    await strict.rejects(
+      () => transaction,
+      (error) => {
+        strict.strictEqual(error, callbackError);
+        return true;
+      },
+    );
+    await strict.rejects(() => escapedBatch!, /transaction scope has ended/);
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT first", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+
+  await it("stops an unawaited nested batch before rolling back its savepoint", async () => {
+    const pool = new BatchPool();
+    pool.client.blockedText = "SELECT nested-first";
+    const started = pool.client.waitForBlockedQuery();
+    let escapedBatch: Promise<unknown> | undefined;
+    await createPostgresDatabase({ pool }).transaction(async (parent) => {
+      const nested = parent.transaction(async (scope) => {
+        escapedBatch = scope.batch([sql`SELECT nested-first`, sql`SELECT nested-never`]);
+        await started;
+      });
+      await started;
+      pool.client.continueBlockedQuery();
+      await strict.rejects(() => nested, /returned before its query batch completed/);
+      await strict.rejects(() => escapedBatch!, /transaction scope has ended/);
+    });
+
+    strict.deepStrictEqual(commandText(pool.client), [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "SELECT nested-first",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+    strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+});

--- a/packages/postgres/test/batch.test.ts
+++ b/packages/postgres/test/batch.test.ts
@@ -229,7 +229,7 @@ await describe("PostgreSQL ordered query batches", async () => {
     strict.deepStrictEqual(commandText(pool.client), ["SELECT first", "SELECT broken"]);
     strict.strictEqual(pool.connectCount, 1);
     strict.strictEqual(pool.client.releaseArguments.length, 1);
-    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+    strict.match((pool.client.releaseArguments[0] as Error).message, /failed: SELECT broken/);
   });
 
   await it("surfaces a release failure after a successful batch without releasing twice", async () => {
@@ -279,6 +279,23 @@ await describe("PostgreSQL transaction query batches", async () => {
 
     strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT first", "SELECT broken", "ROLLBACK"]);
     strict.strictEqual(pool.client.releaseArguments.length, 1);
+  });
+
+  await it("refuses to commit when a transaction callback catches a batch rejection", async () => {
+    const pool = new BatchPool();
+    pool.client.failText = "SELECT broken";
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          await strict.rejects(() => transaction.batch([sql`SELECT broken`]), /failed: SELECT broken/);
+        }),
+      /failed: SELECT broken/,
+    );
+
+    strict.deepStrictEqual(commandText(pool.client), ["BEGIN", "SELECT broken", "ROLLBACK"]);
+    strict.match((pool.client.releaseArguments[0] as Error).message, /failed: SELECT broken/);
   });
 
   await it("rejects a batch before dispatch while a transaction stream owns the client", async () => {

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -1,8 +1,35 @@
+import { EventEmitter } from "node:events";
 import type { Pool as PgPool } from "pg";
 import { describe, it, strict } from "poku";
-import { adaptPgPool, createPgDatabase, loadPgDriver, pg } from "../src/pg.js";
+import { sql } from "../../core/src/index.js";
+import { adaptPgPool, createPgDatabase, loadPgCursorDriver, loadPgDriver, pg } from "../src/pg.js";
 import type { PostgresQueryable, PostgresQueryResult } from "../src/provider.js";
-import type { PostgresQueryConfig } from "../src/runtime.js";
+import { createPostgresDatabase, type PostgresQueryConfig } from "../src/runtime.js";
+
+class FakePgCursor {
+  static readonly created: FakePgCursor[] = [];
+  readonly text: string;
+  readonly values: readonly unknown[] | undefined;
+  readonly config: unknown;
+  closeCount = 0;
+  readCount = 0;
+
+  constructor(text: string, values?: readonly unknown[], config?: unknown) {
+    this.text = text;
+    this.values = values;
+    this.config = config;
+    FakePgCursor.created.push(this);
+  }
+
+  async read(): Promise<readonly Record<string, unknown>[]> {
+    this.readCount += 1;
+    return this.readCount === 1 ? [{ value: 1 }] : [];
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
 
 class CatalogClient implements PostgresQueryable {
   async query<Row extends Record<string, unknown>>(text: string): Promise<PostgresQueryResult<Row>> {
@@ -12,15 +39,32 @@ class CatalogClient implements PostgresQueryable {
   }
 }
 
-class FakePgClient {
+interface FakeNativeCursor {
+  read(rowCount: number): Promise<readonly Record<string, unknown>[]>;
+  close(): Promise<void>;
+}
+
+class FakePgClient extends EventEmitter {
   released = false;
+  releaseError: Error | boolean | undefined;
   readonly calls: unknown[] = [];
-  async query(config: unknown): Promise<{ rows: readonly Record<string, unknown>[] }> {
+  query(config: unknown): Promise<{ rows: readonly Record<string, unknown>[] }> | FakeNativeCursor {
     this.calls.push(config);
-    return { rows: [{ value: 1 }] };
+    if (
+      typeof config === "object" &&
+      config !== null &&
+      "read" in config &&
+      typeof config.read === "function" &&
+      "close" in config &&
+      typeof config.close === "function"
+    ) {
+      return config as FakeNativeCursor;
+    }
+    return Promise.resolve({ rows: [{ value: 1 }] });
   }
-  release(): void {
+  release(error?: Error | boolean): void {
     this.released = true;
+    this.releaseError = error;
   }
 }
 
@@ -28,11 +72,13 @@ class FakePgPool {
   ended = false;
   readonly client = new FakePgClient();
   readonly calls: unknown[] = [];
+  connectCount = 0;
   async query(config: unknown): Promise<{ rows: readonly Record<string, unknown>[] }> {
     this.calls.push(config);
     return { rows: [{ value: 1 }] };
   }
   async connect(): Promise<FakePgClient> {
+    this.connectCount += 1;
     return this.client;
   }
   async end(): Promise<void> {
@@ -73,6 +119,103 @@ await describe("application-owned pg integration", async () => {
     });
     strict.strictEqual(original.client.released, true);
     strict.strictEqual(original.ended, true);
+  });
+
+  await it("loads pg-cursor lazily and bridges its real rows-array API", async () => {
+    FakePgCursor.created.length = 0;
+    const original = new FakePgPool();
+    let imports = 0;
+    const pool = adaptPgPool(original as unknown as PgPool, async () => {
+      imports += 1;
+      return { default: FakePgCursor };
+    });
+    const database = createPostgresDatabase({ pool });
+    const prepared = database.prepare("streamed-value", (value: bigint) => sql`SELECT ${value} AS value`);
+    const stream = database.stream(prepared(7n), { batchSize: 4 });
+
+    strict.strictEqual(imports, 0);
+    strict.strictEqual(original.connectCount, 0);
+    strict.deepStrictEqual(await stream.next(), { done: false, value: { value: 1 } });
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+
+    strict.strictEqual(imports, 1);
+    strict.strictEqual(original.connectCount, 1);
+    strict.strictEqual(original.client.released, true);
+    const cursor = FakePgCursor.created[0];
+    strict.strictEqual(cursor?.text, "SELECT $1 AS value");
+    strict.deepStrictEqual(cursor?.values, ["7"]);
+    const cursorConfig = cursor?.config as { readonly types?: unknown };
+    strict.ok(cursorConfig.types !== undefined);
+    strict.deepStrictEqual(Object.keys(cursorConfig), ["types"]);
+    strict.strictEqual(cursor?.closeCount, 1);
+  });
+
+  await it("keeps ordinary cursor SQL errors on the reusable-client cleanup path", async () => {
+    const sqlError = new Error("invalid input syntax");
+    let closeCount = 0;
+    class SqlErrorCursor {
+      async read(): Promise<readonly Record<string, unknown>[]> {
+        throw sqlError;
+      }
+      async close(): Promise<void> {
+        closeCount += 1;
+      }
+    }
+    const original = new FakePgPool();
+    const database = createPostgresDatabase({
+      pool: adaptPgPool(original as unknown as PgPool, async () => ({ default: SqlErrorCursor })),
+    });
+
+    await strict.rejects(
+      () => database.stream(sql`SELECT broken`).next(),
+      (error) => {
+        strict.strictEqual(error, sqlError);
+        return true;
+      },
+    );
+    strict.strictEqual(closeCount, 1);
+    strict.strictEqual(original.client.released, true);
+    strict.strictEqual(original.client.releaseError, undefined);
+  });
+
+  await it("settles a hanging native cursor close when the leased pg client fails fatally", async () => {
+    const readError = new Error("cursor read failed");
+    const fatalError = new Error("socket terminated");
+    let signalCloseStarted!: () => void;
+    const closeStarted = new Promise<void>((resolve) => {
+      signalCloseStarted = resolve;
+    });
+    let closeCount = 0;
+    class FatalCursor {
+      async read(): Promise<readonly Record<string, unknown>[]> {
+        throw readError;
+      }
+      close(): Promise<void> {
+        closeCount += 1;
+        signalCloseStarted();
+        return new Promise(() => undefined);
+      }
+    }
+    const original = new FakePgPool();
+    const database = createPostgresDatabase({
+      pool: adaptPgPool(original as unknown as PgPool, async () => ({ default: FatalCursor })),
+    });
+    const next = database.stream(sql`SELECT fatal`).next();
+
+    await closeStarted;
+    original.client.emit("error", fatalError);
+    await strict.rejects(
+      () => next,
+      (error) => {
+        strict.strictEqual(error, readError);
+        return true;
+      },
+    );
+    strict.strictEqual(closeCount, 1);
+    strict.strictEqual(original.client.released, true);
+    strict.strictEqual(original.client.releaseError, fatalError);
+    strict.strictEqual(original.client.listenerCount("error"), 0);
+    strict.strictEqual(original.client.listenerCount("end"), 0);
   });
 
   await it("creates and owns a real pg pool without opening a connection", async () => {
@@ -116,5 +259,32 @@ await describe("application-owned pg integration", async () => {
       unexpected,
     );
     strict.ok((await loadPgDriver()).Pool !== undefined);
+  });
+
+  await it("normalizes missing or invalid application-owned pg-cursor failures", async () => {
+    const missing = Object.assign(new Error("missing"), { code: "ERR_MODULE_NOT_FOUND" });
+    await strict.rejects(
+      () =>
+        loadPgCursorDriver(async () => {
+          throw missing;
+        }),
+      /pnpm add pg-cursor/,
+    );
+    await strict.rejects(() => loadPgCursorDriver(async () => ({ default: {} })), /default Cursor constructor/);
+    strict.strictEqual(await loadPgCursorDriver(async () => ({ default: FakePgCursor })), FakePgCursor);
+  });
+
+  await it("does not lease a pg client when the lazy cursor dependency is missing", async () => {
+    const original = new FakePgPool();
+    const missing = Object.assign(new Error("missing"), { code: "ERR_MODULE_NOT_FOUND" });
+    const database = createPostgresDatabase({
+      pool: adaptPgPool(original as unknown as PgPool, async () => {
+        throw missing;
+      }),
+    });
+    const stream = database.stream(sql`SELECT 1`);
+    strict.strictEqual(original.connectCount, 0);
+    await strict.rejects(() => stream.next(), /pnpm add pg-cursor/);
+    strict.strictEqual(original.connectCount, 0);
   });
 });

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -45,7 +45,12 @@ await describe("application-owned pg integration", async () => {
     const original = new FakePgPool();
     const pool = adaptPgPool(original as unknown as PgPool);
     strict.deepStrictEqual((await pool.query("SELECT 1")).rows, [{ value: 1 }]);
-    const config: PostgresQueryConfig = { text: "SELECT $1", values: [1], types: { getTypeParser: () => String } };
+    const config: PostgresQueryConfig = {
+      name: "selected-value",
+      text: "SELECT $1",
+      values: [1],
+      types: { getTypeParser: () => String },
+    };
     await pool.query(config);
     const client = await pool.connect();
     await client.query("SELECT 2");
@@ -54,6 +59,18 @@ await describe("application-owned pg integration", async () => {
     await pool.end();
     strict.strictEqual(original.calls.length, 2);
     strict.strictEqual(original.client.calls.length, 2);
+    strict.deepStrictEqual(original.calls[1], {
+      name: "selected-value",
+      text: "SELECT $1",
+      values: [1],
+      types: config.types,
+    });
+    strict.deepStrictEqual(original.client.calls[1], {
+      name: "selected-value",
+      text: "SELECT $1",
+      values: [1],
+      types: config.types,
+    });
     strict.strictEqual(original.client.released, true);
     strict.strictEqual(original.ended, true);
   });

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import type { Pool as PgPool } from "pg";
 import { describe, it, strict } from "poku";
 import { sql } from "../../core/src/index.js";
-import { adaptPgPool, createPgDatabase, loadPgCursorDriver, loadPgDriver, pg } from "../src/pg.js";
+import { adaptPgPool, createPgDatabase, loadPgCursorDriver, loadPgDriver, type PgOptions, pg } from "../src/pg.js";
 import type { PostgresQueryable, PostgresQueryResult } from "../src/provider.js";
 import { createPostgresDatabase, type PostgresQueryConfig } from "../src/runtime.js";
 
@@ -47,6 +47,7 @@ interface FakeNativeCursor {
 class FakePgClient extends EventEmitter {
   released = false;
   releaseError: Error | boolean | undefined;
+  queryError: Error | undefined;
   readonly calls: unknown[] = [];
   query(config: unknown): Promise<{ rows: readonly Record<string, unknown>[] }> | FakeNativeCursor {
     this.calls.push(config);
@@ -60,6 +61,7 @@ class FakePgClient extends EventEmitter {
     ) {
       return config as FakeNativeCursor;
     }
+    if (this.queryError !== undefined) return Promise.reject(this.queryError);
     return Promise.resolve({ rows: [{ value: 1 }] });
   }
   release(error?: Error | boolean): void {
@@ -87,6 +89,36 @@ class FakePgPool {
 }
 
 await describe("application-owned pg integration", async () => {
+  await it("rejects query_timeout exposed by an application-created pg pool", () => {
+    const direct = Object.assign(new FakePgPool(), { options: { query_timeout: 100 } });
+    strict.throws(() => adaptPgPool(direct as unknown as PgPool), /does not accept pg query_timeout/);
+
+    for (const connectionString of [
+      "postgresql://unused/app?query_timeout=100",
+      "postgresql://unused/app?%71uery_timeout=100",
+    ]) {
+      const fromUri = Object.assign(new FakePgPool(), { options: { connectionString } });
+      strict.throws(() => adaptPgPool(fromUri as unknown as PgPool), /does not accept pg query_timeout/);
+    }
+  });
+
+  await it("rejects query_timeout from real pg Pool options before adapting it", async () => {
+    const { Pool } = await loadPgDriver();
+    const pools = [
+      new Pool({ query_timeout: 100 }),
+      new Pool({ connectionString: "postgresql://unused/app?query_timeout=100" }),
+      new Pool({ connectionString: "postgresql://unused/app?%71uery_timeout=100" }),
+    ];
+
+    for (const pool of pools) {
+      try {
+        strict.throws(() => adaptPgPool(pool), /does not accept pg query_timeout.*statement_timeout/);
+      } finally {
+        await pool.end();
+      }
+    }
+  });
+
   await it("adapts pool and checked-out client query shapes", async () => {
     const original = new FakePgPool();
     const pool = adaptPgPool(original as unknown as PgPool);
@@ -121,6 +153,23 @@ await describe("application-owned pg integration", async () => {
     strict.strictEqual(original.ended, true);
   });
 
+  await it("discards a checked-out pg lease after a root batch query rejection", async () => {
+    const original = new FakePgPool();
+    const queryError = new Error("query rejected before readiness is known");
+    original.client.queryError = queryError;
+    const database = createPostgresDatabase({ pool: adaptPgPool(original as unknown as PgPool) });
+
+    await strict.rejects(
+      () => database.batch([sql`SELECT uncertain`]),
+      (error) => {
+        strict.strictEqual(error, queryError);
+        return true;
+      },
+    );
+    strict.strictEqual(original.client.released, true);
+    strict.strictEqual(original.client.releaseError, queryError);
+  });
+
   await it("loads pg-cursor lazily and bridges its real rows-array API", async () => {
     FakePgCursor.created.length = 0;
     const original = new FakePgPool();
@@ -150,7 +199,7 @@ await describe("application-owned pg integration", async () => {
     strict.strictEqual(cursor?.closeCount, 1);
   });
 
-  await it("keeps ordinary cursor SQL errors on the reusable-client cleanup path", async () => {
+  await it("discards the client with the primary cursor SQL error", async () => {
     const sqlError = new Error("invalid input syntax");
     let closeCount = 0;
     class SqlErrorCursor {
@@ -175,7 +224,7 @@ await describe("application-owned pg integration", async () => {
     );
     strict.strictEqual(closeCount, 1);
     strict.strictEqual(original.client.released, true);
-    strict.strictEqual(original.client.releaseError, undefined);
+    strict.strictEqual(original.client.releaseError, sqlError);
   });
 
   await it("settles a hanging native cursor close when the leased pg client fails fatally", async () => {
@@ -213,7 +262,7 @@ await describe("application-owned pg integration", async () => {
     );
     strict.strictEqual(closeCount, 1);
     strict.strictEqual(original.client.released, true);
-    strict.strictEqual(original.client.releaseError, fatalError);
+    strict.strictEqual(original.client.releaseError, readError);
     strict.strictEqual(original.client.listenerCount("error"), 0);
     strict.strictEqual(original.client.listenerCount("end"), 0);
   });
@@ -221,7 +270,7 @@ await describe("application-owned pg integration", async () => {
   await it("creates and owns a real pg pool without opening a connection", async () => {
     const database = await createPgDatabase({
       connectionString: async () => "postgresql://typed_sql:unused@127.0.0.1:1/unused",
-      poolConfig: { max: 1 },
+      poolConfig: { max: 1, statement_timeout: 5_000 },
     });
     await database.close();
     await strict.rejects(() => createPgDatabase({ connectionString: "" }), /must not be empty/);
@@ -233,6 +282,33 @@ await describe("application-owned pg integration", async () => {
         }),
       /owns poolConfig\.types/,
     );
+    await strict.rejects(
+      () =>
+        createPgDatabase({
+          connectionString: "postgresql://unused/app",
+          poolConfig: { query_timeout: 100 } as never,
+        }),
+      /does not accept pg query_timeout.*statement_timeout/,
+    );
+    for (const connectionString of [
+      "postgresql://unused/app?query_timeout=100",
+      "postgresql://unused/app?%71uery_timeout=100",
+    ]) {
+      await strict.rejects(() => createPgDatabase({ connectionString }), /does not accept pg query_timeout/);
+    }
+    await strict.rejects(
+      () => createPgDatabase({ connectionString: async () => "postgresql://unused/app?%71uery_timeout=100" }),
+      /does not accept pg query_timeout/,
+    );
+
+    const unsupportedClientTimeout = (): PgOptions => ({
+      connectionString: "postgresql://unused/app",
+      poolConfig: {
+        // @ts-expect-error Client-side query_timeout can reject before ReadyForQuery.
+        query_timeout: 100,
+      },
+    });
+    void unsupportedClientTimeout;
   });
 
   await it("supports injected catalog clients and validates provider options", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -11,20 +11,35 @@ import {
 
 class MockClient implements PostgresClientLike {
   readonly calls: (PostgresQueryConfig | string)[] = [];
-  released = false;
+  releaseCount = 0;
+  releaseError: Error | undefined;
   failOnSelect = false;
   failOnRollback = false;
+  failOnRollbackToSavepoint = false;
+  failOnReleaseSavepoint = false;
+  failOnSavepoint = false;
 
   async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
     this.calls.push(config);
     if (this.failOnRollback && config === "ROLLBACK") throw new Error("rollback failed");
+    if (this.failOnRollbackToSavepoint && typeof config === "string" && config.startsWith("ROLLBACK TO SAVEPOINT"))
+      throw new Error("savepoint rollback failed");
+    if (this.failOnReleaseSavepoint && typeof config === "string" && config.startsWith("RELEASE SAVEPOINT"))
+      throw new Error("savepoint release failed");
+    if (this.failOnSavepoint && typeof config === "string" && config.startsWith("SAVEPOINT"))
+      throw new Error("savepoint creation failed");
     if (this.failOnSelect && typeof config !== "string" && config.text.startsWith("SELECT"))
       throw new Error("query failed");
     return { rows: typeof config === "string" ? [] : [{ id: 1 }] };
   }
 
   release(): void {
-    this.released = true;
+    this.releaseCount += 1;
+    if (this.releaseError !== undefined) throw this.releaseError;
+  }
+
+  get released(): boolean {
+    return this.releaseCount > 0;
   }
 }
 
@@ -149,6 +164,44 @@ await describe("PostgreSQL runtime adapter", async () => {
     strict.strictEqual(pool.client.released, true);
   });
 
+  await it("preserves transaction errors when rollback and release cleanup fail", async () => {
+    const pool = new MockPool();
+    pool.client.failOnRollback = true;
+    pool.client.releaseError = new Error("release failed");
+    const db = createPostgresDatabase({ pool });
+    const transactionError = new Error("transaction failed");
+
+    await strict.rejects(
+      () =>
+        db.transaction(async () => {
+          throw transactionError;
+        }),
+      (error) => {
+        strict.strictEqual(error, transactionError);
+        return true;
+      },
+    );
+    strict.deepStrictEqual(pool.client.calls, ["BEGIN", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("surfaces release errors after a successful commit", async () => {
+    const pool = new MockPool();
+    const releaseError = new Error("release failed after commit");
+    pool.client.releaseError = releaseError;
+    const db = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () => db.transaction(async () => "result"),
+      (error) => {
+        strict.strictEqual(error, releaseError);
+        return true;
+      },
+    );
+    strict.deepStrictEqual(pool.client.calls, ["BEGIN", "COMMIT"]);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
   await it("rolls back nested savepoints and preserves outer rollback errors", async () => {
     const nestedPool = new MockPool();
     const nestedDb = createPostgresDatabase({ pool: nestedPool });
@@ -174,6 +227,77 @@ await describe("PostgreSQL runtime adapter", async () => {
       () => rollbackDb.transaction(async (transaction) => transaction.execute(sql`SELECT 1`)),
       /query failed/,
     );
+  });
+
+  await it("preserves nested callback errors when savepoint rollback fails", async () => {
+    const pool = new MockPool();
+    pool.client.failOnRollbackToSavepoint = true;
+    const db = createPostgresDatabase({ pool });
+    const callbackError = new Error("nested callback failed");
+
+    await strict.rejects(
+      () =>
+        db.transaction(async (transaction) => {
+          await transaction.transaction(async () => {
+            throw callbackError;
+          });
+        }),
+      (error) => {
+        strict.strictEqual(error, callbackError);
+        return true;
+      },
+    );
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK TO SAVEPOINT typed_sql_2", "ROLLBACK"],
+    );
+    strict.strictEqual(pool.client.released, true);
+  });
+
+  await it("preserves release errors when savepoint rollback cleanup also fails", async () => {
+    const pool = new MockPool();
+    pool.client.failOnReleaseSavepoint = true;
+    pool.client.failOnRollbackToSavepoint = true;
+    const db = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () => db.transaction(async (transaction) => transaction.transaction(async () => "result")),
+      /savepoint release failed/,
+    );
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      [
+        "BEGIN",
+        "SAVEPOINT typed_sql_2",
+        "RELEASE SAVEPOINT typed_sql_2",
+        "ROLLBACK TO SAVEPOINT typed_sql_2",
+        "ROLLBACK",
+      ],
+    );
+    strict.strictEqual(pool.client.released, true);
+  });
+
+  await it("does not enter a nested callback when savepoint creation fails", async () => {
+    const pool = new MockPool();
+    pool.client.failOnSavepoint = true;
+    const db = createPostgresDatabase({ pool });
+    let callbackCalled = false;
+
+    await strict.rejects(
+      () =>
+        db.transaction(async (transaction) => {
+          await transaction.transaction(async () => {
+            callbackCalled = true;
+          });
+        }),
+      /savepoint creation failed/,
+    );
+    strict.strictEqual(callbackCalled, false);
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK"],
+    );
+    strict.strictEqual(pool.client.released, true);
   });
 
   await it("owns pools when requested and prevents transactional close", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
+import { type Query, type QueryParameters, type QueryRow, sql } from "../../core/src/index.js";
 import {
   createPostgresDatabase,
   createPostgresTypeParsers,
   type PostgresClientLike,
   type PostgresPoolLike,
+  type PostgresPreparedQueryFactory,
   type PostgresQueryConfig,
   type PostgresQueryResult,
   type PostgresTransaction,
@@ -133,6 +134,129 @@ await describe("PostgreSQL runtime adapter", async () => {
     }
     await db.close();
     strict.strictEqual(pool.ended, false);
+  });
+
+  await it("creates lazy prepared factories that retain exact query types", async () => {
+    const pool = new MockPool();
+    const db = createPostgresDatabase({ pool });
+    const accountById = db.prepare(
+      "account-by-id",
+      (id: bigint, active: boolean) =>
+        sql.__typed<
+          { id: number },
+          readonly [bigint, boolean]
+        >()`SELECT id FROM users WHERE id = ${id} AND active = ${active}`,
+    );
+    const exactFactory: Assert<
+      Equal<
+        typeof accountById,
+        PostgresPreparedQueryFactory<[id: bigint, active: boolean], { id: number }, readonly [bigint, boolean]>
+      >
+    > = true;
+    const exactRow: Assert<Equal<QueryRow<ReturnType<typeof accountById>>, { id: number }>> = true;
+    const exactParameters: Assert<Equal<QueryParameters<ReturnType<typeof accountById>>, readonly [bigint, boolean]>> =
+      true;
+    void exactFactory;
+    void exactRow;
+    void exactParameters;
+
+    strict.strictEqual(accountById.statementName, "account-by-id");
+    strict.strictEqual(pool.calls.length, 0);
+    strict.throws(() => {
+      // @ts-expect-error Prepared factory metadata is readonly.
+      accountById.statementName = "changed";
+    }, /read only|Cannot assign/);
+
+    const rows = await db.execute(accountById(7n, true));
+    strict.deepStrictEqual(rows, [{ id: 1 }]);
+    const call = pool.calls[0];
+    if (call === undefined || typeof call === "string") strict.fail("Expected a prepared query config call");
+    else {
+      strict.strictEqual(call.name, "account-by-id");
+      strict.strictEqual(call.text, "SELECT id FROM users WHERE id = $1 AND active = $2");
+      strict.deepStrictEqual(call.values, ["7", true]);
+    }
+  });
+
+  await it("validates prepared names and reserves them at declaration", () => {
+    const db = createPostgresDatabase({ pool: new MockPool() });
+    strict.throws(() => db.prepare(null as never, () => sql`SELECT 1`), /non-empty.*NUL/);
+    strict.throws(() => db.prepare("", () => sql`SELECT 1`), /non-empty.*NUL/);
+    strict.throws(() => db.prepare("bad\0name", () => sql`SELECT 1`), /non-empty.*NUL/);
+    db.prepare("one", () => sql`SELECT 1`);
+    strict.throws(() => db.prepare("one", () => sql`SELECT 1`), /already registered/);
+  });
+
+  await it("rejects structural shape changes before driver dispatch", async () => {
+    const pool = new MockPool();
+    const db = createPostgresDatabase({ pool });
+    const dynamic = db.prepare(
+      "dynamic-account",
+      (projection: "id" | "email") =>
+        sql.__typed<{ id?: number; email?: string }, readonly []>()`SELECT ${sql.raw(projection)} FROM users`,
+    );
+
+    await db.execute(dynamic("id"));
+    strict.strictEqual(pool.calls.length, 1);
+    strict.throws(() => dynamic("email"), /must always render the same SQL text/);
+    strict.strictEqual(pool.calls.length, 1);
+  });
+
+  await it("rejects one query object carrying conflicting prepared names", () => {
+    const db = createPostgresDatabase({ pool: new MockPool() });
+    const shared: Query<{ id: number }, readonly []> = sql.__typed<{ id: number }, readonly []>()`SELECT id FROM users`;
+    const first = db.prepare("first", () => shared);
+    const second = db.prepare("second", () => shared);
+    strict.strictEqual(first(), shared);
+    strict.throws(() => second(), /cannot use both prepared statement "first" and "second"/);
+  });
+
+  await it("shares prepared metadata through transactions and nested transactions", async () => {
+    const pool = new MockPool();
+    const db = createPostgresDatabase({ pool });
+    const rootPrepared = db.prepare("root-prepared", (id: bigint) => sql`SELECT id FROM users WHERE id = ${id}`);
+    let transactionPrepared: PostgresPreparedQueryFactory<[email: string], unknown, readonly [string]> | undefined;
+
+    await db.transaction(async (transaction) => {
+      await transaction.execute(rootPrepared(1n));
+      transactionPrepared = transaction.prepare(
+        "transaction-prepared",
+        (email: string) => sql`SELECT id FROM users WHERE email = ${email}`,
+      );
+      await transaction.transaction(async (nested) => {
+        await nested.execute(transactionPrepared!("a@example.com"));
+      });
+    });
+
+    await db.execute(transactionPrepared!("b@example.com"));
+    const clientQueries = pool.client.calls.filter(
+      (call): call is PostgresQueryConfig => typeof call !== "string" && call.text.startsWith("SELECT"),
+    );
+    strict.deepStrictEqual(
+      clientQueries.map((call) => call.name),
+      ["root-prepared", "transaction-prepared"],
+    );
+    const poolQuery = pool.calls[0];
+    if (poolQuery === undefined || typeof poolQuery === "string") strict.fail("Expected a prepared pool query");
+    else strict.strictEqual(poolQuery.name, "transaction-prepared");
+  });
+
+  await it("treats another database instance's prepared query as ordinary", async () => {
+    const firstPool = new MockPool();
+    const secondPool = new MockPool();
+    const firstDb = createPostgresDatabase({ pool: firstPool });
+    const secondDb = createPostgresDatabase({ pool: secondPool });
+    const prepared = firstDb.prepare("database-local", (id: number) => sql`SELECT id FROM users WHERE id = ${id}`);
+    const query = prepared(1);
+
+    await firstDb.execute(query);
+    await secondDb.execute(query);
+    const firstCall = firstPool.calls[0];
+    const secondCall = secondPool.calls[0];
+    if (firstCall === undefined || typeof firstCall === "string") strict.fail("Expected first query config");
+    else strict.strictEqual(firstCall.name, "database-local");
+    if (secondCall === undefined || typeof secondCall === "string") strict.fail("Expected second query config");
+    else strict.strictEqual(secondCall.name, undefined);
   });
 
   await it("commits on one checked-out client and supports nested savepoints", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -7,7 +7,12 @@ import {
   type PostgresPoolLike,
   type PostgresQueryConfig,
   type PostgresQueryResult,
+  type PostgresTransaction,
 } from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
 
 class MockClient implements PostgresClientLike {
   readonly calls: (PostgresQueryConfig | string)[] = [];
@@ -134,8 +139,14 @@ await describe("PostgreSQL runtime adapter", async () => {
     const pool = new MockPool();
     const db = createPostgresDatabase({ pool });
     await db.transaction(async (transaction) => {
+      const exactTransactionScope: Assert<Equal<typeof transaction, PostgresTransaction>> = true;
+      const transactionOmitsClose: Assert<Equal<Extract<keyof typeof transaction, "close">, never>> = true;
+      void exactTransactionScope;
+      void transactionOmitsClose;
       await transaction.execute(sql`SELECT id FROM users`);
       await transaction.transaction(async (nested) => {
+        const exactNestedScope: Assert<Equal<typeof nested, PostgresTransaction>> = true;
+        void exactNestedScope;
         await nested.execute(sql`SELECT id FROM users`);
       });
     });

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -18,15 +18,35 @@ type Assert<Value extends true> = Value;
 class MockClient implements PostgresClientLike {
   readonly calls: (PostgresQueryConfig | string)[] = [];
   releaseCount = 0;
+  readonly releaseArguments: (Error | boolean | undefined)[] = [];
   releaseError: Error | undefined;
+  failOnBegin = false;
+  failOnCommit = false;
   failOnSelect = false;
+  readonly beginError = new Error("begin failed");
+  readonly commitError = new Error("commit failed");
+  readonly selectError = new Error("query failed");
+  blockedError: Error | undefined;
+  blockedText: string | undefined;
   failOnRollback = false;
   failOnRollbackToSavepoint = false;
   failOnReleaseSavepoint = false;
   failOnSavepoint = false;
+  #continueBlocked: (() => void) | undefined;
+  #signalBlocked: (() => void) | undefined;
 
   async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
     this.calls.push(config);
+    const text = typeof config === "string" ? config : config.text;
+    if (text === this.blockedText) {
+      this.#signalBlocked?.();
+      await new Promise<void>((resolve) => {
+        this.#continueBlocked = resolve;
+      });
+      if (this.blockedError !== undefined) throw this.blockedError;
+    }
+    if (this.failOnBegin && config === "BEGIN") throw this.beginError;
+    if (this.failOnCommit && config === "COMMIT") throw this.commitError;
     if (this.failOnRollback && config === "ROLLBACK") throw new Error("rollback failed");
     if (this.failOnRollbackToSavepoint && typeof config === "string" && config.startsWith("ROLLBACK TO SAVEPOINT"))
       throw new Error("savepoint rollback failed");
@@ -34,13 +54,23 @@ class MockClient implements PostgresClientLike {
       throw new Error("savepoint release failed");
     if (this.failOnSavepoint && typeof config === "string" && config.startsWith("SAVEPOINT"))
       throw new Error("savepoint creation failed");
-    if (this.failOnSelect && typeof config !== "string" && config.text.startsWith("SELECT"))
-      throw new Error("query failed");
+    if (this.failOnSelect && typeof config !== "string" && config.text.startsWith("SELECT")) throw this.selectError;
     return { rows: typeof config === "string" ? [] : [{ id: 1 }] };
   }
 
-  release(): void {
+  waitForBlockedQuery(): Promise<void> {
+    return new Promise((resolve) => {
+      this.#signalBlocked = resolve;
+    });
+  }
+
+  continueBlockedQuery(): void {
+    this.#continueBlocked?.();
+  }
+
+  release(error?: Error | boolean): void {
     this.releaseCount += 1;
+    this.releaseArguments.push(error);
     if (this.releaseError !== undefined) throw this.releaseError;
   }
 
@@ -297,6 +327,259 @@ await describe("PostgreSQL runtime adapter", async () => {
     const commands = pool.client.calls.map((call) => (typeof call === "string" ? call : call.text));
     strict.deepStrictEqual(commands, ["BEGIN", "SELECT id FROM users", "ROLLBACK"]);
     strict.strictEqual(pool.client.released, true);
+    strict.deepStrictEqual(pool.client.releaseArguments, [pool.client.selectError]);
+  });
+
+  await it("refuses to commit when a transaction callback catches a query rejection", async () => {
+    const pool = new MockPool();
+    pool.client.failOnSelect = true;
+    const db = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        db.transaction(async (transaction) => {
+          await strict.rejects(() => transaction.execute(sql`SELECT id FROM users`), /query failed/);
+        }),
+      /query failed/,
+    );
+
+    const commands = pool.client.calls.map((call) => (typeof call === "string" ? call : call.text));
+    strict.deepStrictEqual(commands, ["BEGIN", "SELECT id FROM users", "ROLLBACK"]);
+    strict.strictEqual(pool.client.released, true);
+    strict.deepStrictEqual(pool.client.releaseArguments, [pool.client.selectError]);
+  });
+
+  await it("blocks all later work in a failed transaction scope before driver dispatch", async () => {
+    const pool = new MockPool();
+    pool.client.failOnSelect = true;
+    const db = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        db.transaction(async (transaction) => {
+          await strict.rejects(() => transaction.execute(sql`SELECT failed`), /query failed/);
+          pool.client.failOnSelect = false;
+
+          await strict.rejects(() => transaction.execute(sql`SELECT later`), /scope cannot continue/);
+          await strict.rejects(() => transaction.batch([sql`SELECT later`]), /scope cannot continue/);
+          strict.throws(() => transaction.stream(sql`SELECT later`), /scope cannot continue/);
+          strict.throws(() => transaction.prepare("later", () => sql`SELECT later`), /scope cannot continue/);
+          await strict.rejects(() => transaction.transaction(async () => undefined), /scope cannot continue/);
+        }),
+      (error) => {
+        strict.strictEqual(error, pool.client.selectError);
+        return true;
+      },
+    );
+
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT failed", "ROLLBACK"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [pool.client.selectError]);
+  });
+
+  await it("settles an unawaited execute before rolling back without selecting commit", async () => {
+    const pool = new MockPool();
+    pool.client.blockedText = "SELECT slow";
+    const started = pool.client.waitForBlockedQuery();
+    const db = createPostgresDatabase({ pool });
+    let escapedExecute: Promise<readonly unknown[]> | undefined;
+
+    const transaction = db.transaction(async (scope) => {
+      escapedExecute = scope.execute(sql`SELECT slow`);
+      void escapedExecute.catch(() => undefined);
+      await started;
+    });
+    void transaction.catch(() => undefined);
+
+    await started;
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT slow"],
+    );
+    pool.client.continueBlockedQuery();
+    await escapedExecute;
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT slow", "ROLLBACK"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("preserves execute misuse while a late driver rejection marks the lease for discard", async () => {
+    const pool = new MockPool();
+    const timeoutError = new Error("Query read timeout");
+    pool.client.blockedText = "SELECT timeout";
+    pool.client.blockedError = timeoutError;
+    const started = pool.client.waitForBlockedQuery();
+    const db = createPostgresDatabase({ pool });
+    let escapedExecute: Promise<readonly unknown[]> | undefined;
+
+    const transaction = db.transaction(async (scope) => {
+      escapedExecute = scope.execute(sql`SELECT timeout`);
+      void escapedExecute.catch(() => undefined);
+      await started;
+    });
+    void transaction.catch(() => undefined);
+
+    await started;
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT timeout"],
+    );
+    pool.client.continueBlockedQuery();
+    await strict.rejects(
+      () => escapedExecute!,
+      (error) => {
+        strict.strictEqual(error, timeoutError);
+        return true;
+      },
+    );
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT timeout", "ROLLBACK"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [timeoutError]);
+  });
+
+  await it("preserves a callback error while settling a late rejected execute before rollback", async () => {
+    const pool = new MockPool();
+    const queryError = new Error("late query failure");
+    const callbackError = new Error("callback failed first");
+    pool.client.blockedText = "SELECT late_failure";
+    pool.client.blockedError = queryError;
+    const started = pool.client.waitForBlockedQuery();
+    const db = createPostgresDatabase({ pool });
+    let escapedExecute: Promise<readonly unknown[]> | undefined;
+
+    const transaction = db.transaction(async (scope) => {
+      escapedExecute = scope.execute(sql`SELECT late_failure`);
+      void escapedExecute.catch(() => undefined);
+      await started;
+      throw callbackError;
+    });
+    void transaction.catch(() => undefined);
+
+    await started;
+    pool.client.continueBlockedQuery();
+    await strict.rejects(() => escapedExecute!, queryError);
+    await strict.rejects(
+      () => transaction,
+      (error) => {
+        strict.strictEqual(error, callbackError);
+        return true;
+      },
+    );
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SELECT late_failure", "ROLLBACK"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [queryError]);
+  });
+
+  await it("rolls back an unawaited nested execute before releasing its savepoint", async () => {
+    const pool = new MockPool();
+    pool.client.blockedText = "SELECT nested_slow";
+    const started = pool.client.waitForBlockedQuery();
+    const db = createPostgresDatabase({ pool });
+    let escapedExecute: Promise<readonly unknown[]> | undefined;
+
+    const transaction = db.transaction(async (parent) => {
+      await strict.rejects(
+        () =>
+          parent.transaction(async (nested) => {
+            escapedExecute = nested.execute(sql`SELECT nested_slow`);
+            void escapedExecute.catch(() => undefined);
+            await started;
+          }),
+        /await execute before returning/,
+      );
+    });
+
+    await started;
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "SELECT nested_slow"],
+    );
+    pool.client.continueBlockedQuery();
+    await escapedExecute;
+    await transaction;
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "SELECT nested_slow", "ROLLBACK TO SAVEPOINT typed_sql_2", "COMMIT"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("lets the parent finalizer settle an execute owned by an unawaited nested scope", async () => {
+    const pool = new MockPool();
+    pool.client.blockedText = "SELECT escaped_nested";
+    const started = pool.client.waitForBlockedQuery();
+    const db = createPostgresDatabase({ pool });
+    let escapedExecute: Promise<readonly unknown[]> | undefined;
+    let nestedTransaction: Promise<void> | undefined;
+
+    const transaction = db.transaction(async (parent) => {
+      nestedTransaction = parent.transaction(async (nested) => {
+        escapedExecute = nested.execute(sql`SELECT escaped_nested`);
+        void escapedExecute.catch(() => undefined);
+        await started;
+      });
+      void nestedTransaction.catch(() => undefined);
+      await started;
+    });
+    void transaction.catch(() => undefined);
+
+    await started;
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "SELECT escaped_nested"],
+    );
+    pool.client.continueBlockedQuery();
+    await escapedExecute;
+    await strict.rejects(() => nestedTransaction!, /parent PostgreSQL transaction scope ended|await execute/);
+    await strict.rejects(() => transaction, /await execute before returning/);
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      ["BEGIN", "SAVEPOINT typed_sql_2", "SELECT escaped_nested", "ROLLBACK"],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("recovers the parent after savepoint rollback but still discards its lease", async () => {
+    const pool = new MockPool();
+    pool.client.failOnSelect = true;
+    const db = createPostgresDatabase({ pool });
+
+    await db.transaction(async (parent) => {
+      await strict.rejects(
+        () =>
+          parent.transaction(async (nested) => {
+            await strict.rejects(() => nested.execute(sql`SELECT nested_failed`), /query failed/);
+            pool.client.failOnSelect = false;
+            await strict.rejects(() => nested.execute(sql`SELECT nested_blocked`), /scope cannot continue/);
+            await strict.rejects(() => parent.execute(sql`SELECT parent_too_early`), /until.*rolled back/);
+          }),
+        /query failed/,
+      );
+      await parent.execute(sql`SELECT parent_recovered`);
+    });
+
+    strict.deepStrictEqual(
+      pool.client.calls.map((call) => (typeof call === "string" ? call : call.text)),
+      [
+        "BEGIN",
+        "SAVEPOINT typed_sql_2",
+        "SELECT nested_failed",
+        "ROLLBACK TO SAVEPOINT typed_sql_2",
+        "SELECT parent_recovered",
+        "COMMIT",
+      ],
+    );
+    strict.deepStrictEqual(pool.client.releaseArguments, [pool.client.selectError]);
   });
 
   await it("preserves transaction errors when rollback and release cleanup fail", async () => {
@@ -318,6 +601,53 @@ await describe("PostgreSQL runtime adapter", async () => {
     );
     strict.deepStrictEqual(pool.client.calls, ["BEGIN", "ROLLBACK"]);
     strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("keeps a successfully rolled-back callback-only failure lease reusable", async () => {
+    const pool = new MockPool();
+    const db = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        db.transaction(async () => {
+          throw new Error("callback failed");
+        }),
+      /callback failed/,
+    );
+
+    strict.deepStrictEqual(pool.client.calls, ["BEGIN", "ROLLBACK"]);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("discards the lease when transaction control queries reject", async () => {
+    const beginPool = new MockPool();
+    beginPool.client.failOnBegin = true;
+    let callbackCalled = false;
+    await strict.rejects(
+      () =>
+        createPostgresDatabase({ pool: beginPool }).transaction(async () => {
+          callbackCalled = true;
+        }),
+      (error) => {
+        strict.strictEqual(error, beginPool.client.beginError);
+        return true;
+      },
+    );
+    strict.strictEqual(callbackCalled, false);
+    strict.deepStrictEqual(beginPool.client.calls, ["BEGIN", "ROLLBACK"]);
+    strict.deepStrictEqual(beginPool.client.releaseArguments, [beginPool.client.beginError]);
+
+    const commitPool = new MockPool();
+    commitPool.client.failOnCommit = true;
+    await strict.rejects(
+      () => createPostgresDatabase({ pool: commitPool }).transaction(async () => "result"),
+      (error) => {
+        strict.strictEqual(error, commitPool.client.commitError);
+        return true;
+      },
+    );
+    strict.deepStrictEqual(commitPool.client.calls, ["BEGIN", "COMMIT", "ROLLBACK"]);
+    strict.deepStrictEqual(commitPool.client.releaseArguments, [commitPool.client.commitError]);
   });
 
   await it("surfaces release errors after a successful commit", async () => {

--- a/packages/postgres/test/stream.test.ts
+++ b/packages/postgres/test/stream.test.ts
@@ -405,6 +405,7 @@ await describe("PostgreSQL transaction query streams", async () => {
     });
     strict.deepStrictEqual(commands(pool.client), ["BEGIN", "COMMIT"]);
     await strict.rejects(() => escaped!.execute(sql`SELECT escaped`), /transaction scope has ended/);
+    await strict.rejects(() => escaped!.batch([sql`SELECT escaped`]), /transaction scope has ended/);
     strict.throws(() => escaped!.stream(sql`SELECT escaped`), /transaction scope has ended/);
     strict.throws(() => escaped!.prepare("escaped", () => sql`SELECT escaped`), /transaction scope has ended/);
     await strict.rejects(() => escaped!.transaction(async () => undefined), /transaction scope has ended/);
@@ -424,6 +425,7 @@ await describe("PostgreSQL transaction query streams", async () => {
       /callback failed/,
     );
     await strict.rejects(() => escaped!.execute(sql`SELECT escaped`), /transaction scope has ended/);
+    await strict.rejects(() => escaped!.batch([sql`SELECT escaped`]), /transaction scope has ended/);
     strict.throws(() => escaped!.stream(sql`SELECT escaped`), /transaction scope has ended/);
     strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
   });

--- a/packages/postgres/test/stream.test.ts
+++ b/packages/postgres/test/stream.test.ts
@@ -1,0 +1,495 @@
+import type { QueryStream } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import { sql } from "../../core/src/index.js";
+import {
+  createPostgresDatabase,
+  type PostgresClientLike,
+  type PostgresCursorLike,
+  type PostgresPoolLike,
+  type PostgresQueryConfig,
+  type PostgresQueryResult,
+  type PostgresTransaction,
+} from "../src/runtime.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
+type Assert<Value extends true> = Value;
+
+class FakeCursor implements PostgresCursorLike {
+  readonly reads: number[] = [];
+  closeCount = 0;
+  closeError: Error | undefined;
+  failAtRead: number | undefined;
+  readonly #pages: readonly (readonly Record<string, unknown>[])[];
+
+  constructor(pages: readonly (readonly Record<string, unknown>[])[]) {
+    this.#pages = pages;
+  }
+
+  async read(rowCount: number): Promise<readonly Record<string, unknown>[]> {
+    this.reads.push(rowCount);
+    if (this.failAtRead === this.reads.length) throw new Error(`cursor read ${this.reads.length} failed`);
+    return this.#pages[this.reads.length - 1] ?? [];
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+    if (this.closeError !== undefined) throw this.closeError;
+  }
+}
+
+class FakeClient implements PostgresClientLike {
+  readonly calls: (PostgresQueryConfig | string)[] = [];
+  readonly cursorConfigs: PostgresQueryConfig[] = [];
+  cursor = new FakeCursor([[{ id: 1 }, { id: 2 }], []]);
+  cursorOpenError: Error | undefined;
+  releaseCount = 0;
+  releaseErrors: (Error | boolean | undefined)[] = [];
+  releaseError: Error | undefined;
+
+  async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
+    this.calls.push(config);
+    return { rows: [] };
+  }
+
+  async openCursor(config: PostgresQueryConfig): Promise<PostgresCursorLike> {
+    this.cursorConfigs.push(config);
+    if (this.cursorOpenError !== undefined) throw this.cursorOpenError;
+    return this.cursor;
+  }
+
+  release(error?: Error | boolean): void {
+    this.releaseCount += 1;
+    this.releaseErrors.push(error);
+    if (this.releaseError !== undefined) throw this.releaseError;
+  }
+}
+
+class FakePool implements PostgresPoolLike {
+  readonly client = new FakeClient();
+  readonly calls: (PostgresQueryConfig | string)[] = [];
+  connectCount = 0;
+
+  async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
+    this.calls.push(config);
+    return { rows: [] };
+  }
+
+  async connect(): Promise<PostgresClientLike> {
+    this.connectCount += 1;
+    return this.client;
+  }
+
+  async end(): Promise<void> {}
+}
+
+function commands(client: FakeClient): string[] {
+  return client.calls.map((call) => (typeof call === "string" ? call : call.text));
+}
+
+await describe("PostgreSQL query streams", async () => {
+  await it("is lazy, retains the row type, fetches bounded pages, and releases once on completion", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    const stream = database.stream(sql<{ id: number }>`SELECT id FROM account`, { batchSize: 2 });
+    const exactType: Assert<Equal<typeof stream, QueryStream<{ id: number }>>> = true;
+    void exactType;
+
+    strict.strictEqual(pool.connectCount, 0);
+    const rows: { id: number }[] = [];
+    for await (const row of stream) rows.push(row);
+
+    strict.deepStrictEqual(rows, [{ id: 1 }, { id: 2 }]);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.deepStrictEqual(pool.client.cursor.reads, [2, 2]);
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+  });
+
+  await it("validates batch sizes without acquiring a connection", () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    for (const batchSize of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) {
+      strict.throws(() => database.stream(sql`SELECT 1`, { batchSize }), /positive safe integer/);
+    }
+    strict.strictEqual(pool.connectCount, 0);
+    strict.doesNotThrow(() => database.stream(sql`SELECT 1`, { batchSize: 1 }));
+  });
+
+  await it("closes before iteration, double-closes, and async-disposes without acquiring", async () => {
+    const pool = new FakePool();
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await stream.close();
+    await stream.close();
+    await stream[Symbol.asyncDispose]();
+    strict.strictEqual(pool.connectCount, 0);
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+  });
+
+  await it("closes and releases on early for-await break", async () => {
+    const pool = new FakePool();
+    const stream = createPostgresDatabase({ pool }).stream(sql<{ id: number }>`SELECT id FROM account`);
+    for await (const row of stream) {
+      strict.strictEqual(row.id, 1);
+      break;
+    }
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("preserves a consumer-body error while for-await closes and releases", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.closeError = new Error("cursor close failed");
+    pool.client.releaseError = new Error("release failed");
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    const consumerError = new Error("consumer failed");
+    await strict.rejects(
+      async () => {
+        for await (const _row of stream) throw consumerError;
+      },
+      (error) => {
+        strict.strictEqual(error, consumerError);
+        return true;
+      },
+    );
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("closes an active stream explicitly and releases once", async () => {
+    const pool = new FakePool();
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    strict.deepStrictEqual(await stream.next(), { done: false, value: { id: 1 } });
+    await stream.close();
+    await stream.close();
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("preserves driver failures while closing and releasing exactly once", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.failAtRead = 2;
+    pool.client.cursor.closeError = new Error("cursor close failed");
+    pool.client.releaseError = new Error("release failed");
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`, { batchSize: 1 });
+    await stream.next();
+    await stream.next();
+    await strict.rejects(() => stream.next(), /cursor read 2 failed/);
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+    strict.strictEqual(pool.client.releaseErrors[0], pool.client.cursor.closeError);
+  });
+
+  await it("preserves a driver failure before the first row", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.failAtRead = 1;
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await strict.rejects(() => stream.next(), /cursor read 1 failed/);
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("async-disposes an active stream", async () => {
+    const pool = new FakePool();
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await stream.next();
+    await stream[Symbol.asyncDispose]();
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("surfaces cleanup failures after successful work and still releases", async () => {
+    const pool = new FakePool();
+    const closeError = new Error("cursor close failed");
+    pool.client.cursor.closeError = closeError;
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await stream.next();
+    await strict.rejects(
+      () => stream.close(),
+      (error) => {
+        strict.strictEqual(error, closeError);
+        return true;
+      },
+    );
+    strict.strictEqual(pool.client.releaseCount, 1);
+    strict.strictEqual(pool.client.releaseErrors[0], closeError);
+  });
+
+  await it("surfaces a release failure when cursor cleanup succeeds", async () => {
+    const pool = new FakePool();
+    const releaseError = new Error("release failed");
+    pool.client.releaseError = releaseError;
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await stream.next();
+    await strict.rejects(
+      () => stream.close(),
+      (error) => {
+        strict.strictEqual(error, releaseError);
+        return true;
+      },
+    );
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+    await stream.close();
+  });
+
+  await it("releases a root lease when cursor creation fails", async () => {
+    const pool = new FakePool();
+    pool.client.cursorOpenError = new Error("cursor creation failed");
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    await strict.rejects(() => stream.next(), /cursor creation failed/);
+    strict.strictEqual(pool.client.releaseCount, 1);
+    strict.strictEqual(pool.client.releaseErrors[0], pool.client.cursorOpenError);
+  });
+
+  await it("reports a missing optional cursor capability only when iteration starts", async () => {
+    const pool = new FakePool();
+    (pool.client as { openCursor: FakeClient["openCursor"] | undefined }).openCursor = undefined;
+    const stream = createPostgresDatabase({ pool }).stream(sql`SELECT 1`);
+    strict.strictEqual(pool.connectCount, 0);
+    await strict.rejects(() => stream.next(), /pnpm add pg-cursor/);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("retains prepared metadata at the driver-neutral cursor boundary", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    const prepared = database.prepare("account-stream", (id: bigint) => sql`SELECT id FROM account WHERE id = ${id}`);
+    const stream = database.stream(prepared(7n));
+    await stream.next();
+    const config = pool.client.cursorConfigs[0];
+    strict.strictEqual(config?.name, "account-stream");
+    strict.strictEqual(config?.text, "SELECT id FROM account WHERE id = $1");
+    strict.deepStrictEqual(config?.values, ["7"]);
+    await stream.close();
+  });
+});
+
+await describe("PostgreSQL transaction query streams", async () => {
+  await it("reuses the transaction client without releasing it before commit", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      const stream = transaction.stream(sql<{ id: number }>`SELECT id FROM account`);
+      const exactType: Assert<Equal<typeof stream, QueryStream<{ id: number }>>> = true;
+      void exactType;
+      await stream.next();
+      await stream.close();
+      strict.strictEqual(pool.client.releaseCount, 0);
+    });
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "COMMIT"]);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("allows ordinary work before an unstarted stream begins", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      const stream = transaction.stream(sql`SELECT streamed`);
+      await transaction.execute(sql`SELECT buffered`);
+      await stream.close();
+    });
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "SELECT buffered", "COMMIT"]);
+  });
+
+  await it("rejects competing work while a transaction stream is active", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      const first = transaction.stream(sql`SELECT first`);
+      const second = transaction.stream(sql`SELECT second`);
+      await first.next();
+      await strict.rejects(() => transaction.execute(sql`SELECT buffered`), /stream is still open/);
+      await strict.rejects(() => second.next(), /stream is still open/);
+      await strict.rejects(() => transaction.transaction(async () => undefined), /stream is still open/);
+      strict.deepStrictEqual(commands(pool.client), ["BEGIN"]);
+      await first.close();
+    });
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "COMMIT"]);
+  });
+
+  await it("shares active-stream ownership across nested transaction scopes", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (parent) => {
+      await parent.transaction(async (nested) => {
+        const stream = nested.stream(sql`SELECT nested`);
+        await stream.next();
+        await strict.rejects(() => parent.execute(sql`SELECT parent`), /stream is still open/);
+        strict.deepStrictEqual(commands(pool.client), ["BEGIN", "SAVEPOINT typed_sql_2"]);
+        await stream.close();
+      });
+    });
+    strict.deepStrictEqual(commands(pool.client), [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "RELEASE SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+  });
+
+  await it("closes an unawaited nested stream before the parent rolls back", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    let continueNested!: () => void;
+    const nestedGate = new Promise<void>((resolve) => {
+      continueNested = resolve;
+    });
+    let nestedStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      nestedStarted = resolve;
+    });
+    let nestedTransaction: Promise<void> | undefined;
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (parent) => {
+          nestedTransaction = parent.transaction(async (nested) => {
+            const stream = nested.stream(sql`SELECT nested`);
+            await stream.next();
+            nestedStarted();
+            await nestedGate;
+          });
+          await started;
+        }),
+      /callback returned before all query streams were completed or closed/,
+    );
+
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK"]);
+    continueNested();
+    await strict.rejects(() => nestedTransaction!, /parent PostgreSQL transaction scope ended/);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK"]);
+  });
+
+  await it("closes a leaked started stream and rolls back instead of committing", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          const stream = transaction.stream(sql`SELECT streamed`);
+          await stream.next();
+        }),
+      /callback returned before all query streams were completed or closed/,
+    );
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("invalidates an escaped unstarted stream and rolls back without opening it", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    let escaped: QueryStream<unknown> | undefined;
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          escaped = transaction.stream(sql`SELECT streamed`);
+        }),
+      /callback returned before all query streams were completed or closed/,
+    );
+    strict.strictEqual(pool.client.cursorConfigs.length, 0);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+    strict.deepStrictEqual(await escaped?.next(), { done: true, value: undefined });
+  });
+
+  await it("invalidates an escaped transaction adapter after its callback exits", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    let escaped: PostgresTransaction | undefined;
+    await database.transaction(async (transaction) => {
+      escaped = transaction;
+    });
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "COMMIT"]);
+    await strict.rejects(() => escaped!.execute(sql`SELECT escaped`), /transaction scope has ended/);
+    strict.throws(() => escaped!.stream(sql`SELECT escaped`), /transaction scope has ended/);
+    strict.throws(() => escaped!.prepare("escaped", () => sql`SELECT escaped`), /transaction scope has ended/);
+    await strict.rejects(() => escaped!.transaction(async () => undefined), /transaction scope has ended/);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "COMMIT"]);
+  });
+
+  await it("invalidates an escaped transaction adapter after its callback fails", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    let escaped: PostgresTransaction | undefined;
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          escaped = transaction;
+          throw new Error("callback failed");
+        }),
+      /callback failed/,
+    );
+    await strict.rejects(() => escaped!.execute(sql`SELECT escaped`), /transaction scope has ended/);
+    strict.throws(() => escaped!.stream(sql`SELECT escaped`), /transaction scope has ended/);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+  });
+
+  await it("preserves a callback error while cleaning its live stream before rollback", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.closeError = new Error("close failed");
+    const database = createPostgresDatabase({ pool });
+    const callbackError = new Error("callback failed");
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          const stream = transaction.stream(sql`SELECT streamed`);
+          await stream.next();
+          throw callbackError;
+        }),
+      (error) => {
+        strict.strictEqual(error, callbackError);
+        return true;
+      },
+    );
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseCount, 1);
+  });
+
+  await it("cleans a nested-scope leak before rolling back its savepoint", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      await strict.rejects(
+        () =>
+          transaction.transaction(async (nested) => {
+            nested.stream(sql`SELECT nested`);
+          }),
+        /callback returned before all query streams were completed or closed/,
+      );
+    });
+    strict.deepStrictEqual(commands(pool.client), [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+    strict.strictEqual(pool.client.cursorConfigs.length, 0);
+  });
+
+  await it("closes a started nested-scope leak before rolling back its savepoint", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    await database.transaction(async (transaction) => {
+      await strict.rejects(
+        () =>
+          transaction.transaction(async (nested) => {
+            const stream = nested.stream(sql`SELECT nested`);
+            await stream.next();
+          }),
+        /callback returned before all query streams were completed or closed/,
+      );
+    });
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+  });
+});

--- a/packages/postgres/test/stream.test.ts
+++ b/packages/postgres/test/stream.test.ts
@@ -20,6 +20,7 @@ class FakeCursor implements PostgresCursorLike {
   closeCount = 0;
   closeError: Error | undefined;
   failAtRead: number | undefined;
+  readError: Error | undefined;
   readonly #pages: readonly (readonly Record<string, unknown>[])[];
 
   constructor(pages: readonly (readonly Record<string, unknown>[])[]) {
@@ -28,7 +29,10 @@ class FakeCursor implements PostgresCursorLike {
 
   async read(rowCount: number): Promise<readonly Record<string, unknown>[]> {
     this.reads.push(rowCount);
-    if (this.failAtRead === this.reads.length) throw new Error(`cursor read ${this.reads.length} failed`);
+    if (this.failAtRead === this.reads.length) {
+      this.readError = new Error(`cursor read ${this.reads.length} failed`);
+      throw this.readError;
+    }
     return this.#pages[this.reads.length - 1] ?? [];
   }
 
@@ -178,7 +182,7 @@ await describe("PostgreSQL query streams", async () => {
     await strict.rejects(() => stream.next(), /cursor read 2 failed/);
     strict.strictEqual(pool.client.cursor.closeCount, 1);
     strict.strictEqual(pool.client.releaseCount, 1);
-    strict.strictEqual(pool.client.releaseErrors[0], pool.client.cursor.closeError);
+    strict.strictEqual(pool.client.releaseErrors[0], pool.client.cursor.readError);
   });
 
   await it("preserves a driver failure before the first row", async () => {
@@ -188,6 +192,7 @@ await describe("PostgreSQL query streams", async () => {
     await strict.rejects(() => stream.next(), /cursor read 1 failed/);
     strict.strictEqual(pool.client.cursor.closeCount, 1);
     strict.strictEqual(pool.client.releaseCount, 1);
+    strict.strictEqual(pool.client.releaseErrors[0], pool.client.cursor.readError);
   });
 
   await it("async-disposes an active stream", async () => {
@@ -283,6 +288,63 @@ await describe("PostgreSQL transaction query streams", async () => {
     strict.strictEqual(pool.client.releaseCount, 1);
   });
 
+  await it("rolls back when a transaction callback catches a cursor read failure", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.failAtRead = 1;
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          const stream = transaction.stream(sql`SELECT streamed`);
+          await strict.rejects(() => stream.next(), /cursor read 1 failed/);
+        }),
+      /cursor read 1 failed/,
+    );
+
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+    strict.strictEqual(pool.client.releaseCount, 1);
+    strict.deepStrictEqual(pool.client.releaseErrors, [pool.client.cursor.readError]);
+  });
+
+  await it("rolls back when a transaction callback catches a cursor-open failure", async () => {
+    const pool = new FakePool();
+    pool.client.cursorOpenError = new Error("cursor creation failed");
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          const stream = transaction.stream(sql`SELECT streamed`);
+          await strict.rejects(() => stream.next(), /cursor creation failed/);
+        }),
+      /cursor creation failed/,
+    );
+
+    strict.strictEqual(pool.client.cursor.closeCount, 0);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+  });
+
+  await it("rolls back when a transaction callback catches cursor cleanup failure", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.closeError = new Error("cursor close failed");
+    const database = createPostgresDatabase({ pool });
+
+    await strict.rejects(
+      () =>
+        database.transaction(async (transaction) => {
+          const stream = transaction.stream(sql`SELECT streamed`);
+          await stream.next();
+          await strict.rejects(() => stream.close(), /cursor close failed/);
+        }),
+      /cursor close failed/,
+    );
+
+    strict.strictEqual(pool.client.cursor.closeCount, 1);
+    strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
+  });
+
   await it("allows ordinary work before an unstarted stream begins", async () => {
     const pool = new FakePool();
     const database = createPostgresDatabase({ pool });
@@ -328,6 +390,31 @@ await describe("PostgreSQL transaction query streams", async () => {
       "RELEASE SAVEPOINT typed_sql_2",
       "COMMIT",
     ]);
+  });
+
+  await it("contains a caught nested cursor failure with its savepoint", async () => {
+    const pool = new FakePool();
+    pool.client.cursor.failAtRead = 1;
+    const database = createPostgresDatabase({ pool });
+
+    await database.transaction(async (parent) => {
+      await strict.rejects(
+        () =>
+          parent.transaction(async (nested) => {
+            const stream = nested.stream(sql`SELECT nested`);
+            await strict.rejects(() => stream.next(), /cursor read 1 failed/);
+          }),
+        /cursor read 1 failed/,
+      );
+    });
+
+    strict.deepStrictEqual(commands(pool.client), [
+      "BEGIN",
+      "SAVEPOINT typed_sql_2",
+      "ROLLBACK TO SAVEPOINT typed_sql_2",
+      "COMMIT",
+    ]);
+    strict.deepStrictEqual(pool.client.releaseErrors, [pool.client.cursor.readError]);
   });
 
   await it("closes an unawaited nested stream before the parent rolls back", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       pg:
         specifier: 8.23.0
         version: 8.23.0
+      pg-cursor:
+        specifier: 2.22.0
+        version: 2.22.0(pg@8.23.0)
     devDependencies:
       poku:
         specifier: 4.5.0
@@ -2393,6 +2396,11 @@ packages:
 
   pg-connection-string@2.14.0:
     resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-cursor@2.22.0:
+    resolution: {integrity: sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==}
+    peerDependencies:
+      pg: ^8
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -5106,6 +5114,10 @@ snapshots:
     optional: true
 
   pg-connection-string@2.14.0: {}
+
+  pg-cursor@2.22.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
 
   pg-int8@1.0.1: {}
 

--- a/scripts/performance-gate.mjs
+++ b/scripts/performance-gate.mjs
@@ -1,72 +1,40 @@
 import { strict as assert } from "node:assert";
 import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
-import { cpus, platform, release, tmpdir, totalmem } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { performance } from "node:perf_hooks";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { compileSource, extractStaticQueries } from "../packages/compiler/dist/packages/compiler/src/index.js";
 import { renderQuery, sql } from "../packages/core/dist/packages/core/src/index.js";
 import { TypedSqlLanguageService } from "../packages/language-server/dist/packages/language-server/src/index.js";
 import { postgres } from "../packages/postgres/dist/packages/postgres/src/index.js";
+import {
+  capturePerformanceContext,
+  createPerformanceArtifact,
+  measureLatency,
+  measureThroughput,
+  summarizePerformanceResults,
+  writePerformanceArtifact,
+} from "./performance/harness.mjs";
+import { deterministicMicrobenchmarks } from "./performance/microbenchmarks.mjs";
 
 const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const budgets = JSON.parse(await readFile(join(workspace, "performance-budgets.json"), "utf8"));
 const methodology = budgets.methodology;
 const results = {};
-const processors = cpus();
-const context = {
-  node: process.version,
-  platform: platform(),
-  platformRelease: release(),
-  architecture: process.arch,
-  cpuModel: processors[0]?.model ?? "unknown",
-  logicalCpuCount: processors.length,
-  totalMemoryMiB: Math.round(totalmem() / 1024 / 1024),
-  ci: process.env.CI === "true",
+const context = capturePerformanceContext({
+  workspace,
   productionBuild: true,
   budgetVersion: budgets.version,
-};
+});
+assert.equal(typeof context.cpuModel, "string");
 console.log(`typed-sql performance context\n${JSON.stringify(context, null, 2)}`);
-
-function percentile(samples, quantile) {
-  const ordered = [...samples].sort((left, right) => left - right);
-  return ordered[Math.max(0, Math.ceil(ordered.length * quantile) - 1)];
-}
-
-function statistics(samples) {
-  const mean = samples.reduce((total, sample) => total + sample, 0) / samples.length;
-  const variance = samples.reduce((total, sample) => total + (sample - mean) ** 2, 0) / samples.length;
-  const standardDeviation = Math.sqrt(variance);
-  return {
-    samples: samples.length,
-    minimum: Math.min(...samples),
-    mean,
-    standardDeviation,
-    coefficientOfVariation: mean === 0 ? 0 : standardDeviation / mean,
-    p50: percentile(samples, 0.5),
-    p95: percentile(samples, 0.95),
-    maximum: Math.max(...samples),
-  };
-}
 
 async function latency(name, operation, options = {}) {
   const warmups = options.warmups ?? methodology.warmups;
   const sampleCount = options.samples ?? methodology.samples;
   const iterations = options.iterations ?? 1;
-  for (let warmup = 0; warmup < warmups; warmup += 1) {
-    for (let iteration = 0; iteration < iterations; iteration += 1) {
-      await operation(warmup * iterations + iteration);
-    }
-  }
-  const samples = [];
-  for (let sample = 0; sample < sampleCount; sample += 1) {
-    const start = performance.now();
-    for (let iteration = 0; iteration < iterations; iteration += 1) {
-      await operation(sample * iterations + iteration);
-    }
-    samples.push((performance.now() - start) / iterations);
-  }
-  const measured = statistics(samples);
+  const measured = await measureLatency({ operation, warmups, samples: sampleCount, iterations });
+  assert.ok(Number.isFinite(measured.coefficientOfVariation));
   const budget = budgets.latencyMs[name];
   assert.ok(budget !== undefined, `Missing latency budget for ${name}`);
   results[name] = { unit: "ms", iterationsPerSample: iterations, ...measured, budget };
@@ -187,24 +155,21 @@ await structuralMetric(
 );
 
 const coreIterations = 10_000;
-const coreSamples = [];
-for (let warmup = 0; warmup < methodology.warmups; warmup += 1) {
-  for (let index = 0; index < coreIterations; index += 1) {
+const coreThroughput = measureThroughput({
+  warmups: methodology.warmups,
+  samples: methodology.samples,
+  iterations: coreIterations,
+  warmupOperation(index) {
     renderQuery(sql`SELECT ${sql.ident("id")} FROM users WHERE id = ${index}`, dialect);
-  }
-}
-for (let sample = 0; sample < methodology.samples; sample += 1) {
-  const start = performance.now();
-  for (let index = 0; index < coreIterations; index += 1) {
+  },
+  operation(index) {
     const predicate = sql.and([
       sql.fragment`account.id >= ${index}`,
       index % 2 === 0 ? sql.fragment`account.email = ${"person@example.com"}` : undefined,
     ]);
     renderQuery(sql`SELECT ${sql.ident("id")} FROM users AS account WHERE ${predicate}`, dialect);
-  }
-  coreSamples.push((coreIterations * 1_000) / (performance.now() - start));
-}
-const coreThroughput = statistics(coreSamples);
+  },
+});
 const coreBudget = budgets.throughput["core.composeAndRender"];
 results["core.composeAndRender"] = { unit: "operations/second", ...coreThroughput, budget: coreBudget };
 if (coreThroughput.p50 < coreBudget.minimumOperationsPerSecond / methodology.warningRatio) {
@@ -216,6 +181,8 @@ assert.ok(
   coreThroughput.p50 >= coreBudget.minimumOperationsPerSecond,
   `core.composeAndRender p50 ${coreThroughput.p50.toFixed(0)} ops/s fell below ${coreBudget.minimumOperationsPerSecond}`,
 );
+
+Object.assign(results, await deterministicMicrobenchmarks(methodology));
 
 const temporary = await mkdtemp(join(tmpdir(), "typed-sql-performance-"));
 try {
@@ -333,13 +300,7 @@ try {
   await rm(temporary, { recursive: true, force: true });
 }
 
-console.log(
-  JSON.stringify(
-    {
-      context,
-      results,
-    },
-    null,
-    2,
-  ),
-);
+const artifact = createPerformanceArtifact(context, results);
+const artifactPath = process.env.TYPED_SQL_PERFORMANCE_ARTIFACT;
+if (artifactPath !== undefined) await writePerformanceArtifact(resolve(workspace, artifactPath), artifact);
+console.log(JSON.stringify({ context, results: summarizePerformanceResults(results) }, null, 2));

--- a/scripts/performance/harness.d.mts
+++ b/scripts/performance/harness.d.mts
@@ -1,0 +1,86 @@
+export interface BenchmarkStatistics {
+  readonly samples: number;
+  readonly minimum: number;
+  readonly mean: number;
+  readonly standardDeviation: number;
+  readonly coefficientOfVariation: number;
+  readonly p50: number;
+  readonly p95: number;
+  readonly maximum: number;
+}
+
+export interface Measurement extends BenchmarkStatistics {
+  readonly iterationsPerSample: number;
+  readonly rawSamples: readonly number[];
+}
+
+export interface MeasurementOptions {
+  readonly operation: (iteration: number) => unknown;
+  readonly warmupOperation?: (iteration: number) => unknown;
+  readonly warmups: number;
+  readonly samples: number;
+  readonly iterations?: number;
+  readonly clock?: () => number;
+}
+
+export interface AsyncMeasurementOptions extends Omit<MeasurementOptions, "operation"> {
+  readonly operation: (iteration: number) => unknown | Promise<unknown>;
+  readonly warmupOperation?: (iteration: number) => unknown | Promise<unknown>;
+}
+
+export interface PerformanceContextOptions {
+  readonly budgetVersion: number;
+  readonly productionBuild: boolean;
+  readonly workspace: string;
+  readonly environment?: Readonly<Record<string, string | undefined>>;
+  readonly system?: {
+    readonly node: string;
+    readonly platform: string;
+    readonly platformRelease: string;
+    readonly architecture: string;
+    readonly processors: readonly { readonly model: string }[];
+    readonly totalMemoryBytes: number;
+  };
+  readonly git?: {
+    readonly gitRevision: string;
+    readonly gitDirty?: boolean;
+  };
+}
+
+export interface PerformanceContext {
+  readonly node: string;
+  readonly platform: string;
+  readonly platformRelease: string;
+  readonly architecture: string;
+  readonly cpuModel: string;
+  readonly logicalCpuCount: number;
+  readonly totalMemoryMiB: number;
+  readonly ci: boolean;
+  readonly productionBuild: boolean;
+  readonly budgetVersion: number;
+  readonly packageManager: string;
+  readonly gitRevision: string;
+  readonly gitDirty?: boolean;
+}
+
+export interface PerformanceArtifact {
+  readonly formatVersion: 1;
+  readonly generatedAt: string;
+  readonly context: PerformanceContext;
+  readonly results: Readonly<Record<string, unknown>>;
+}
+
+export function percentile(samples: readonly number[], quantile: number): number;
+export function statistics(samples: readonly number[]): BenchmarkStatistics;
+export function measureLatency(options: AsyncMeasurementOptions): Promise<Measurement>;
+export function measureThroughput(options: MeasurementOptions & { readonly iterations: number }): Measurement;
+export function capturePerformanceContext(options: PerformanceContextOptions): PerformanceContext;
+export function createPerformanceArtifact(
+  context: PerformanceContext,
+  results: Readonly<Record<string, unknown>>,
+  generatedAt?: Date,
+): PerformanceArtifact;
+export function summarizePerformanceResults(
+  results: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>>;
+export function writePerformanceArtifact(path: string, artifact: PerformanceArtifact): Promise<void>;

--- a/scripts/performance/harness.mjs
+++ b/scripts/performance/harness.mjs
@@ -1,0 +1,181 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { cpus, platform, release, totalmem } from "node:os";
+import { dirname } from "node:path";
+import { performance } from "node:perf_hooks";
+
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) throw new RangeError(`${label} must be a positive integer`);
+  return value;
+}
+
+function samplesOf(values) {
+  if (!Array.isArray(values) || values.length === 0) throw new TypeError("samples must be a non-empty array");
+  for (const value of values) {
+    if (!Number.isFinite(value)) throw new TypeError("samples must contain only finite numbers");
+  }
+  return values;
+}
+
+export function percentile(samples, quantile) {
+  const values = samplesOf(samples);
+  if (!Number.isFinite(quantile) || quantile < 0 || quantile > 1)
+    throw new RangeError("quantile must be between zero and one");
+  const ordered = [...values].sort((left, right) => left - right);
+  return ordered[Math.max(0, Math.ceil(ordered.length * quantile) - 1)];
+}
+
+export function statistics(samples) {
+  const values = samplesOf(samples);
+  const mean = values.reduce((total, sample) => total + sample, 0) / values.length;
+  const variance = values.reduce((total, sample) => total + (sample - mean) ** 2, 0) / values.length;
+  const standardDeviation = Math.sqrt(variance);
+  return {
+    samples: values.length,
+    minimum: Math.min(...values),
+    mean,
+    standardDeviation,
+    coefficientOfVariation: mean === 0 ? 0 : standardDeviation / Math.abs(mean),
+    p50: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+    maximum: Math.max(...values),
+  };
+}
+
+export async function measureLatency({
+  operation,
+  warmupOperation = operation,
+  warmups,
+  samples,
+  iterations = 1,
+  clock = performance.now.bind(performance),
+}) {
+  positiveInteger(warmups, "warmups");
+  const sampleCount = positiveInteger(samples, "samples");
+  const iterationsPerSample = positiveInteger(iterations, "iterations");
+  if (typeof operation !== "function") throw new TypeError("operation must be a function");
+  if (typeof warmupOperation !== "function") throw new TypeError("warmupOperation must be a function");
+
+  for (let warmup = 0; warmup < warmups; warmup += 1) {
+    for (let iteration = 0; iteration < iterationsPerSample; iteration += 1) {
+      await warmupOperation(warmup * iterationsPerSample + iteration);
+    }
+  }
+
+  const measuredSamples = [];
+  for (let sample = 0; sample < sampleCount; sample += 1) {
+    const start = clock();
+    for (let iteration = 0; iteration < iterationsPerSample; iteration += 1) {
+      await operation(sample * iterationsPerSample + iteration);
+    }
+    const elapsed = clock() - start;
+    if (!Number.isFinite(elapsed) || elapsed < 0) throw new RangeError("clock must advance monotonically");
+    measuredSamples.push(elapsed / iterationsPerSample);
+  }
+
+  return { iterationsPerSample, rawSamples: Object.freeze(measuredSamples), ...statistics(measuredSamples) };
+}
+
+export function measureThroughput({
+  operation,
+  warmupOperation = operation,
+  warmups,
+  samples,
+  iterations,
+  clock = performance.now.bind(performance),
+}) {
+  positiveInteger(warmups, "warmups");
+  const sampleCount = positiveInteger(samples, "samples");
+  const iterationsPerSample = positiveInteger(iterations, "iterations");
+  if (typeof operation !== "function") throw new TypeError("operation must be a function");
+  if (typeof warmupOperation !== "function") throw new TypeError("warmupOperation must be a function");
+
+  for (let warmup = 0; warmup < warmups; warmup += 1) {
+    for (let iteration = 0; iteration < iterationsPerSample; iteration += 1) {
+      warmupOperation(warmup * iterationsPerSample + iteration);
+    }
+  }
+
+  const measuredSamples = [];
+  for (let sample = 0; sample < sampleCount; sample += 1) {
+    const start = clock();
+    for (let iteration = 0; iteration < iterationsPerSample; iteration += 1) {
+      operation(sample * iterationsPerSample + iteration);
+    }
+    const elapsed = clock() - start;
+    if (!Number.isFinite(elapsed) || elapsed <= 0) throw new RangeError("clock must advance after each sample");
+    measuredSamples.push((iterationsPerSample * 1_000) / elapsed);
+  }
+
+  return { iterationsPerSample, rawSamples: Object.freeze(measuredSamples), ...statistics(measuredSamples) };
+}
+
+function gitContext(workspace) {
+  try {
+    const revision = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: workspace,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const status = execFileSync("git", ["status", "--short", "--untracked-files=normal"], {
+      cwd: workspace,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return { gitRevision: revision || "unknown", gitDirty: status.length > 0 };
+  } catch {
+    return { gitRevision: "unknown", gitDirty: undefined };
+  }
+}
+
+export function capturePerformanceContext({
+  budgetVersion,
+  productionBuild,
+  workspace,
+  environment = process.env,
+  system,
+  git,
+}) {
+  const processors = system?.processors ?? cpus();
+  const memoryBytes = system?.totalMemoryBytes ?? totalmem();
+  const sourceControl = git ?? gitContext(workspace);
+  return {
+    node: system?.node ?? process.version,
+    platform: system?.platform ?? platform(),
+    platformRelease: system?.platformRelease ?? release(),
+    architecture: system?.architecture ?? process.arch,
+    cpuModel: processors[0]?.model ?? "unknown",
+    logicalCpuCount: processors.length,
+    totalMemoryMiB: Math.round(memoryBytes / 1024 / 1024),
+    ci: environment.CI === "true",
+    productionBuild,
+    budgetVersion,
+    packageManager: environment.npm_config_user_agent?.split(" ", 1)[0] ?? "unknown",
+    ...sourceControl,
+  };
+}
+
+export function createPerformanceArtifact(context, results, generatedAt = new Date()) {
+  return {
+    formatVersion: 1,
+    generatedAt: generatedAt.toISOString(),
+    context,
+    results,
+  };
+}
+
+export function summarizePerformanceResults(results) {
+  return Object.fromEntries(
+    Object.entries(results).map(([name, result]) => {
+      if (typeof result !== "object" || result === null || !("rawSamples" in result)) return [name, result];
+      const { rawSamples: _rawSamples, ...summary } = result;
+      return [name, summary];
+    }),
+  );
+}
+
+export async function writePerformanceArtifact(path, artifact) {
+  if (typeof path !== "string" || path.length === 0) throw new TypeError("artifact path must be a non-empty string");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+}

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -1,0 +1,172 @@
+import { strict as assert } from "node:assert";
+import { renderQuery, sql } from "../../packages/core/dist/packages/core/src/index.js";
+import { createMySqlDatabase, mysqlRenderer } from "../../packages/mysql/dist/packages/mysql/src/runtime.js";
+import {
+  createPostgresDatabase,
+  createPostgresTypeParsers,
+  postgresRenderer,
+} from "../../packages/postgres/dist/packages/postgres/src/runtime.js";
+import { measureLatency, measureThroughput } from "./harness.mjs";
+
+function throughput(operation, methodology, iterations) {
+  return {
+    unit: "operations/second",
+    trackingOnly: true,
+    ...measureThroughput({
+      operation,
+      warmups: methodology.warmups,
+      samples: methodology.samples,
+      iterations,
+    }),
+  };
+}
+
+async function latency(operation, methodology, iterations) {
+  return {
+    unit: "ms",
+    trackingOnly: true,
+    ...(await measureLatency({
+      operation,
+      warmups: methodology.warmups,
+      samples: methodology.samples,
+      iterations,
+    })),
+  };
+}
+
+function mysqlResult(columnCount) {
+  const entries = Array.from({ length: columnCount }, (_, index) => [`value_${index}`, String(index + 1)]);
+  return {
+    rows: [Object.fromEntries(entries)],
+    fields: entries.map(([name]) => ({ name, columnType: 8 })),
+  };
+}
+
+export async function deterministicMicrobenchmarks(methodology) {
+  const results = {};
+  const renderIterations = 10_000;
+  const asyncIterations = Math.min(100, methodology.subMillisecondIterations);
+
+  const staticQuery = sql`SELECT account.id, account.email FROM account`;
+  const parameterList = sql.join(Array.from({ length: 100 }, (_, index) => sql.value(index)));
+  const parameterizedQuery = sql`SELECT ${parameterList}`;
+
+  let staticRendered;
+  results["micro.render.static"] = throughput(
+    () => {
+      staticRendered = renderQuery(staticQuery, postgresRenderer);
+    },
+    methodology,
+    renderIterations,
+  );
+  assert.equal(staticRendered.text, "SELECT account.id, account.email FROM account");
+  assert.deepEqual(staticRendered.values, []);
+
+  let parametersRendered;
+  results["micro.render.100Parameters"] = throughput(
+    () => {
+      parametersRendered = renderQuery(parameterizedQuery, postgresRenderer);
+    },
+    methodology,
+    renderIterations,
+  );
+  assert.equal(parametersRendered.values.length, 100);
+  assert.ok(parametersRendered.text.endsWith("$100"));
+
+  let postgresConfig;
+  const postgresPool = {
+    async query(config) {
+      postgresConfig = config;
+      return { rows: [] };
+    },
+    async connect() {
+      throw new Error("microbenchmark does not acquire a connection");
+    },
+    async end() {},
+  };
+  const postgresDatabase = createPostgresDatabase({ pool: postgresPool });
+  const nestedValues = [1n, [2n, [3n, 4n]], "done"];
+  const postgresEncodingQuery = sql`SELECT ${nestedValues}`;
+  results["micro.postgres.renderEncodeDispatch"] = await latency(
+    () => postgresDatabase.execute(postgresEncodingQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.deepEqual(postgresConfig.values, [["1", ["2", ["3", "4"]], "done"]]);
+
+  const postgresParsers = createPostgresTypeParsers();
+  const parseBigint = postgresParsers.getTypeParser(20);
+  const parseNumeric = postgresParsers.getTypeParser(1700);
+  const parseDate = postgresParsers.getTypeParser(1184);
+  const parseJson = postgresParsers.getTypeParser(3802);
+  const parseBigintArray = postgresParsers.getTypeParser(1016);
+  let bigintDecoded;
+  let numericDecoded;
+  let dateDecoded;
+  let jsonDecoded;
+  let arrayDecoded;
+  results["micro.postgres.decode.policySet"] = throughput(
+    () => {
+      bigintDecoded = parseBigint("922337203685477580");
+      numericDecoded = parseNumeric("12.50");
+      dateDecoded = parseDate("2026-08-26T12:00:00Z");
+      jsonDecoded = parseJson('{"active":true}');
+      arrayDecoded = parseBigintArray("{1,2,3}");
+    },
+    methodology,
+    1_000,
+  );
+  assert.equal(bigintDecoded, 922337203685477580n);
+  assert.equal(numericDecoded, "12.50");
+  assert.ok(dateDecoded instanceof Date);
+  assert.equal(jsonDecoded.active, true);
+  assert.deepEqual(arrayDecoded, [1n, 2n, 3n]);
+
+  const mysqlQuery = sql`SELECT 1`;
+  for (const columnCount of [1, 10, 100]) {
+    const result = mysqlResult(columnCount);
+    const mysqlPool = {
+      async execute() {
+        return result;
+      },
+      async getConnection() {
+        throw new Error("microbenchmark does not acquire a connection");
+      },
+      async end() {},
+    };
+    const mysqlDatabase = createMySqlDatabase({ pool: mysqlPool });
+    let decoded;
+    results[`micro.mysql.bufferedExecute.${columnCount}Columns`] = await latency(
+      async () => {
+        decoded = await mysqlDatabase.execute(mysqlQuery);
+      },
+      methodology,
+      asyncIterations,
+    );
+    assert.equal(Object.keys(decoded[0]).length, columnCount);
+    assert.equal(decoded[0].value_0, 1n);
+  }
+
+  let mysqlValues;
+  const mysqlEncodingPool = {
+    async execute(_text, values) {
+      mysqlValues = values;
+      return { rows: [], fields: [] };
+    },
+    async getConnection() {
+      throw new Error("microbenchmark does not acquire a connection");
+    },
+    async end() {},
+  };
+  const mysqlDatabase = createMySqlDatabase({ pool: mysqlEncodingPool });
+  const mysqlEncodingQuery = sql`SELECT ${nestedValues}`;
+  results["micro.mysql.renderEncodeDispatch"] = await latency(
+    () => mysqlDatabase.execute(mysqlEncodingQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.deepEqual(mysqlValues, [["1", ["2", ["3", "4"]], "done"]]);
+  assert.equal(mysqlRenderer.placeholder(1), "?");
+
+  return results;
+}

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -94,6 +94,53 @@ export async function deterministicMicrobenchmarks(methodology) {
   );
   assert.deepEqual(postgresConfig.values, [["1", ["2", ["3", "4"]], "done"]]);
 
+  const postgresStreamRows = Array.from({ length: 100 }, (_, index) => ({ id: BigInt(index + 1) }));
+  let postgresStreamReleases = 0;
+  const postgresStreamingDatabase = createPostgresDatabase({
+    pool: {
+      async query() {
+        throw new Error("stream microbenchmark must use a leased cursor");
+      },
+      async connect() {
+        let offset = 0;
+        return {
+          async query() {
+            throw new Error("stream microbenchmark must use a cursor");
+          },
+          openCursor() {
+            return {
+              async read(rowCount) {
+                const rows = postgresStreamRows.slice(offset, offset + rowCount);
+                offset += rows.length;
+                return rows;
+              },
+              async close() {},
+            };
+          },
+          release() {
+            postgresStreamReleases += 1;
+          },
+        };
+      },
+      async end() {},
+    },
+  });
+  let postgresStreamCount = 0;
+  results["micro.postgres.stream.100Rows"] = await latency(
+    async () => {
+      postgresStreamCount = 0;
+      for await (const _row of postgresStreamingDatabase.stream(sql`SELECT account.id FROM account`, {
+        batchSize: 25,
+      })) {
+        postgresStreamCount += 1;
+      }
+    },
+    methodology,
+    asyncIterations,
+  );
+  assert.equal(postgresStreamCount, 100);
+  assert.ok(postgresStreamReleases > 0);
+
   const postgresParsers = createPostgresTypeParsers();
   const parseBigint = postgresParsers.getTypeParser(20);
   const parseNumeric = postgresParsers.getTypeParser(1700);
@@ -167,6 +214,64 @@ export async function deterministicMicrobenchmarks(methodology) {
   );
   assert.deepEqual(mysqlValues, [["1", ["2", ["3", "4"]], "done"]]);
   assert.equal(mysqlRenderer.placeholder(1), "?");
+
+  const mysqlStreamRows = Array.from({ length: 100 }, (_, index) => ({ id: String(index + 1) }));
+  let mysqlStreamReleases = 0;
+  const mysqlStreamingDatabase = createMySqlDatabase({
+    pool: {
+      async execute() {
+        throw new Error("stream microbenchmark must use a leased protocol stream");
+      },
+      async getConnection() {
+        return {
+          async execute() {
+            throw new Error("stream microbenchmark must use protocol streaming");
+          },
+          async query() {
+            throw new Error("stream microbenchmark does not issue transaction commands");
+          },
+          async beginTransaction() {},
+          async commit() {},
+          async rollback() {},
+          stream() {
+            let offset = 0;
+            return {
+              fields: Promise.resolve([{ name: "id", columnType: 8 }]),
+              connectionReusable: true,
+              [Symbol.asyncIterator]() {
+                return this;
+              },
+              async next() {
+                if (offset >= mysqlStreamRows.length) return { done: true, value: undefined };
+                return { done: false, value: mysqlStreamRows[offset++] };
+              },
+              async close() {},
+            };
+          },
+          release() {
+            mysqlStreamReleases += 1;
+          },
+        };
+      },
+      async end() {},
+    },
+  });
+  let mysqlStreamCount = 0;
+  let mysqlStreamLastId = 0n;
+  results["micro.mysql.streamDecode.100Rows"] = await latency(
+    async () => {
+      mysqlStreamCount = 0;
+      for await (const row of mysqlStreamingDatabase.stream(sql`SELECT account.id FROM account`, { batchSize: 25 })) {
+        mysqlStreamCount += 1;
+        mysqlStreamLastId = row.id;
+      }
+    },
+    methodology,
+    asyncIterations,
+  );
+  assert.equal(mysqlStreamCount, 100);
+  assert.equal(mysqlStreamLastId, 100n);
+  assert.ok(mysqlStreamReleases > 0);
 
   return results;
 }

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -141,6 +141,40 @@ export async function deterministicMicrobenchmarks(methodology) {
   assert.equal(postgresStreamCount, 100);
   assert.ok(postgresStreamReleases > 0);
 
+  const postgresBatchQueries = Array.from({ length: 25 }, (_, index) => sql`SELECT ${index} AS value`);
+  let postgresBatchDispatches = 0;
+  let postgresBatchReleases = 0;
+  const postgresBatchDatabase = createPostgresDatabase({
+    pool: {
+      async query() {
+        throw new Error("batch microbenchmark must use one leased connection");
+      },
+      async connect() {
+        return {
+          async query() {
+            postgresBatchDispatches += 1;
+            return { rows: [{ value: postgresBatchDispatches }] };
+          },
+          release() {
+            postgresBatchReleases += 1;
+          },
+        };
+      },
+      async end() {},
+    },
+  });
+  let postgresBatchResultCount = 0;
+  results["micro.postgres.batch.25Queries"] = await latency(
+    async () => {
+      const batchResults = await postgresBatchDatabase.batch(postgresBatchQueries);
+      postgresBatchResultCount = batchResults.length;
+    },
+    methodology,
+    asyncIterations,
+  );
+  assert.equal(postgresBatchResultCount, 25);
+  assert.equal(postgresBatchDispatches, postgresBatchReleases * 25);
+
   const postgresParsers = createPostgresTypeParsers();
   const parseBigint = postgresParsers.getTypeParser(20);
   const parseNumeric = postgresParsers.getTypeParser(1700);
@@ -272,6 +306,52 @@ export async function deterministicMicrobenchmarks(methodology) {
   assert.equal(mysqlStreamCount, 100);
   assert.equal(mysqlStreamLastId, 100n);
   assert.ok(mysqlStreamReleases > 0);
+
+  const mysqlBatchQueries = Array.from({ length: 25 }, (_, index) => sql`SELECT ${index} AS value`);
+  let mysqlBatchDispatches = 0;
+  let mysqlBatchReleases = 0;
+  const mysqlBatchDatabase = createMySqlDatabase({
+    pool: {
+      async execute() {
+        throw new Error("batch microbenchmark must use one leased connection");
+      },
+      async getConnection() {
+        return {
+          async execute() {
+            mysqlBatchDispatches += 1;
+            return {
+              rows: [{ value: String(mysqlBatchDispatches) }],
+              fields: [{ name: "value", columnType: 8 }],
+            };
+          },
+          async query() {
+            throw new Error("batch microbenchmark does not issue transaction commands");
+          },
+          async beginTransaction() {},
+          async commit() {},
+          async rollback() {},
+          release() {
+            mysqlBatchReleases += 1;
+          },
+        };
+      },
+      async end() {},
+    },
+  });
+  let mysqlBatchResultCount = 0;
+  let mysqlBatchLastValue = 0n;
+  results["micro.mysql.batchDecode.25Queries"] = await latency(
+    async () => {
+      const batchResults = await mysqlBatchDatabase.batch(mysqlBatchQueries);
+      mysqlBatchResultCount = batchResults.length;
+      mysqlBatchLastValue = batchResults.at(-1)?.[0]?.value ?? 0n;
+    },
+    methodology,
+    asyncIterations,
+  );
+  assert.equal(mysqlBatchResultCount, 25);
+  assert.equal(mysqlBatchLastValue, BigInt(mysqlBatchDispatches));
+  assert.equal(mysqlBatchDispatches, mysqlBatchReleases * 25);
 
   return results;
 }

--- a/test/contracts/performance-harness.test.ts
+++ b/test/contracts/performance-harness.test.ts
@@ -1,0 +1,157 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, strict } from "poku";
+import {
+  capturePerformanceContext,
+  createPerformanceArtifact,
+  measureLatency,
+  measureThroughput,
+  percentile,
+  statistics,
+  summarizePerformanceResults,
+  writePerformanceArtifact,
+} from "../../scripts/performance/harness.mjs";
+
+function clock(values: readonly number[]): () => number {
+  let index = 0;
+  return () => {
+    const value = values[index];
+    index += 1;
+    if (value === undefined) throw new Error("deterministic clock exhausted");
+    return value;
+  };
+}
+
+await describe("performance harness", async () => {
+  await it("computes nearest-rank percentiles and complete statistics", () => {
+    strict.strictEqual(percentile([9, 1, 5, 3], 0), 1);
+    strict.strictEqual(percentile([9, 1, 5, 3], 0.5), 3);
+    strict.strictEqual(percentile([9, 1, 5, 3], 0.95), 9);
+    strict.deepStrictEqual(statistics([1, 2, 3]), {
+      samples: 3,
+      minimum: 1,
+      mean: 2,
+      standardDeviation: Math.sqrt(2 / 3),
+      coefficientOfVariation: Math.sqrt(2 / 3) / 2,
+      p50: 2,
+      p95: 3,
+      maximum: 3,
+    });
+    strict.throws(() => percentile([], 0.5), /non-empty/u);
+    strict.throws(() => percentile([1], 1.1), /between zero and one/u);
+    strict.throws(() => statistics([Number.NaN]), /finite numbers/u);
+  });
+
+  await it("measures async latency with deterministic warm-up and sample indexes", async () => {
+    const indexes: number[] = [];
+    const measured = await measureLatency({
+      operation: async (index) => indexes.push(index),
+      warmups: 1,
+      samples: 2,
+      iterations: 2,
+      clock: clock([0, 20, 20, 60]),
+    });
+
+    strict.deepStrictEqual(indexes, [0, 1, 0, 1, 2, 3]);
+    strict.deepStrictEqual(measured.rawSamples, [10, 20]);
+    strict.strictEqual(measured.iterationsPerSample, 2);
+    strict.strictEqual(measured.p50, 10);
+    strict.strictEqual(measured.p95, 20);
+  });
+
+  await it("measures synchronous throughput without adding promise scheduling", () => {
+    const indexes: number[] = [];
+    const measured = measureThroughput({
+      operation: (index) => indexes.push(index),
+      warmups: 1,
+      samples: 2,
+      iterations: 2,
+      clock: clock([0, 10, 10, 30]),
+    });
+
+    strict.deepStrictEqual(indexes, [0, 1, 0, 1, 2, 3]);
+    strict.deepStrictEqual(measured.rawSamples, [200, 100]);
+    strict.strictEqual(measured.p50, 100);
+    strict.strictEqual(measured.p95, 200);
+  });
+
+  await it("captures reproducibility context from injectable system and git inputs", () => {
+    const context = capturePerformanceContext({
+      budgetVersion: 2,
+      productionBuild: true,
+      workspace: "/workspace",
+      environment: { CI: "true", npm_config_user_agent: "pnpm/10.32.1 node/v24.10.0" },
+      system: {
+        node: "v24.10.0",
+        platform: "test-os",
+        platformRelease: "1.2.3",
+        architecture: "test-arch",
+        processors: [{ model: "test-cpu" }, { model: "test-cpu" }],
+        totalMemoryBytes: 8 * 1024 * 1024,
+      },
+      git: { gitRevision: "0123456789", gitDirty: false },
+    });
+
+    strict.deepStrictEqual(context, {
+      node: "v24.10.0",
+      platform: "test-os",
+      platformRelease: "1.2.3",
+      architecture: "test-arch",
+      cpuModel: "test-cpu",
+      logicalCpuCount: 2,
+      totalMemoryMiB: 8,
+      ci: true,
+      productionBuild: true,
+      budgetVersion: 2,
+      packageManager: "pnpm/10.32.1",
+      gitRevision: "0123456789",
+      gitDirty: false,
+    });
+  });
+
+  await it("writes versioned machine-readable artifacts and creates parent directories", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "typed-sql-performance-harness-"));
+    try {
+      const context = capturePerformanceContext({
+        budgetVersion: 2,
+        productionBuild: true,
+        workspace: temporary,
+        environment: {},
+        system: {
+          node: "v24.10.0",
+          platform: "test-os",
+          platformRelease: "1.2.3",
+          architecture: "test-arch",
+          processors: [{ model: "test-cpu" }],
+          totalMemoryBytes: 1024 * 1024,
+        },
+        git: { gitRevision: "revision", gitDirty: true },
+      });
+      const artifact = createPerformanceArtifact(
+        context,
+        { render: { unit: "operations/second", p50: 100 } },
+        new Date("2026-08-26T12:00:00.000Z"),
+      );
+      const path = join(temporary, "nested", "performance.json");
+      await writePerformanceArtifact(path, artifact);
+
+      strict.deepStrictEqual(JSON.parse(await readFile(path, "utf8")), artifact);
+      strict.strictEqual(artifact.formatVersion, 1);
+      strict.strictEqual(artifact.generatedAt, "2026-08-26T12:00:00.000Z");
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("keeps raw samples in artifacts but removes them from console summaries", () => {
+    const result = { unit: "ms", rawSamples: [1, 2], p50: 1, budget: { p50: 5 } };
+    const results = { measured: result, memory: { unit: "MiB", value: 2 } };
+
+    strict.deepStrictEqual(summarizePerformanceResults(results), {
+      measured: { unit: "ms", p50: 1, budget: { p50: 5 } },
+      memory: results.memory,
+    });
+    strict.deepStrictEqual(result.rawSamples, [1, 2]);
+  });
+});

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -158,6 +158,35 @@ function mysqlPreparedContract(database: MySqlDatabase): ExactQuery {
   return prepared(1n);
 }
 
+function postgresStreamingContract(database: PostgresDatabase, query: ExactQuery): QueryStream<Account> {
+  const stream = database.stream(query, { batchSize: 256 });
+  const exact: Assert<Equal<typeof stream, QueryStream<Account>>> = true;
+  void exact;
+  return stream;
+}
+
+function mysqlStreamingContract(database: MySqlDatabase, query: ExactQuery): QueryStream<Account> {
+  const stream = database.stream(query, { batchSize: 256 });
+  const exact: Assert<Equal<typeof stream, QueryStream<Account>>> = true;
+  void exact;
+  return stream;
+}
+
+async function transactionStreamingContract(
+  postgres: PostgresDatabase,
+  mysql: MySqlDatabase,
+  query: ExactQuery,
+): Promise<void> {
+  await postgres.transaction(async (transaction) => {
+    const exact: QueryStream<Account> = transaction.stream(query);
+    await exact.close();
+  });
+  await mysql.transaction(async (transaction) => {
+    const exact: QueryStream<Account> = transaction.stream(query);
+    await exact.close();
+  });
+}
+
 type ReferencedStableTypes =
   | CheckFileOptions
   | CheckFileResult
@@ -205,6 +234,9 @@ void postgresTransactionOmitsClose;
 void mysqlTransactionOmitsClose;
 void postgresPreparedContract;
 void mysqlPreparedContract;
+void postgresStreamingContract;
+void mysqlStreamingContract;
+void transactionStreamingContract;
 void (undefined as unknown as ReferencedStableTypes);
 
 const expectedRuntimeExports = {
@@ -265,7 +297,7 @@ const expectedRuntimeExports = {
     "sql",
     "typePolicy",
   ],
-  pg: ["adaptPgPool", "createPgDatabase", "loadPgDriver", "pg"],
+  pg: ["adaptPgPool", "createPgDatabase", "loadPgCursorDriver", "loadPgDriver", "pg"],
   postgresRuntime: ["createPostgresDatabase", "createPostgresTypeParsers", "postgresRenderer"],
   schema: [
     "SCHEMA_FORMAT_VERSION",

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -22,7 +22,10 @@ import type {
   Query,
   QueryExecutor,
   QueryParameters,
+  QueryResult,
+  QueryResults,
   QueryRow,
+  QueryStream,
   RenderedQuery,
   SchemaSnapshot,
   SqlDiagnostic,
@@ -31,6 +34,7 @@ import type {
   SqlRenderer,
   SqlSegment,
   SqlTag,
+  StreamOptions,
   TransactionDatabase,
   TransactionRunner,
   TypedSqlConfig,
@@ -38,11 +42,15 @@ import type {
 import * as coreApi from "../../packages/core/src/index.js";
 import * as mysqlApi from "../../packages/mysql/src/index.js";
 import * as mysql2Api from "../../packages/mysql/src/mysql2.js";
-import type { MySqlDatabase, MySqlTransaction } from "../../packages/mysql/src/runtime.js";
+import type { MySqlDatabase, MySqlPreparedQueryFactory, MySqlTransaction } from "../../packages/mysql/src/runtime.js";
 import * as mysqlRuntimeApi from "../../packages/mysql/src/runtime.js";
 import * as postgresApi from "../../packages/postgres/src/index.js";
 import * as pgApi from "../../packages/postgres/src/pg.js";
-import type { PostgresDatabase, PostgresTransaction } from "../../packages/postgres/src/runtime.js";
+import type {
+  PostgresDatabase,
+  PostgresPreparedQueryFactory,
+  PostgresTransaction,
+} from "../../packages/postgres/src/runtime.js";
 import * as postgresRuntimeApi from "../../packages/postgres/src/runtime.js";
 import * as schemaApi from "../../packages/schema/src/index.js";
 
@@ -56,6 +64,10 @@ type ExactQuery = Query<Account, readonly [bigint]>;
 
 const queryRow: Assert<Equal<QueryRow<ExactQuery>, Account>> = true;
 const queryParameters: Assert<Equal<QueryParameters<ExactQuery>, readonly [bigint]>> = true;
+const queryResult: Assert<Equal<QueryResult<ExactQuery>, readonly Account[]>> = true;
+const queryResults: Assert<
+  Equal<QueryResults<readonly [ExactQuery, ExactQuery]>, readonly [readonly Account[], readonly Account[]]>
+> = true;
 const rowInvariant: Assert<Equal<Assignable<ExactQuery, Query<{ readonly id: bigint }, readonly [bigint]>>, false>> =
   true;
 const parametersInvariant: Assert<Equal<Assignable<ExactQuery, Query<Account, readonly [unknown]>>, false>> = true;
@@ -116,6 +128,36 @@ const mysqlTransaction: Assert<Equal<MySqlTransactionScope, MySqlTransaction>> =
 const postgresTransactionOmitsClose: Assert<Equal<Extract<keyof PostgresTransaction, "close">, never>> = true;
 const mysqlTransactionOmitsClose: Assert<Equal<Extract<keyof MySqlTransaction, "close">, never>> = true;
 
+function postgresPreparedContract(database: PostgresDatabase): ExactQuery {
+  const prepared = database.prepare(
+    "account-by-id",
+    (id: bigint) =>
+      coreApi.sql.__typed<
+        Account,
+        readonly [bigint]
+      >()`SELECT account.id, account.status FROM account WHERE account.id = ${id}`,
+  );
+  const exact: Assert<Equal<typeof prepared, PostgresPreparedQueryFactory<[id: bigint], Account, readonly [bigint]>>> =
+    true;
+  void exact;
+  return prepared(1n);
+}
+
+function mysqlPreparedContract(database: MySqlDatabase): ExactQuery {
+  const prepared = database.prepare(
+    "account-by-id",
+    (id: bigint) =>
+      coreApi.sql.__typed<
+        Account,
+        readonly [bigint]
+      >()`SELECT account.id, account.status FROM account WHERE account.id = ${id}`,
+  );
+  const exact: Assert<Equal<typeof prepared, MySqlPreparedQueryFactory<[id: bigint], Account, readonly [bigint]>>> =
+    true;
+  void exact;
+  return prepared(1n);
+}
+
 type ReferencedStableTypes =
   | CheckFileOptions
   | CheckFileResult
@@ -130,6 +172,7 @@ type ReferencedStableTypes =
   | DialectPlugin
   | OptionalSqlFragment
   | QueryExecutor
+  | QueryStream<Account>
   | RenderedQuery
   | SqlFragment
   | SqlDiagnostic
@@ -137,12 +180,15 @@ type ReferencedStableTypes =
   | SqlRenderer
   | SqlSegment
   | SqlTag
+  | StreamOptions
   | TransactionDatabase
   | TransactionRunner
   | TypedSqlConfig;
 
 void queryRow;
 void queryParameters;
+void queryResult;
+void queryResults;
 void rowInvariant;
 void parametersInvariant;
 void composedParameters;
@@ -157,6 +203,8 @@ void postgresTransaction;
 void mysqlTransaction;
 void postgresTransactionOmitsClose;
 void mysqlTransactionOmitsClose;
+void postgresPreparedContract;
+void mysqlPreparedContract;
 void (undefined as unknown as ReferencedStableTypes);
 
 const expectedRuntimeExports = {

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -20,6 +20,7 @@ import type {
   DialectPlugin,
   OptionalSqlFragment,
   Query,
+  QueryBatch,
   QueryExecutor,
   QueryParameters,
   QueryResult,
@@ -187,6 +188,45 @@ async function transactionStreamingContract(
   });
 }
 
+function postgresBatchContract(
+  database: PostgresDatabase,
+  query: ExactQuery,
+): Promise<readonly [readonly Account[], readonly Account[]]> {
+  const results = database.batch([query, query]);
+  const exact: Assert<Equal<typeof results, Promise<readonly [readonly Account[], readonly Account[]]>>> = true;
+  void exact;
+  // @ts-expect-error every ordered batch member must be a typed Query
+  void database.batch([query, "not a query"]);
+  return results;
+}
+
+function mysqlBatchContract(
+  database: MySqlDatabase,
+  query: ExactQuery,
+): Promise<readonly [readonly Account[], readonly Account[]]> {
+  const results = database.batch([query, query]);
+  const exact: Assert<Equal<typeof results, Promise<readonly [readonly Account[], readonly Account[]]>>> = true;
+  void exact;
+  // @ts-expect-error every ordered batch member must be a typed Query
+  void database.batch([query, 42]);
+  return results;
+}
+
+async function transactionBatchContract(
+  postgres: PostgresDatabase,
+  mysql: MySqlDatabase,
+  query: ExactQuery,
+): Promise<void> {
+  await postgres.transaction(async (transaction) => {
+    const exact: readonly [readonly Account[]] = await transaction.batch([query]);
+    void exact;
+  });
+  await mysql.transaction(async (transaction) => {
+    const exact: readonly [readonly Account[]] = await transaction.batch([query]);
+    void exact;
+  });
+}
+
 type ReferencedStableTypes =
   | CheckFileOptions
   | CheckFileResult
@@ -200,6 +240,7 @@ type ReferencedStableTypes =
   | DialectCapabilities
   | DialectPlugin
   | OptionalSqlFragment
+  | QueryBatch<readonly [ExactQuery]>
   | QueryExecutor
   | QueryStream<Account>
   | RenderedQuery
@@ -237,6 +278,9 @@ void mysqlPreparedContract;
 void postgresStreamingContract;
 void mysqlStreamingContract;
 void transactionStreamingContract;
+void postgresBatchContract;
+void mysqlBatchContract;
+void transactionBatchContract;
 void (undefined as unknown as ReferencedStableTypes);
 
 const expectedRuntimeExports = {

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -38,11 +38,11 @@ import type {
 import * as coreApi from "../../packages/core/src/index.js";
 import * as mysqlApi from "../../packages/mysql/src/index.js";
 import * as mysql2Api from "../../packages/mysql/src/mysql2.js";
-import type { MySqlDatabase } from "../../packages/mysql/src/runtime.js";
+import type { MySqlDatabase, MySqlTransaction } from "../../packages/mysql/src/runtime.js";
 import * as mysqlRuntimeApi from "../../packages/mysql/src/runtime.js";
 import * as postgresApi from "../../packages/postgres/src/index.js";
 import * as pgApi from "../../packages/postgres/src/pg.js";
-import type { PostgresDatabase } from "../../packages/postgres/src/runtime.js";
+import type { PostgresDatabase, PostgresTransaction } from "../../packages/postgres/src/runtime.js";
 import * as postgresRuntimeApi from "../../packages/postgres/src/runtime.js";
 import * as schemaApi from "../../packages/schema/src/index.js";
 
@@ -109,6 +109,12 @@ type PostgresAdapter = Awaited<ReturnType<typeof pgApi.createPgDatabase>>;
 type MySqlAdapter = Awaited<ReturnType<typeof mysql2Api.createMySql2Database>>;
 const postgresAdapter: Assert<Equal<PostgresAdapter, PostgresDatabase>> = true;
 const mysqlAdapter: Assert<Equal<MySqlAdapter, MySqlDatabase>> = true;
+type PostgresTransactionScope = Parameters<Parameters<PostgresDatabase["transaction"]>[0]>[0];
+type MySqlTransactionScope = Parameters<Parameters<MySqlDatabase["transaction"]>[0]>[0];
+const postgresTransaction: Assert<Equal<PostgresTransactionScope, PostgresTransaction>> = true;
+const mysqlTransaction: Assert<Equal<MySqlTransactionScope, MySqlTransaction>> = true;
+const postgresTransactionOmitsClose: Assert<Equal<Extract<keyof PostgresTransaction, "close">, never>> = true;
+const mysqlTransactionOmitsClose: Assert<Equal<Extract<keyof MySqlTransaction, "close">, never>> = true;
 
 type ReferencedStableTypes =
   | CheckFileOptions
@@ -147,6 +153,10 @@ void enrichedTransactionContract;
 void enrichedIsDefaultCompatible;
 void postgresAdapter;
 void mysqlAdapter;
+void postgresTransaction;
+void mysqlTransaction;
+void postgresTransactionOmitsClose;
+void mysqlTransactionOmitsClose;
 void (undefined as unknown as ReferencedStableTypes);
 
 const expectedRuntimeExports = {

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -31,6 +31,7 @@ import type {
   SqlRenderer,
   SqlSegment,
   SqlTag,
+  TransactionDatabase,
   TransactionRunner,
   TypedSqlConfig,
 } from "../../packages/core/src/index.js";
@@ -73,6 +74,37 @@ function executionContract(database: Database, query: ExactQuery): Promise<reado
   return database.execute(query);
 }
 
+function defaultTransactionContract(database: Database, query: ExactQuery): Promise<readonly Account[]> {
+  return database.transaction(async (transaction) => {
+    const compatible: Database = transaction;
+    void compatible;
+    return transaction.execute(query);
+  });
+}
+
+interface EnrichedTransaction extends Database<EnrichedTransaction> {
+  explain<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<string>;
+}
+
+interface EnrichedDatabase extends Database<EnrichedTransaction> {
+  close(): Promise<void>;
+}
+
+function enrichedTransactionContract(database: EnrichedDatabase, query: ExactQuery): Promise<string> {
+  return database.transaction(async (transaction) => {
+    const retainedCapability: Promise<string> = transaction.explain(query);
+    await transaction.transaction(async (nested) => {
+      const nestedCapability: Promise<string> = nested.explain(query);
+      void nestedCapability;
+    });
+    // @ts-expect-error transaction scopes retain adapter capabilities without exposing root lifecycle methods
+    await transaction.close();
+    return retainedCapability;
+  });
+}
+
+const enrichedIsDefaultCompatible: Assert<Assignable<EnrichedDatabase, Database>> = true;
+
 type PostgresAdapter = Awaited<ReturnType<typeof pgApi.createPgDatabase>>;
 type MySqlAdapter = Awaited<ReturnType<typeof mysql2Api.createMySql2Database>>;
 const postgresAdapter: Assert<Equal<PostgresAdapter, PostgresDatabase>> = true;
@@ -99,6 +131,7 @@ type ReferencedStableTypes =
   | SqlRenderer
   | SqlSegment
   | SqlTag
+  | TransactionDatabase
   | TransactionRunner
   | TypedSqlConfig;
 
@@ -109,6 +142,9 @@ void parametersInvariant;
 void composedParameters;
 void emptyParameters;
 void executionContract;
+void defaultTransactionContract;
+void enrichedTransactionContract;
+void enrichedIsDefaultCompatible;
 void postgresAdapter;
 void mysqlAdapter;
 void (undefined as unknown as ReferencedStableTypes);


### PR DESCRIPTION
## Summary

- establish runtime performance baselines and optimize MySQL row decoding
- preserve adapter capabilities and exact types across root and nested transactions
- add typed prepared-query factories for PostgreSQL and MySQL
- add lazy typed streaming backed by pg-cursor and mysql2 streams
- add ordered, exact-tuple typed query batches
- harden transaction ownership so unawaited execute, batch, and stream work cannot race commit, rollback, savepoint release, or connection release
- reject unsafe PostgreSQL query_timeout configuration and conservatively discard uncertain leases
- document execution semantics, performance characteristics, and driver requirements

## Safety decisions

Generic AbortSignal cancellation is intentionally not included. Neither pg/pg-cursor nor mysql2 exposes a documented public primitive that can guarantee in-flight server cancellation, deterministic transaction fate, and safe connection reuse. This can be revisited as an optional adapter capability backed by dedicated control connections.

## Verification

- pnpm verify
- TypeScript 7 workspace typecheck
- all Poku package, contract, soundness, and coverage suites
- PostgreSQL coverage: 98.72%
- MySQL coverage: 98.4%
- VitePress production build
- performance gate
- live PostgreSQL container E2E
- live MySQL container E2E
- independent PostgreSQL and MySQL lifecycle reviews