### PR TITLE
fix: respect stable registry package boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
           TYPED_SQL_REGISTRY_TAG: next
+          TYPED_SQL_REGISTRY_PREVIEW_TAG: next
       - run: pnpm audit --prod --audit-level high
       - name: Assert CodeQL release policy
         run: pnpm release:security
@@ -117,6 +118,7 @@ jobs:
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
           TYPED_SQL_REGISTRY_TAG: next
+          TYPED_SQL_REGISTRY_PREVIEW_TAG: next
       - name: Publish stable
         uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'stable'
@@ -130,3 +132,4 @@ jobs:
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
           TYPED_SQL_REGISTRY_TAG: latest
+          TYPED_SQL_REGISTRY_PREVIEW_TAG: next

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -36,9 +36,11 @@ const packageNames = [
   "ts-bridge",
   "language-server",
 ] as const;
+const previewPackageNames = new Set(["@typed-sql/ts-bridge", "@typed-sql/language-server"]);
 const consumerSource = process.env.TYPED_SQL_CONSUMER_SOURCE ?? "packed";
 const registryOnly = consumerSource === "registry";
 const registryTag = process.env.TYPED_SQL_REGISTRY_TAG ?? "next";
+const registryPreviewTag = process.env.TYPED_SQL_REGISTRY_PREVIEW_TAG ?? "next";
 if (!registryOnly && consumerSource !== "packed") {
   throw new Error(`TYPED_SQL_CONSUMER_SOURCE must be packed or registry, received ${consumerSource}`);
 }
@@ -70,6 +72,22 @@ async function mustRun(command: string, args: readonly string[], cwd = workspace
   return result;
 }
 
+async function mustEventuallyRun(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  timeout = 180_000,
+): Promise<CommandResult> {
+  const deadline = Date.now() + timeout;
+  let result = await run(command, args, cwd);
+  while (result.code !== 0 && Date.now() < deadline) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 5_000));
+    result = await run(command, args, cwd);
+  }
+  if (result.code === 0) return result;
+  throw new Error(`${command} ${args.join(" ")} failed (${result.code})\n${result.stdout}${result.stderr}`);
+}
+
 async function ensureImage(image: string, context: string): Promise<void> {
   if ((await run(engine, ["image", "exists", image])).code === 0) return;
   await mustRun(engine, ["build", "--tag", image, "--file", "Containerfile", "."], context);
@@ -80,7 +98,7 @@ async function write(path: string, value: string): Promise<void> {
 }
 
 await describe(`${consumerSource} real-database consumers`, async () => {
-  await it(`generates, typechecks, and executes from ${registryOnly ? "npm next" : "tarballs"}`, async () => {
+  await it(`generates, typechecks, and executes from ${registryOnly ? `npm ${registryTag}` : "tarballs"}`, async () => {
     const temporary = await mkdtemp(join(tmpdir(), `typed-sql-${consumerSource}-real-`));
     const tarballs = join(temporary, "tarballs");
     const consumer = join(temporary, "consumer");
@@ -88,14 +106,15 @@ await describe(`${consumerSource} real-database consumers`, async () => {
     await mkdir(consumer);
     try {
       log(
-        `${registryOnly ? "Resolving npm next" : "Packing public artifacts"} and building both immutable database images`,
+        `${registryOnly ? `Resolving npm ${registryTag} with preview tooling from ${registryPreviewTag}` : "Packing public artifacts"} and building both immutable database images`,
       );
       const dependencies: Record<string, string> = {};
       for (const directory of packageNames) {
         const manifest = JSON.parse(await readFile(join(workspace, "packages", directory, "package.json"), "utf8")) as {
           readonly name: string;
         };
-        if (registryOnly) dependencies[manifest.name] = registryTag;
+        if (registryOnly)
+          dependencies[manifest.name] = previewPackageNames.has(manifest.name) ? registryPreviewTag : registryTag;
         else {
           const before = new Set(await readdir(tarballs));
           await execFile("pnpm", ["--silent", "--filter", manifest.name, "pack", "--pack-destination", tarballs], {
@@ -139,14 +158,17 @@ await describe(`${consumerSource} real-database consumers`, async () => {
           2,
         )}\n`,
       );
-      await execFile(
-        "pnpm",
-        ["install", ...(registryOnly ? [] : ["--offline", "--ignore-scripts"]), "--no-frozen-lockfile"],
-        {
+      const installArgs = [
+        "install",
+        ...(registryOnly ? [] : ["--offline", "--ignore-scripts"]),
+        "--no-frozen-lockfile",
+      ];
+      if (registryOnly) await mustEventuallyRun("pnpm", installArgs, consumer);
+      else
+        await execFile("pnpm", installArgs, {
           cwd: consumer,
           env: { ...cleanEnvironment, CI: "true" },
-        },
-      );
+        });
 
       if (registryOnly) {
         const manifest = await readFile(join(consumer, "package.json"), "utf8");

--- a/test/contracts/registry-acceptance.test.ts
+++ b/test/contracts/registry-acceptance.test.ts
@@ -23,6 +23,9 @@ await describe("registry-only consumer acceptance", async () => {
 
     for (const contract of [
       'process.env.TYPED_SQL_REGISTRY_TAG ?? "next"',
+      'process.env.TYPED_SQL_REGISTRY_PREVIEW_TAG ?? "next"',
+      'new Set(["@typed-sql/ts-bridge", "@typed-sql/language-server"])',
+      "mustEventuallyRun",
       'typescript: "7.0.2"',
       '"@types/node": "24.13.3"',
       'for (const protocol of ["workspace:", "link:", "file:"])',
@@ -49,8 +52,13 @@ await describe("registry-only consumer acceptance", async () => {
 
     strict.ok(gate >= 0, "release workflow must run the registry-only gate");
     strict.ok(workflow.slice(gate, stableAssertion).includes("TYPED_SQL_REGISTRY_TAG: next"));
+    strict.ok(workflow.slice(gate, stableAssertion).includes("TYPED_SQL_REGISTRY_PREVIEW_TAG: next"));
     strict.ok(workflow.slice(gate, stableAssertion).includes("if: inputs.channel == 'stable'"));
     strict.ok(gate < stableAssertion, "registry gate must precede the stable release assertion");
     strict.ok(stableAssertion < stablePublish, "registry gate and assertion must precede stable publication");
+
+    const stableVerification = workflow.indexOf("Verify published stable packages from npm");
+    strict.ok(workflow.slice(stableVerification).includes("TYPED_SQL_REGISTRY_TAG: latest"));
+    strict.ok(workflow.slice(stableVerification).includes("TYPED_SQL_REGISTRY_PREVIEW_TAG: next"));
   });
 });


### PR DESCRIPTION
## Summary

- install stable packages from the requested registry tag while keeping preview tooling explicitly on `next`
- tolerate bounded npm metadata propagation during clean consumer installation
- lock both behaviors into the release workflow contract

## Root cause

The first stable verification ran before npm exposed `@typed-sql/core@1.0.0`. After propagation, the smoke installed stable packages from `latest` but also selected the experimental language server from its stale `latest` beta tag. The preview packages intentionally remain on `next`.

## Verification

- `pnpm quality`
- `pnpm typecheck`
- `poku test/contracts/registry-acceptance.test.ts --reporter=compact --enforce`
- `TYPED_SQL_CONTAINER_ENGINE=podman TYPED_SQL_REGISTRY_TAG=latest TYPED_SQL_REGISTRY_PREVIEW_TAG=next pnpm e2e:registry`