### PR TITLE
feat: add grammar-neutral semantic query metadata

### DIFF
--- a/.changeset/quiet-planets-prove.md
+++ b/.changeset/quiet-planets-prove.md
@@ -1,0 +1,10 @@
+---
+"@typed-sql/core": major
+"@typed-sql/compiler": major
+"@typed-sql/ast": minor
+"@typed-sql/schema": minor
+"@typed-sql/postgres": major
+"@typed-sql/mysql": major
+---
+
+Add the dialect contract v4 semantic query evidence foundation. PostgreSQL and MySQL now report operation, dependencies, cardinality, volatility, locking, connection affinity, and required capabilities; compiler results add deterministic query and structural-variant fingerprints and conservatively merged source-mapped semantics. Schema snapshots can record function volatility, and the AST package exposes a neutral statement walker for grammar implementations.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -39,6 +39,7 @@ Every grammar implements the same public contract for:
 - identifier, quoting, and placeholder rules;
 - catalog snapshot validation and introspection;
 - result-column and ordered-parameter resolution;
+- evidence-backed operation, dependency, cardinality, volatility, locking, and connection-affinity semantics;
 - database-to-TypeScript mapping;
 - runtime encoding and decoding;
 - feature and server-version capabilities.
@@ -46,6 +47,10 @@ Every grammar implements the same public contract for:
 The compiler recognizes the `sqlModule` declared by the configured dialect. It does not branch on package names, dialect ids, or drivers. PostgreSQL, MySQL, and third-party grammars use the same compiler and schema infrastructure while owning their SQL semantics.
 
 Core exposes grammar-neutral resolver mechanisms such as indexed catalog lookup, ordered parameter collection, literal-union normalization, and name suggestions. Identifiers, operators, built-ins, nullability, feature gates, and diagnostics remain grammar responsibilities.
+
+Every successful analysis also returns versioned `QuerySemantics`. A semantic fact includes the source evidence that supports it. Dependencies distinguish schema-resolved objects from syntactic references, and unsupported or ambiguous statements return unknown semantics. For conditional composition, the compiler merges all possible branches conservatively: dependencies and capabilities are combined, cardinality widens, and the highest-risk volatility, locking, or connection requirement wins.
+
+Compiled queries expose a path-independent SHA-256 fingerprint and the fingerprints of their structural variants. These identify compiler artifacts; they do not contain parameter values and are not a security signature.
 
 ## Generated metadata
 

--- a/docs/extending/custom-grammars.md
+++ b/docs/extending/custom-grammars.md
@@ -31,6 +31,7 @@ import {
   type DialectAnalysis,
   type DialectPlugin,
   type SchemaSnapshot,
+  unknownQuerySemantics,
 } from "@typed-sql/core";
 import { parseSchemaSnapshot } from "@typed-sql/schema";
 
@@ -71,6 +72,10 @@ function analyze(
     columns: [],
     parameters: [],
     diagnostics: [],
+    semantics: unknownQuerySemantics(
+      { start: 0, end: text.length, line: 1, column: 1 },
+      "The example grammar has not implemented semantic analysis.",
+    ),
   };
 }
 
@@ -114,13 +119,17 @@ The dialect contract separates neutral compiler mechanics from SQL semantics:
 - `placeholder(index)` renders one-based parameter markers.
 - `quoteIdentifier(identifier)` matches the runtime renderer.
 - `capabilities` is an immutable, grammar-owned feature map.
-- `analyze(text, snapshot, policy)` returns columns, ordered parameter evidence, and source-mapped diagnostics.
+- `analyze(text, snapshot, policy)` returns columns, ordered parameter evidence, source-mapped diagnostics, and versioned `QuerySemantics`.
 - `validateSnapshot(value)` owns dialect and grammar-version compatibility.
 - `defaultTypePolicy` defines the default database-to-TypeScript mapping.
 
 Return parameters in placeholder order. Use `unknown` when evidence is insufficient. Unsupported, ambiguous, invalid, or version-gated SQL must produce a diagnostic or conservative unknown result, never an optimistic type.
 
 Core exports optional grammar-neutral helpers including `ResolverSchemaIndex`, `ParameterCollector`, `unionTypeLiterals`, and `closestName`. A grammar retains control of parsing, identifiers, operators, built-ins, coercions, nullability, and diagnostics.
+
+Semantic metadata records the operation, referenced objects, result cardinality, volatility, locking, connection affinity, and required capabilities. Every positive safety classification needs syntax or schema evidence. Dependencies must say whether they are schema-resolved or only syntactic. If the grammar cannot support a statement or establish its effects, return `unknownQuerySemantics()` and a diagnostic where the SQL itself is unsupported. Do not infer safety from a statement prefix or regular expression.
+
+Use `defineQuerySemantics()` to canonicalize and deeply freeze successful grammar evidence. Structural variants are analyzed as complete statements. The compiler maps their semantic ranges back to TypeScript and merges the possible results conservatively through `mergeQuerySemantics()`.
 
 ## Compatibility versions
 
@@ -142,6 +151,8 @@ Before publishing a grammar:
 4. Prove one exact row and ordered parameter tuple.
 5. Prove a type-policy override changes inference and runtime decoding together.
 6. Produce a documented diagnostic for unsupported syntax.
-7. Install the packed package in an empty project without workspace imports or a database driver.
+7. Prove operation, cardinality, dependency, and volatility evidence for the exact query.
+8. Prove unsupported analysis exposes unknown semantics.
+9. Install the packed package in an empty project without workspace imports or a database driver.
 
 Executable conformance examples live in the repository's [`test/grammar`](https://github.com/Lojhan/typed-sql/tree/main/test/grammar) fixtures.

--- a/docs/guides/schema-snapshots.md
+++ b/docs/guides/schema-snapshots.md
@@ -17,7 +17,7 @@ The configured provider introspects the selected schemas and writes deterministi
 
 - the dialect and grammar version;
 - database server version;
-- tables, views, columns, defaults, enums, domains, and supported functions;
+- tables, views, columns, defaults, enums, domains, and supported functions, including function volatility when the catalog exposes it;
 - database-to-TypeScript mappings;
 - the schema hash and type-policy hash.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -132,11 +132,19 @@ Public schema types include `SchemaSnapshot`, `GeneratedSchemaSnapshot`, table, 
 - `compileSource` and its query or fragment results;
 - `extractStaticQueries`, `mapSqlRange`, `ExtractedQuery`, and `ExtractedInterpolation`.
 
+Each `CompiledQuery` includes:
+
+- `fingerprint`, a dialect- and grammar-version-scoped SHA-256 identity;
+- `variantFingerprints`, containing every bounded structural SQL identity;
+- `semantics`, with source-mapped, conservatively merged query evidence.
+
 Scanner control flow, append extraction, structural parsing, branch expansion, and conditional row rendering remain internal.
 
 ## Grammar entrypoints
 
 `@typed-sql/core` exports `DialectPlugin`, `DialectCapabilities`, `SchemaProvider`, resolution and snapshot types, `DIALECT_CONTRACT_VERSION`, `assertDialectPlugin`, and grammar-neutral resolver helpers.
+
+Dialect contract version 4 requires every `DialectAnalysis` to include `QuerySemantics`. Its operation, cardinality, volatility, locking, and connection-affinity values carry source evidence. Dependencies record object kind, access, name, optional schema/parent, source range, and whether the reference was schema-resolved or only syntactic. `defineQuerySemantics`, `unknownQuerySemantics`, `mapQuerySemanticRanges`, and `mergeQuerySemantics` provide canonical immutability, fail-closed analysis, source mapping, and structural-composition mechanics.
 
 See [Authoring a custom grammar](../extending/custom-grammars.md).
 

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -17,6 +17,8 @@ const statement = parseStatement("SELECT account.id FROM accounts AS account");
 The parser supports PostgreSQL and MySQL syntax modes and preserves ranges for diagnostics, hover,
 definitions, and quick fixes. Input length, token count, and parse nesting are resource-bounded.
 Failures expose structured `SqlTokenizeError` or `SqlParseError` values with source ranges.
+Grammar authors can use `walkStatement` to visit nested syntax with lexical CTE context while
+retaining ownership of dialect semantics.
 
 Application code normally imports `sql` from `@typed-sql/postgres` or `@typed-sql/mysql` instead.
 See [Inference and safety](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/type-safety.md)

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -46,3 +46,5 @@ export type {
   WindowSpecification,
   WithClause,
 } from "./types.js";
+export type { SqlAstContext, SqlAstVisitor } from "./walk.js";
+export { walkStatement } from "./walk.js";

--- a/packages/ast/src/walk.ts
+++ b/packages/ast/src/walk.ts
@@ -1,0 +1,139 @@
+import type { Expression, Identifier, Statement, TableReference, TypeName } from "./types.js";
+
+export interface SqlAstContext {
+  readonly ctes: readonly Identifier[];
+}
+
+export interface SqlAstVisitor {
+  readonly statement?: (statement: Statement) => void;
+  readonly table?: (table: TableReference, statement: Statement, context: SqlAstContext) => void;
+  readonly expression?: (expression: Expression, statement: Statement) => void;
+  readonly type?: (type: TypeName, statement: Statement) => void;
+}
+
+function walkExpression(
+  expression: Expression,
+  statement: Statement,
+  visitor: SqlAstVisitor,
+  context: SqlAstContext,
+): void {
+  visitor.expression?.(expression, statement);
+  switch (expression.kind) {
+    case "array":
+    case "row":
+      for (const element of expression.elements) walkExpression(element, statement, visitor, context);
+      break;
+    case "call":
+      for (const argument of expression.arguments) walkExpression(argument, statement, visitor, context);
+      if (expression.filter !== undefined) walkExpression(expression.filter, statement, visitor, context);
+      if (expression.over !== undefined && "partitionBy" in expression.over) {
+        for (const item of expression.over.partitionBy) walkExpression(item, statement, visitor, context);
+        for (const item of expression.over.orderBy) walkExpression(item.expression, statement, visitor, context);
+      }
+      break;
+    case "cast":
+      walkExpression(expression.expression, statement, visitor, context);
+      visitor.type?.(expression.databaseType, statement);
+      break;
+    case "binary":
+      walkExpression(expression.left, statement, visitor, context);
+      walkExpression(expression.right, statement, visitor, context);
+      break;
+    case "unary":
+      walkExpression(expression.expression, statement, visitor, context);
+      break;
+    case "case":
+      if (expression.operand !== undefined) walkExpression(expression.operand, statement, visitor, context);
+      for (const branch of expression.branches) {
+        walkExpression(branch.when, statement, visitor, context);
+        walkExpression(branch.then, statement, visitor, context);
+      }
+      if (expression.elseExpression !== undefined)
+        walkExpression(expression.elseExpression, statement, visitor, context);
+      break;
+    case "subquery":
+    case "exists":
+      walkStatementWithContext(expression.query, visitor, context.ctes);
+      break;
+    case "in":
+      walkExpression(expression.expression, statement, visitor, context);
+      if ("kind" in expression.values) walkStatementWithContext(expression.values, visitor, context.ctes);
+      else for (const value of expression.values) walkExpression(value, statement, visitor, context);
+      break;
+    case "between":
+      walkExpression(expression.expression, statement, visitor, context);
+      walkExpression(expression.lower, statement, visitor, context);
+      walkExpression(expression.upper, statement, visitor, context);
+      break;
+    case "column":
+    case "star":
+    case "literal":
+    case "parameter":
+      break;
+  }
+}
+
+function walkTable(table: TableReference, statement: Statement, visitor: SqlAstVisitor, context: SqlAstContext): void {
+  visitor.table?.(table, statement, context);
+  if (table.kind === "subquery") walkStatementWithContext(table.query, visitor, context.ctes);
+}
+
+function walkStatementWithContext(
+  statement: Statement,
+  visitor: SqlAstVisitor,
+  inheritedCtes: readonly Identifier[],
+): void {
+  visitor.statement?.(statement);
+  const localCtes = [...inheritedCtes];
+  if (statement.with?.recursive) localCtes.push(...statement.with.queries.map((query) => query.name));
+  for (const query of statement.with?.queries ?? []) {
+    walkStatementWithContext(query.statement, visitor, localCtes);
+    if (!statement.with?.recursive) localCtes.push(query.name);
+  }
+  const context = Object.freeze({ ctes: Object.freeze(localCtes) });
+  if (statement.kind === "select") {
+    if (statement.from !== undefined) walkTable(statement.from, statement, visitor, context);
+    for (const join of statement.joins) {
+      walkTable(join.table, statement, visitor, context);
+      if (join.on !== undefined) walkExpression(join.on, statement, visitor, context);
+    }
+    for (const item of statement.columns) walkExpression(item.expression, statement, visitor, context);
+    if (statement.where !== undefined) walkExpression(statement.where, statement, visitor, context);
+    for (const expression of statement.groupBy) walkExpression(expression, statement, visitor, context);
+    if (statement.having !== undefined) walkExpression(statement.having, statement, visitor, context);
+    for (const expression of statement.distinctOn) walkExpression(expression, statement, visitor, context);
+    for (const window of statement.windows) {
+      for (const expression of window.specification.partitionBy)
+        walkExpression(expression, statement, visitor, context);
+      for (const item of window.specification.orderBy) walkExpression(item.expression, statement, visitor, context);
+    }
+    for (const item of statement.orderBy) walkExpression(item.expression, statement, visitor, context);
+    if (statement.limit !== undefined) walkExpression(statement.limit, statement, visitor, context);
+    if (statement.offset !== undefined) walkExpression(statement.offset, statement, visitor, context);
+    return;
+  }
+  walkTable(statement.table, statement, visitor, context);
+  if (statement.kind === "insert") {
+    if (statement.source.kind === "values") {
+      for (const row of statement.source.rows)
+        for (const expression of row) walkExpression(expression, statement, visitor, context);
+    } else if (statement.source.kind === "select") walkStatementWithContext(statement.source, visitor, context.ctes);
+  } else if (statement.kind === "update") {
+    for (const assignment of statement.assignments) walkExpression(assignment.value, statement, visitor, context);
+    if (statement.from !== undefined) walkTable(statement.from, statement, visitor, context);
+    for (const join of statement.joins) {
+      walkTable(join.table, statement, visitor, context);
+      if (join.on !== undefined) walkExpression(join.on, statement, visitor, context);
+    }
+    if (statement.where !== undefined) walkExpression(statement.where, statement, visitor, context);
+  } else {
+    for (const table of statement.using) walkTable(table, statement, visitor, context);
+    if (statement.where !== undefined) walkExpression(statement.where, statement, visitor, context);
+  }
+  for (const item of statement.returning) walkExpression(item.expression, statement, visitor, context);
+}
+
+/** Walks syntax only. Dialect packages remain responsible for assigning semantics. */
+export function walkStatement(statement: Statement, visitor: SqlAstVisitor): void {
+  walkStatementWithContext(statement, visitor, []);
+}

--- a/packages/ast/test/walk.test.ts
+++ b/packages/ast/test/walk.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, strict } from "poku";
+import { parseStatement, walkStatement } from "../src/index.js";
+
+await describe("SQL AST walker", async () => {
+  await it("visits nested CTE, relation, expression, and cast syntax once", () => {
+    const statement = parseStatement(
+      "WITH changed AS (UPDATE accounts SET status = $1 RETURNING id) SELECT CAST(id AS bigint) FROM changed",
+    );
+    const statements: string[] = [];
+    const tables: string[] = [];
+    const expressions: string[] = [];
+    const types: string[] = [];
+    const visibleCtes: string[][] = [];
+    walkStatement(statement, {
+      statement: (item) => statements.push(item.kind),
+      table: (item, _statement, context) => {
+        tables.push(item.kind === "table" ? item.name.name : "subquery");
+        visibleCtes.push(context.ctes.map(({ name }) => name));
+      },
+      expression: (item) => expressions.push(item.kind),
+      type: (item) => types.push(item.name),
+    });
+    strict.deepStrictEqual(statements, ["select", "update"]);
+    strict.deepStrictEqual(tables, ["accounts", "changed"]);
+    strict.deepStrictEqual(visibleCtes, [[], ["changed"]]);
+    strict.ok(expressions.includes("parameter"));
+    strict.ok(expressions.includes("cast"));
+    strict.deepStrictEqual(types, ["bigint"]);
+  });
+
+  await it("walks every supported expression and data-changing statement shape", () => {
+    const sources = [
+      `SELECT ARRAY[$1, 2], ROW(id, $2),
+              COUNT(DISTINCT id) FILTER (WHERE active) OVER (PARTITION BY team_id ORDER BY id),
+              CAST(id + 1 AS bigint), NOT active,
+              CASE id WHEN 1 THEN 2 ELSE 3 END,
+              EXISTS (SELECT 1 FROM audit),
+              id IN (SELECT user_id FROM audit), id BETWEEN 1 AND 9
+       FROM (SELECT id, active, team_id FROM users) AS account
+       LEFT JOIN teams ON teams.id = account.team_id
+       WHERE account.id > 0 GROUP BY account.id, account.active, account.team_id
+       HAVING COUNT(*) > 0 ORDER BY account.id LIMIT 10 OFFSET 1`,
+      "INSERT INTO users (id) VALUES ($1), ($2) RETURNING id",
+      "INSERT INTO users (id) SELECT id FROM audit RETURNING id",
+      "UPDATE users SET id = $1 FROM audit LEFT JOIN teams ON teams.id = audit.team_id WHERE users.id = audit.user_id RETURNING users.id",
+      "DELETE FROM users USING audit WHERE users.id = audit.user_id RETURNING users.id",
+      "WITH RECURSIVE tree(id) AS (SELECT 1) SELECT id FROM tree",
+    ];
+    const visited = { statements: 0, tables: 0, expressions: 0, types: 0 };
+    for (const source of sources) {
+      walkStatement(parseStatement(source), {
+        statement: () => {
+          visited.statements += 1;
+        },
+        table: () => {
+          visited.tables += 1;
+        },
+        expression: () => {
+          visited.expressions += 1;
+        },
+        type: () => {
+          visited.types += 1;
+        },
+      });
+    }
+    strict.ok(visited.statements >= 10);
+    strict.ok(visited.tables >= 12);
+    strict.ok(visited.expressions >= 60);
+    strict.strictEqual(visited.types, 1);
+  });
+});

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -21,7 +21,8 @@ const result = compileSource({
 ```
 
 `compileSource` consumes only `DialectPlugin`; it does not branch on a database, grammar package,
-or driver. Its public options include the structural-variant bound used for conditional fragments.
+or driver. Compiled queries expose path-independent SHA-256 fingerprints, variant fingerprints,
+and source-mapped semantics merged conservatively across conditional structure. Its public options include the structural-variant bound used for conditional fragments.
 Application projects normally use the compiler through `typed-sql check` or the language server.
 
 Read [Architecture](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/architecture.md),

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -222,12 +222,13 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
     const resolved = dialect.analyze(query.sql, schema, options.typePolicy);
     diagnostics.push(...resolved.diagnostics.map((diagnostic) => mapDiagnostic(source, query, diagnostic)));
     if (!resolved.diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+      const queryFingerprint = fingerprint(dialect, query.sql);
       compiled.push({
         query,
         rowType: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
         parameterType: parameterTypeLiteral(query.parameterCount, resolved.parameters),
-        fingerprint: fingerprint(dialect, query.sql),
-        variantFingerprints: Object.freeze([fingerprint(dialect, query.sql)]),
+        fingerprint: queryFingerprint,
+        variantFingerprints: Object.freeze([queryFingerprint]),
         semantics: sourceSemantics(source, query, resolved.semantics),
       });
     }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,6 +1,10 @@
+import { createHash } from "node:crypto";
 import {
   type DialectPlugin,
+  mapQuerySemanticRanges,
+  mergeQuerySemantics,
   parameterTypeLiteral,
+  type QuerySemantics,
   type ResolvedParameter,
   rowTypeLiteral,
   type SchemaSnapshot,
@@ -22,6 +26,9 @@ export interface CompiledQuery {
   readonly rowType: string;
   readonly parameterType: string;
   readonly structural?: true;
+  readonly fingerprint: string;
+  readonly variantFingerprints: readonly string[];
+  readonly semantics: QuerySemantics;
 }
 
 export interface CompiledFragment {
@@ -46,6 +53,14 @@ export interface CompileSourceOptions<Snapshot extends SchemaSnapshot, Policy> {
 
 function mapDiagnostic(source: string, query: ExtractedQuery, diagnostic: SqlDiagnostic): SqlDiagnostic {
   return { ...diagnostic, range: mapSqlRange(source, query, diagnostic.range) };
+}
+
+function fingerprint(dialect: DialectPlugin, sql: string): string {
+  return `sha256:${createHash("sha256").update(`${dialect.id}\0${dialect.grammarVersion}\0${sql}`).digest("hex")}`;
+}
+
+function sourceSemantics(source: string, query: ExtractedQuery, semantics: QuerySemantics): QuerySemantics {
+  return mapQuerySemanticRanges(semantics, (range) => mapSqlRange(source, query, range));
 }
 
 function deduplicateDiagnostics(diagnostics: readonly SqlDiagnostic[]): readonly SqlDiagnostic[] {
@@ -117,6 +132,7 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
       const resolvedVariants = expansion.variants.map((variant) => ({
         variant,
         resolved: dialect.analyze(variant.query.sql, schema, options.typePolicy),
+        fingerprint: fingerprint(dialect, variant.query.sql),
       }));
       for (const { variant, resolved } of resolvedVariants) {
         diagnostics.push(...resolved.diagnostics.map((diagnostic) => mapDiagnostic(source, variant.query, diagnostic)));
@@ -183,6 +199,16 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
           rowType: structuralRowType(source, query, rows),
           parameterType: parameterTypes.join(" | "),
           structural: true,
+          variantFingerprints: Object.freeze(
+            [...new Set(resolvedVariants.map((variant) => variant.fingerprint))].sort(),
+          ),
+          fingerprint: fingerprint(
+            dialect,
+            [...new Set(resolvedVariants.map((variant) => variant.fingerprint))].sort().join("\0"),
+          ),
+          semantics: mergeQuerySemantics(
+            resolvedVariants.map(({ variant, resolved }) => sourceSemantics(source, variant.query, resolved.semantics)),
+          ),
         });
         compiledFragments.push(
           ...[...byPosition.values()].map((item) => ({
@@ -200,6 +226,9 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
         query,
         rowType: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
         parameterType: parameterTypeLiteral(query.parameterCount, resolved.parameters),
+        fingerprint: fingerprint(dialect, query.sql),
+        variantFingerprints: Object.freeze([fingerprint(dialect, query.sql)]),
+        semantics: sourceSemantics(source, query, resolved.semantics),
       });
     }
   }

--- a/packages/compiler/test/compiler.test.ts
+++ b/packages/compiler/test/compiler.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, strict } from "poku";
-import { DIALECT_CONTRACT_VERSION, type DialectPlugin, type SchemaSnapshot } from "../../core/src/index.js";
+import {
+  DIALECT_CONTRACT_VERSION,
+  type DialectPlugin,
+  type SchemaSnapshot,
+  unknownQuerySemantics,
+} from "../../core/src/index.js";
 import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
 import { loadSchemaSnapshot } from "../../schema/src/index.js";
 import { checkFile, compileSource, extractStaticQueries, mapSqlRange } from "../src/index.js";
@@ -175,6 +180,7 @@ await describe("TypeScript 7 compiler wrapper", async () => {
         parameters: [],
         diagnostics: [],
         resultKind: "rows" as const,
+        semantics: unknownQuerySemantics({ start: 0, end: sql.length, line: 1, column: 1 }, "Test grammar"),
       }),
     };
     const source = [
@@ -324,6 +330,7 @@ await describe("TypeScript 7 compiler wrapper", async () => {
             range: { start: 7, end: 9, line: 1, column: 8 },
           },
         ],
+        semantics: unknownQuerySemantics({ start: 0, end: 1, line: 1, column: 1 }, "Test diagnostic"),
       }),
     };
     const conditional =
@@ -338,6 +345,7 @@ await describe("TypeScript 7 compiler wrapper", async () => {
         parameters: [{ index: 1, tsType: sql.includes("users AS account") ? "number" : "string", nullable: false }],
         diagnostics: [],
         resultKind: "rows",
+        semantics: unknownQuerySemantics({ start: 0, end: sql.length, line: 1, column: 1 }, "Test grammar"),
       }),
     };
     const contextual = [
@@ -364,6 +372,25 @@ await describe("TypeScript 7 compiler wrapper", async () => {
     const result = compileSource({ source, schema: schema as PostgresSchemaSnapshot, dialect: postgres() });
     strict.deepStrictEqual(result.diagnostics, []);
     strict.ok(result.transformedSource.includes('sql<{ "id": number; }, readonly []>`SELECT id FROM users`'));
+    strict.match(result.queries[0]?.fingerprint ?? "", /^sha256:[a-f0-9]{64}$/u);
+    strict.deepStrictEqual(result.queries[0]?.variantFingerprints, [result.queries[0]?.fingerprint]);
+    strict.strictEqual(result.queries[0]?.semantics.operation.value, "read");
+    strict.strictEqual(result.queries[0]?.semantics.dependencies[0]?.range.line, 2);
+  });
+
+  await it("merges structural semantic variants and fingerprints without source-path identity", async () => {
+    const schema = await loadSchemaSnapshot(schemaPath);
+    const source = [
+      'import { sql } from "@typed-sql/postgres";',
+      "const q = sql`SELECT id FROM users ${filter ? sql.fragment`WHERE id = ${id}` : sql.empty}`;",
+    ].join("\n");
+    const first = compileSource({ source, schema: schema as PostgresSchemaSnapshot, dialect: postgres() });
+    const second = compileSource({ source, schema: schema as PostgresSchemaSnapshot, dialect: postgres() });
+    strict.deepStrictEqual(first.queries, second.queries);
+    strict.strictEqual(first.queries[0]?.variantFingerprints.length, 2);
+    strict.strictEqual(first.queries[0]?.semantics.operation.value, "read");
+    strict.strictEqual(first.queries[0]?.semantics.volatility.value, "stable");
+    strict.ok(first.queries[0]?.semantics.dependencies.every(({ range }) => range.line === 2));
   });
 
   await it("injects CTE and DML RETURNING rows and command-only never results", async () => {

--- a/packages/compiler/test/performance.test.ts
+++ b/packages/compiler/test/performance.test.ts
@@ -1,6 +1,11 @@
 import { performance } from "node:perf_hooks";
 import { describe, it, strict } from "poku";
-import { DIALECT_CONTRACT_VERSION, type DialectPlugin, type SchemaSnapshot } from "../../core/src/index.js";
+import {
+  DIALECT_CONTRACT_VERSION,
+  type DialectPlugin,
+  type SchemaSnapshot,
+  unknownQuerySemantics,
+} from "../../core/src/index.js";
 import { compileSource, extractStaticQueries } from "../src/index.js";
 
 const schema = { formatVersion: 1, dialect: "performance", tables: {} } as const satisfies SchemaSnapshot;
@@ -14,7 +19,7 @@ const dialect: DialectPlugin<typeof schema, Record<string, never>> = {
   placeholder: (index) => `$${index}`,
   quoteIdentifier: (identifier) => `"${identifier}"`,
   validateSnapshot: () => schema,
-  analyze: (_sql, _snapshot) => ({
+  analyze: (sql, _snapshot) => ({
     columns: [
       {
         name: "id",
@@ -27,6 +32,7 @@ const dialect: DialectPlugin<typeof schema, Record<string, never>> = {
     parameters: [],
     diagnostics: [],
     resultKind: "rows",
+    semantics: unknownQuerySemantics({ start: 0, end: sql.length, line: 1, column: 1 }, "Performance grammar"),
   }),
 };
 

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -31,7 +31,7 @@ await describe("typed-sql config", async () => {
     const source = `
       export default {
         dialect: {
-          contractVersion: 3,
+          contractVersion: 4,
           id: "fixture",
           grammarVersion: "1.0.0",
           sqlModule: "@example/typed-sql-fixture",
@@ -63,11 +63,11 @@ await describe("typed-sql config", async () => {
       "{}",
       "{ dialect: null }",
       "{ dialect: { contractVersion: 1 } }",
-      "{ dialect: { contractVersion: 3, id: 1 } }",
-      "{ dialect: { contractVersion: 3, id: 'x' } }",
-      "{ dialect: { contractVersion: 3, id: 'x', analyze() {} } }",
-      "{ dialect: { contractVersion: 3, id: 'x', analyze() {}, validateSnapshot() {} }, schema: {} }",
-      "{ dialect: { contractVersion: 3, id: 'x', analyze() {}, validateSnapshot() {} }, schema: { file: 'x' } }",
+      "{ dialect: { contractVersion: 4, id: 1 } }",
+      "{ dialect: { contractVersion: 4, id: 'x' } }",
+      "{ dialect: { contractVersion: 4, id: 'x', analyze() {} } }",
+      "{ dialect: { contractVersion: 4, id: 'x', analyze() {}, validateSnapshot() {} }, schema: {} }",
+      "{ dialect: { contractVersion: 4, id: 'x', analyze() {}, validateSnapshot() {} }, schema: { file: 'x' } }",
     ];
     try {
       for (const [index, candidate] of candidates.entries()) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,8 +27,8 @@ type Parameters = QueryParameters<typeof query>;
 ```
 
 Grammar and adapter authors can use `DialectPlugin`, `DIALECT_CONTRACT_VERSION`,
-`assertDialectPlugin`, `createDatabase`, `renderQuery`, the prepared-query skeleton helpers, and
-the neutral resolver primitives from the package root. The package has no parser, grammar,
+`assertDialectPlugin`, `defineQuerySemantics`, `mergeQuerySemantics`, `createDatabase`, `renderQuery`,
+the prepared-query skeleton helpers, and the neutral resolver primitives from the package root. The package has no parser, grammar,
 database driver, TypeScript compiler, or editor dependency.
 
 Read the [query API](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/api.md),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,26 @@ export {
 export type { ResolverType } from "./resolver.js";
 export { closestName, ParameterCollector, ResolverSchemaIndex, unionTypeLiterals } from "./resolver.js";
 export type {
+  QueryCardinality,
+  QueryConnectionAffinity,
+  QueryDependency,
+  QueryDependencyAccess,
+  QueryDependencyKind,
+  QueryLocking,
+  QueryOperation,
+  QuerySemantics,
+  QueryVolatility,
+  SemanticEvidence,
+  SemanticFact,
+} from "./semantics.js";
+export {
+  defineQuerySemantics,
+  mapQuerySemanticRanges,
+  mergeQuerySemantics,
+  QUERY_SEMANTICS_VERSION,
+  unknownQuerySemantics,
+} from "./semantics.js";
+export type {
   ColumnSnapshot,
   DialectAnalysis,
   DialectCapabilities,

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -94,6 +94,17 @@ function addToIndex<Value>(index: Map<string, Value[]>, key: string, value: Valu
 
 /** Precomputed case-sensitive and folded schema lookups shared by SQL grammars. */
 export class ResolverSchemaIndex {
+  static readonly #cache = new WeakMap<SchemaSnapshot, ResolverSchemaIndex>();
+
+  /** Reuses immutable snapshot indexes across resolver and semantic passes. */
+  static for(snapshot: SchemaSnapshot): ResolverSchemaIndex {
+    const cached = ResolverSchemaIndex.#cache.get(snapshot);
+    if (cached !== undefined) return cached;
+    const index = new ResolverSchemaIndex(snapshot);
+    ResolverSchemaIndex.#cache.set(snapshot, index);
+    return index;
+  }
+
   readonly #exactTables = new Map<string, IndexedTable[]>();
   readonly #foldedTables = new Map<string, IndexedTable[]>();
   readonly #exactColumns = new WeakMap<TableSnapshot, ReadonlyMap<string, ColumnSnapshot>>();

--- a/packages/core/src/semantics.ts
+++ b/packages/core/src/semantics.ts
@@ -82,16 +82,16 @@ export function defineQuerySemantics(semantics: QuerySemantics): QuerySemantics 
 }
 
 export function unknownQuerySemantics(range: SourceRange, description: string): QuerySemantics {
-  const evidence = Object.freeze([{ kind: "conservative" as const, description, range }]);
+  const evidence = [{ kind: "conservative" as const, description, range }];
   return defineQuerySemantics({
     version: QUERY_SEMANTICS_VERSION,
-    operation: Object.freeze({ value: "unknown", evidence }),
-    dependencies: Object.freeze([]),
-    cardinality: Object.freeze({ minimum: 0, maximum: "unknown", evidence }),
-    volatility: Object.freeze({ value: "unknown", evidence }),
-    locking: Object.freeze({ value: "unknown", evidence }),
-    connectionAffinity: Object.freeze({ value: "unknown", evidence }),
-    capabilities: Object.freeze([]),
+    operation: { value: "unknown", evidence },
+    dependencies: [],
+    cardinality: { minimum: 0, maximum: "unknown", evidence },
+    volatility: { value: "unknown", evidence },
+    locking: { value: "unknown", evidence },
+    connectionAffinity: { value: "unknown", evidence },
+    capabilities: [],
   });
 }
 
@@ -100,16 +100,16 @@ export function mapQuerySemanticRanges(
   map: (range: SourceRange) => SourceRange,
 ): QuerySemantics {
   const evidence = (values: readonly SemanticEvidence[]) =>
-    Object.freeze(values.map((value) => Object.freeze({ ...value, range: map(value.range) })));
-  const fact = <Value extends string>(value: SemanticFact<Value>): SemanticFact<Value> =>
-    Object.freeze({ value: value.value, evidence: evidence(value.evidence) });
+    values.map((value) => ({ ...value, range: map(value.range) }));
+  const fact = <Value extends string>(value: SemanticFact<Value>): SemanticFact<Value> => ({
+    value: value.value,
+    evidence: evidence(value.evidence),
+  });
   return defineQuerySemantics({
     ...semantics,
     operation: fact(semantics.operation),
-    dependencies: Object.freeze(
-      semantics.dependencies.map((dependency) => Object.freeze({ ...dependency, range: map(dependency.range) })),
-    ),
-    cardinality: Object.freeze({ ...semantics.cardinality, evidence: evidence(semantics.cardinality.evidence) }),
+    dependencies: semantics.dependencies.map((dependency) => ({ ...dependency, range: map(dependency.range) })),
+    cardinality: { ...semantics.cardinality, evidence: evidence(semantics.cardinality.evidence) },
     volatility: fact(semantics.volatility),
     locking: fact(semantics.locking),
     connectionAffinity: fact(semantics.connectionAffinity),
@@ -186,14 +186,12 @@ export function mergeQuerySemantics(variants: readonly QuerySemantics[]): QueryS
       variants.map((variant) => variant.operation),
       "unknown",
     ),
-    dependencies: Object.freeze(
-      [...dependencies.values()].sort((left, right) => dependencyKey(left).localeCompare(dependencyKey(right))),
-    ),
-    cardinality: Object.freeze({
+    dependencies: [...dependencies.values()],
+    cardinality: {
       minimum: variants.some((variant) => variant.cardinality.minimum === 0) ? 0 : 1,
       maximum,
       evidence: mergeEvidence(variants.map((variant) => variant.cardinality.evidence)),
-    }),
+    },
     volatility: mergeRankedFact(
       variants.map((variant) => variant.volatility),
       {
@@ -221,6 +219,6 @@ export function mergeQuerySemantics(variants: readonly QuerySemantics[]): QueryS
         unknown: 3,
       },
     ),
-    capabilities: Object.freeze([...new Set(variants.flatMap((variant) => variant.capabilities))].sort()),
+    capabilities: [...new Set(variants.flatMap((variant) => variant.capabilities))],
   });
 }

--- a/packages/core/src/semantics.ts
+++ b/packages/core/src/semantics.ts
@@ -1,0 +1,226 @@
+import type { SourceRange } from "./types.js";
+
+export const QUERY_SEMANTICS_VERSION = 1 as const;
+
+export type QueryOperation = "read" | "write" | "ddl" | "transaction-control" | "unknown";
+export type QueryVolatility = "immutable" | "stable" | "volatile" | "unknown";
+export type QueryLocking = "none" | "row" | "table" | "unknown";
+export type QueryConnectionAffinity = "none" | "transaction" | "session" | "unknown";
+export type QueryDependencyKind = "relation" | "column" | "function" | "type" | "sequence" | "unknown";
+export type QueryDependencyAccess = "read" | "write" | "execute" | "reference" | "unknown";
+
+export interface SemanticEvidence {
+  readonly kind: "syntax" | "schema" | "conservative";
+  readonly description: string;
+  readonly range: SourceRange;
+}
+
+export interface SemanticFact<Value extends string> {
+  readonly value: Value;
+  readonly evidence: readonly SemanticEvidence[];
+}
+
+export interface QueryCardinality {
+  readonly minimum: 0 | 1;
+  readonly maximum: 0 | 1 | "many" | "unknown";
+  readonly evidence: readonly SemanticEvidence[];
+}
+
+export interface QueryDependency {
+  readonly kind: QueryDependencyKind;
+  readonly access: QueryDependencyAccess;
+  readonly name: string;
+  readonly schema?: string;
+  readonly parent?: string;
+  readonly certainty: "resolved" | "syntactic";
+  readonly range: SourceRange;
+}
+
+/** Evidence produced by a grammar for one complete SQL statement. */
+export interface QuerySemantics {
+  readonly version: typeof QUERY_SEMANTICS_VERSION;
+  readonly operation: SemanticFact<QueryOperation>;
+  readonly dependencies: readonly QueryDependency[];
+  readonly cardinality: QueryCardinality;
+  readonly volatility: SemanticFact<QueryVolatility>;
+  readonly locking: SemanticFact<QueryLocking>;
+  readonly connectionAffinity: SemanticFact<QueryConnectionAffinity>;
+  readonly capabilities: readonly string[];
+}
+
+/** Canonicalizes and deeply freezes grammar-produced semantic evidence. */
+export function defineQuerySemantics(semantics: QuerySemantics): QuerySemantics {
+  if (semantics.version !== QUERY_SEMANTICS_VERSION) {
+    throw new TypeError(`Unsupported query semantics version ${String(semantics.version)}`);
+  }
+  const evidence = (values: readonly SemanticEvidence[]) =>
+    Object.freeze(
+      [...values]
+        .sort((left, right) => evidenceKey(left).localeCompare(evidenceKey(right)))
+        .map((value) => Object.freeze({ ...value, range: Object.freeze({ ...value.range }) })),
+    );
+  const fact = <Value extends string>(value: SemanticFact<Value>): SemanticFact<Value> =>
+    Object.freeze({ value: value.value, evidence: evidence(value.evidence) });
+  return Object.freeze({
+    version: QUERY_SEMANTICS_VERSION,
+    operation: fact(semantics.operation),
+    dependencies: Object.freeze(
+      [...semantics.dependencies]
+        .sort((left, right) => dependencyKey(left).localeCompare(dependencyKey(right)))
+        .map((dependency) => Object.freeze({ ...dependency, range: Object.freeze({ ...dependency.range }) })),
+    ),
+    cardinality: Object.freeze({
+      minimum: semantics.cardinality.minimum,
+      maximum: semantics.cardinality.maximum,
+      evidence: evidence(semantics.cardinality.evidence),
+    }),
+    volatility: fact(semantics.volatility),
+    locking: fact(semantics.locking),
+    connectionAffinity: fact(semantics.connectionAffinity),
+    capabilities: Object.freeze([...new Set(semantics.capabilities)].sort()),
+  });
+}
+
+export function unknownQuerySemantics(range: SourceRange, description: string): QuerySemantics {
+  const evidence = Object.freeze([{ kind: "conservative" as const, description, range }]);
+  return defineQuerySemantics({
+    version: QUERY_SEMANTICS_VERSION,
+    operation: Object.freeze({ value: "unknown", evidence }),
+    dependencies: Object.freeze([]),
+    cardinality: Object.freeze({ minimum: 0, maximum: "unknown", evidence }),
+    volatility: Object.freeze({ value: "unknown", evidence }),
+    locking: Object.freeze({ value: "unknown", evidence }),
+    connectionAffinity: Object.freeze({ value: "unknown", evidence }),
+    capabilities: Object.freeze([]),
+  });
+}
+
+export function mapQuerySemanticRanges(
+  semantics: QuerySemantics,
+  map: (range: SourceRange) => SourceRange,
+): QuerySemantics {
+  const evidence = (values: readonly SemanticEvidence[]) =>
+    Object.freeze(values.map((value) => Object.freeze({ ...value, range: map(value.range) })));
+  const fact = <Value extends string>(value: SemanticFact<Value>): SemanticFact<Value> =>
+    Object.freeze({ value: value.value, evidence: evidence(value.evidence) });
+  return defineQuerySemantics({
+    ...semantics,
+    operation: fact(semantics.operation),
+    dependencies: Object.freeze(
+      semantics.dependencies.map((dependency) => Object.freeze({ ...dependency, range: map(dependency.range) })),
+    ),
+    cardinality: Object.freeze({ ...semantics.cardinality, evidence: evidence(semantics.cardinality.evidence) }),
+    volatility: fact(semantics.volatility),
+    locking: fact(semantics.locking),
+    connectionAffinity: fact(semantics.connectionAffinity),
+  });
+}
+
+function evidenceKey(value: SemanticEvidence): string {
+  return `${value.range.start}\0${value.range.end}\0${value.kind}\0${value.description}`;
+}
+
+function mergeEvidence(values: readonly (readonly SemanticEvidence[])[]): readonly SemanticEvidence[] {
+  const merged = new Map<string, SemanticEvidence>();
+  for (const value of values.flat()) merged.set(evidenceKey(value), value);
+  return [...merged.values()].sort(
+    (left, right) =>
+      left.range.start - right.range.start ||
+      left.range.end - right.range.end ||
+      left.kind.localeCompare(right.kind) ||
+      left.description.localeCompare(right.description),
+  );
+}
+
+function mergeFact<Value extends string>(facts: readonly SemanticFact<Value>[], unknown: Value): SemanticFact<Value> {
+  const first = facts[0]?.value ?? unknown;
+  return {
+    value: facts.every((fact) => fact.value === first) ? first : unknown,
+    evidence: mergeEvidence(facts.map((fact) => fact.evidence)),
+  };
+}
+
+function mergeRankedFact<Value extends string>(
+  facts: readonly SemanticFact<Value>[],
+  ranks: Readonly<Record<Value, number>>,
+): SemanticFact<Value> {
+  const value = facts.reduce(
+    (current, fact) => (ranks[fact.value] > ranks[current] ? fact.value : current),
+    facts[0]!.value,
+  );
+  return { value, evidence: mergeEvidence(facts.map((fact) => fact.evidence)) };
+}
+
+function dependencyKey(value: QueryDependency): string {
+  return [
+    value.kind,
+    value.access,
+    value.schema ?? "",
+    value.parent ?? "",
+    value.name,
+    value.certainty,
+    value.range.start,
+    value.range.end,
+  ].join("\0");
+}
+
+const cardinalityMaximum = { 0: 0, 1: 1, many: 2, unknown: 3 } as const;
+
+/** Conservatively merges every possible structural query variant. */
+export function mergeQuerySemantics(variants: readonly QuerySemantics[]): QuerySemantics {
+  if (variants.length === 0) throw new TypeError("At least one query semantic variant is required");
+  const dependencies = new Map<string, QueryDependency>();
+  for (const dependency of variants.flatMap((variant) => variant.dependencies)) {
+    dependencies.set(dependencyKey(dependency), dependency);
+  }
+  const maximum = variants.reduce<QueryCardinality["maximum"]>(
+    (current, variant) =>
+      cardinalityMaximum[variant.cardinality.maximum] > cardinalityMaximum[current]
+        ? variant.cardinality.maximum
+        : current,
+    0,
+  );
+  return defineQuerySemantics({
+    version: QUERY_SEMANTICS_VERSION,
+    operation: mergeFact(
+      variants.map((variant) => variant.operation),
+      "unknown",
+    ),
+    dependencies: Object.freeze(
+      [...dependencies.values()].sort((left, right) => dependencyKey(left).localeCompare(dependencyKey(right))),
+    ),
+    cardinality: Object.freeze({
+      minimum: variants.some((variant) => variant.cardinality.minimum === 0) ? 0 : 1,
+      maximum,
+      evidence: mergeEvidence(variants.map((variant) => variant.cardinality.evidence)),
+    }),
+    volatility: mergeRankedFact(
+      variants.map((variant) => variant.volatility),
+      {
+        immutable: 0,
+        stable: 1,
+        volatile: 2,
+        unknown: 3,
+      },
+    ),
+    locking: mergeRankedFact(
+      variants.map((variant) => variant.locking),
+      {
+        none: 0,
+        row: 1,
+        table: 2,
+        unknown: 3,
+      },
+    ),
+    connectionAffinity: mergeRankedFact(
+      variants.map((variant) => variant.connectionAffinity),
+      {
+        none: 0,
+        transaction: 1,
+        session: 2,
+        unknown: 3,
+      },
+    ),
+    capabilities: Object.freeze([...new Set(variants.flatMap((variant) => variant.capabilities))].sort()),
+  });
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,6 @@
-export const DIALECT_CONTRACT_VERSION = 3 as const;
+import type { QuerySemantics } from "./semantics.js";
+
+export const DIALECT_CONTRACT_VERSION = 4 as const;
 
 export interface SourceRange {
   readonly start: number;
@@ -53,6 +55,7 @@ export interface FunctionSnapshot {
   readonly returnType: string;
   readonly nullable: boolean;
   readonly setReturning?: boolean;
+  readonly volatility?: "immutable" | "stable" | "volatile";
 }
 
 export interface SchemaSnapshot {
@@ -97,6 +100,8 @@ export interface DialectAnalysis {
   readonly parameters: readonly ResolvedParameter[];
   readonly diagnostics: readonly SqlDiagnostic[];
   readonly resultKind?: "rows" | "command";
+  /** Grammar-owned, evidence-backed statement semantics. */
+  readonly semantics: QuerySemantics;
 }
 
 /**

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -23,6 +23,7 @@ import {
   type SqlRenderer,
   sql,
   unionTypeLiterals,
+  unknownQuerySemantics,
 } from "../src/index.js";
 
 const renderer: SqlRenderer = {
@@ -333,7 +334,12 @@ await describe("core contracts", async () => {
     defaultTypePolicy: {},
     placeholder: (index) => `?${index}`,
     quoteIdentifier: (identifier) => `"${identifier}"`,
-    analyze: () => ({ columns: [], parameters: [], diagnostics: [] }),
+    analyze: (sql) => ({
+      columns: [],
+      parameters: [],
+      diagnostics: [],
+      semantics: unknownQuerySemantics({ start: 0, end: sql.length, line: 1, column: 1 }, "Test grammar"),
+    }),
     validateSnapshot: () => schema,
   };
 
@@ -350,7 +356,7 @@ await describe("core contracts", async () => {
     strict.throws(
       () =>
         defineConfig({
-          dialect: { ...dialect, contractVersion: 4 as never },
+          dialect: { ...dialect, contractVersion: 5 as never },
           schema: { file: "schema.json" },
           outDir: "generated",
         }),

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -449,6 +449,7 @@ await describe("core contracts", async () => {
       },
     };
     const index = new ResolverSchemaIndex(indexedSchema);
+    strict.strictEqual(ResolverSchemaIndex.for(indexedSchema), ResolverSchemaIndex.for(indexedSchema));
     const table = index.tables("users", "PUBLIC")[0]?.table;
     strict.ok(table !== undefined);
     strict.strictEqual(index.tables("users").length, 1);

--- a/packages/core/test/semantics.test.ts
+++ b/packages/core/test/semantics.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, strict } from "poku";
+import {
+  defineQuerySemantics,
+  mapQuerySemanticRanges,
+  mergeQuerySemantics,
+  QUERY_SEMANTICS_VERSION,
+  type QuerySemantics,
+  unknownQuerySemantics,
+} from "../src/index.js";
+
+const firstRange = { start: 0, end: 6, line: 1, column: 1 } as const;
+
+function semantics(operation: "read" | "write", maximum: 1 | "many"): QuerySemantics {
+  const evidence = [{ kind: "syntax" as const, description: operation, range: firstRange }];
+  return {
+    version: QUERY_SEMANTICS_VERSION,
+    operation: { value: operation, evidence },
+    dependencies: [
+      {
+        kind: "relation",
+        access: operation,
+        name: operation === "read" ? "accounts" : "audit",
+        certainty: "resolved",
+        range: firstRange,
+      },
+    ],
+    cardinality: { minimum: operation === "read" ? 1 : 0, maximum, evidence },
+    volatility: { value: operation === "read" ? "stable" : "volatile", evidence },
+    locking: { value: "none", evidence },
+    connectionAffinity: { value: "none", evidence },
+    capabilities: operation === "read" ? ["ctes"] : ["returning"],
+  };
+}
+
+await describe("query semantics", async () => {
+  await it("merges structural variants conservatively and deterministically", () => {
+    const merged = mergeQuerySemantics([semantics("write", "many"), semantics("read", 1)]);
+    strict.strictEqual(merged.operation.value, "unknown");
+    strict.strictEqual(merged.cardinality.minimum, 0);
+    strict.strictEqual(merged.cardinality.maximum, "many");
+    strict.strictEqual(merged.volatility.value, "volatile");
+    strict.deepStrictEqual(merged.capabilities, ["ctes", "returning"]);
+    strict.deepStrictEqual(
+      merged.dependencies.map(({ name }) => name),
+      ["accounts", "audit"],
+    );
+    strict.deepStrictEqual(mergeQuerySemantics([semantics("write", "many"), semantics("read", 1)]), merged);
+    strict.ok(Object.isFrozen(merged));
+    strict.ok(Object.isFrozen(merged.dependencies));
+    strict.ok(Object.isFrozen(merged.dependencies[0]));
+    strict.ok(Object.isFrozen(merged.operation.evidence[0]?.range));
+  });
+
+  await it("maps every evidence and dependency range without mutating the grammar result", () => {
+    const original = semantics("read", 1);
+    const mapped = mapQuerySemanticRanges(original, (range) => ({
+      ...range,
+      start: range.start + 10,
+      end: range.end + 10,
+    }));
+    strict.strictEqual(original.operation.evidence[0]?.range.start, 0);
+    strict.strictEqual(mapped.operation.evidence[0]?.range.start, 10);
+    strict.strictEqual(mapped.cardinality.evidence[0]?.range.start, 10);
+    strict.strictEqual(mapped.dependencies[0]?.range.start, 10);
+  });
+
+  await it("represents unsupported analysis as explicit unknown evidence", () => {
+    const unknown = unknownQuerySemantics(firstRange, "Unsupported statement");
+    strict.strictEqual(unknown.operation.value, "unknown");
+    strict.strictEqual(unknown.cardinality.maximum, "unknown");
+    strict.strictEqual(unknown.volatility.value, "unknown");
+    strict.strictEqual(unknown.locking.value, "unknown");
+    strict.strictEqual(unknown.operation.evidence[0]?.kind, "conservative");
+  });
+
+  await it("rejects an empty structural merge", () => {
+    strict.throws(() => mergeQuerySemantics([]), /At least one/);
+    strict.throws(
+      () => defineQuerySemantics({ ...semantics("read", 1), version: 2 as never }),
+      /Unsupported query semantics version 2/,
+    );
+  });
+});

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -1,7 +1,8 @@
 import { parseStatement, SqlParseError } from "@typed-sql/ast";
-import { DIALECT_CONTRACT_VERSION, type DialectPlugin } from "@typed-sql/core";
+import { DIALECT_CONTRACT_VERSION, type DialectPlugin, unknownQuerySemantics } from "@typed-sql/core";
 import { parseSchemaSnapshot, type SchemaSnapshot } from "@typed-sql/schema";
 import { resolveMySqlStatement } from "./resolver.js";
+import { analyzeMySqlSemantics } from "./semantics.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
 
 export const MYSQL_DIALECT_VERSION = "1.0.0";
@@ -51,13 +52,21 @@ export function mysql(options: MySqlDialectOptions = {}): DialectPlugin<MySqlSch
     },
     analyze(sql: string, snapshot: MySqlSchemaSnapshot, policy = defaultTypePolicy) {
       try {
-        return resolveMySqlStatement(parseStatement(sql, { syntax: "mysql" }), snapshot, { typePolicy: policy });
+        const statement = parseStatement(sql, { syntax: "mysql" });
+        const resolved = resolveMySqlStatement(statement, snapshot, { typePolicy: policy });
+        return {
+          ...resolved,
+          semantics: resolved.diagnostics.some(({ severity }) => severity === "error")
+            ? unknownQuerySemantics(statement.range, "MySQL semantic analysis reported an error.")
+            : analyzeMySqlSemantics(statement, snapshot),
+        };
       } catch (error) {
         if (!(error instanceof SqlParseError)) throw error;
         return {
           columns: [],
           parameters: [],
           diagnostics: [{ code: error.code, message: error.message, severity: "error" as const, range: error.range }],
+          semantics: unknownQuerySemantics(error.range, "The SQL could not be parsed by the MySQL grammar."),
         };
       }
     },

--- a/packages/mysql/src/provider.ts
+++ b/packages/mysql/src/provider.ts
@@ -33,6 +33,8 @@ interface RoutineRow extends Record<string, unknown> {
   readonly schema_name: string;
   readonly function_name: string;
   readonly database_return_type: string;
+  readonly is_deterministic: "YES" | "NO";
+  readonly sql_data_access: "CONTAINS SQL" | "NO SQL" | "READS SQL DATA" | "MODIFIES SQL DATA";
 }
 
 export const mysqlCatalogQueries = Object.freeze({
@@ -55,7 +57,9 @@ export const mysqlCatalogQueries = Object.freeze({
     return `
       SELECT ROUTINE_SCHEMA AS schema_name,
              ROUTINE_NAME AS function_name,
-             DTD_IDENTIFIER AS database_return_type
+             DTD_IDENTIFIER AS database_return_type,
+             IS_DETERMINISTIC AS is_deterministic,
+             SQL_DATA_ACCESS AS sql_data_access
       FROM information_schema.ROUTINES
       WHERE ROUTINE_TYPE = 'FUNCTION'
         AND ROUTINE_SCHEMA IN (${Array.from({ length: schemaCount }, () => "?").join(", ")})
@@ -124,6 +128,7 @@ export class MySqlSchemaProvider implements SchemaProvider {
         databaseReturnType: string;
         returnType: string;
         nullable: boolean;
+        volatility: "immutable" | "stable" | "volatile";
       }
     > = {};
     for (const row of routineRows) {
@@ -134,6 +139,12 @@ export class MySqlSchemaProvider implements SchemaProvider {
         databaseReturnType: row.database_return_type,
         returnType: mapMySqlType(row.database_return_type, this.#policy),
         nullable: true,
+        volatility:
+          row.sql_data_access === "MODIFIES SQL DATA" || row.is_deterministic === "NO"
+            ? "volatile"
+            : row.sql_data_access === "READS SQL DATA"
+              ? "stable"
+              : "immutable",
       };
     }
     return {

--- a/packages/mysql/src/resolver.ts
+++ b/packages/mysql/src/resolver.ts
@@ -104,7 +104,7 @@ class Resolver {
 
   constructor(schema: SchemaSnapshot, options: ResolveMySqlOptions) {
     this.#schema = schema;
-    this.#index = new ResolverSchemaIndex(schema);
+    this.#index = ResolverSchemaIndex.for(schema);
     this.#policy = options.typePolicy ?? defaultMySqlTypePolicy;
     this.#strict = options.strictExpressions ?? true;
   }

--- a/packages/mysql/src/semantics.ts
+++ b/packages/mysql/src/semantics.ts
@@ -50,7 +50,7 @@ function functionVolatility(expression: CallExpression, index: ResolverSchemaInd
 }
 
 export function analyzeMySqlSemantics(statement: Statement, snapshot: SchemaSnapshot): QuerySemantics {
-  const index = new ResolverSchemaIndex(snapshot);
+  const index = ResolverSchemaIndex.for(snapshot);
   const dependencies = new Map<string, QueryDependency>();
   const capabilities = new Set<string>();
   const volatilities: QueryVolatility[] = [];
@@ -157,12 +157,12 @@ export function analyzeMySqlSemantics(statement: Statement, snapshot: SchemaSnap
 
   return defineQuerySemantics({
     version: QUERY_SEMANTICS_VERSION,
-    operation: Object.freeze({ value: write ? "write" : "read", evidence: Object.freeze([operationEvidence]) }),
-    dependencies: Object.freeze([...dependencies.values()].sort((left, right) => key(left).localeCompare(key(right)))),
-    cardinality: Object.freeze({
+    operation: { value: write ? "write" : "read", evidence: [operationEvidence] },
+    dependencies: [...dependencies.values()],
+    cardinality: {
       minimum: exactOne ? 1 : 0,
       maximum: command ? 0 : exactOne ? 1 : "many",
-      evidence: Object.freeze([
+      evidence: [
         syntax(
           command
             ? "The command has no RETURNING clause."
@@ -171,11 +171,11 @@ export function analyzeMySqlSemantics(statement: Statement, snapshot: SchemaSnap
               : "The statement can return a data-dependent number of rows.",
           statement.range,
         ),
-      ]),
-    }),
-    volatility: Object.freeze({
+      ],
+    },
+    volatility: {
       value: volatility,
-      evidence: Object.freeze([
+      evidence: [
         syntax(
           write
             ? "Writes are volatile."
@@ -186,18 +186,16 @@ export function analyzeMySqlSemantics(statement: Statement, snapshot: SchemaSnap
                 : "The statement contains only immutable syntax.",
           statement.range,
         ),
-      ]),
-    }),
-    locking: Object.freeze({
+      ],
+    },
+    locking: {
       value: "none",
-      evidence: Object.freeze([syntax("The supported statement contains no locking clause.", statement.range)]),
-    }),
-    connectionAffinity: Object.freeze({
+      evidence: [syntax("The supported statement contains no locking clause.", statement.range)],
+    },
+    connectionAffinity: {
       value: "none",
-      evidence: Object.freeze([
-        syntax("The supported statement contains no session or transaction control.", statement.range),
-      ]),
-    }),
-    capabilities: Object.freeze([...capabilities].sort()),
+      evidence: [syntax("The supported statement contains no session or transaction control.", statement.range)],
+    },
+    capabilities: [...capabilities],
   });
 }

--- a/packages/mysql/src/semantics.ts
+++ b/packages/mysql/src/semantics.ts
@@ -1,0 +1,203 @@
+import { type CallExpression, type Statement, walkStatement } from "@typed-sql/ast";
+import {
+  defineQuerySemantics,
+  QUERY_SEMANTICS_VERSION,
+  type QueryDependency,
+  type QuerySemantics,
+  type QueryVolatility,
+  ResolverSchemaIndex,
+  type SemanticEvidence,
+} from "@typed-sql/core";
+import type { SchemaSnapshot } from "@typed-sql/schema";
+
+const builtinVolatility: Readonly<Record<string, QueryVolatility>> = Object.freeze({
+  AVG: "immutable",
+  COALESCE: "immutable",
+  COUNT: "immutable",
+  GROUP_CONCAT: "immutable",
+  IFNULL: "immutable",
+  JSON_ARRAYAGG: "immutable",
+  JSON_EXTRACT: "immutable",
+  JSON_OBJECTAGG: "immutable",
+  MAX: "immutable",
+  MIN: "immutable",
+  NULLIF: "immutable",
+  RAND: "volatile",
+  SUM: "immutable",
+  UUID: "volatile",
+});
+
+function syntax(description: string, range: Statement["range"]): SemanticEvidence {
+  return { kind: "syntax", description, range };
+}
+
+function key(dependency: QueryDependency): string {
+  return [
+    dependency.kind,
+    dependency.access,
+    dependency.schema ?? "",
+    dependency.parent ?? "",
+    dependency.name,
+    dependency.range.start,
+  ].join("\0");
+}
+
+function functionVolatility(expression: CallExpression, index: ResolverSchemaIndex): QueryVolatility {
+  const builtin = builtinVolatility[expression.name.name.toUpperCase()];
+  if (builtin !== undefined && expression.schema === undefined) return builtin;
+  const candidates = index.functions(expression.name.name, expression.arguments.length, expression.schema?.name);
+  return candidates.length === 1 ? (candidates[0]!.volatility ?? "unknown") : "unknown";
+}
+
+export function analyzeMySqlSemantics(statement: Statement, snapshot: SchemaSnapshot): QuerySemantics {
+  const index = new ResolverSchemaIndex(snapshot);
+  const dependencies = new Map<string, QueryDependency>();
+  const capabilities = new Set<string>();
+  const volatilities: QueryVolatility[] = [];
+  let write = false;
+  let hasRelation = false;
+  let hasCall = false;
+
+  walkStatement(statement, {
+    statement(current) {
+      if (current.kind !== "select") write = true;
+      if (current.with !== undefined) capabilities.add(current.with.recursive ? "recursiveCtes" : "ctes");
+      if (current.kind !== "select" && current.returning.length > 0) capabilities.add("returning");
+    },
+    table(table, owner, context) {
+      if (
+        table.kind !== "table" ||
+        (table.schema === undefined &&
+          context.ctes.some((cte) =>
+            cte.quoted ? cte.name === table.name.name : cte.name.toLowerCase() === table.name.name.toLowerCase(),
+          ))
+      )
+        return;
+      hasRelation = true;
+      const matches = index.tables(table.name.name, table.schema?.name, table.name.quoted || table.schema?.quoted);
+      const resolved = matches.length === 1 ? matches[0] : undefined;
+      const schema = resolved?.table.schema ?? table.schema?.name;
+      const dependency: QueryDependency = {
+        kind: "relation",
+        access: owner.kind !== "select" && owner.table === table ? "write" : "read",
+        name: resolved?.table.name ?? table.name.name,
+        ...(schema === undefined ? {} : { schema }),
+        certainty: resolved === undefined ? "syntactic" : "resolved",
+        range: table.range,
+      };
+      dependencies.set(key(dependency), dependency);
+    },
+    expression(expression, owner) {
+      if (expression.kind === "column") {
+        const dependency: QueryDependency = {
+          kind: "column",
+          access: owner.kind === "select" ? "read" : "unknown",
+          name: expression.column.name,
+          ...(expression.relation === undefined ? {} : { parent: expression.relation.name }),
+          certainty: "syntactic",
+          range: expression.range,
+        };
+        dependencies.set(key(dependency), dependency);
+      } else if (expression.kind === "call") {
+        hasCall = true;
+        if (expression.over !== undefined) capabilities.add("windows");
+        const candidates = index.functions(expression.name.name, expression.arguments.length, expression.schema?.name);
+        const resolved = candidates.length === 1 ? candidates[0] : undefined;
+        const schema = resolved?.schema ?? expression.schema?.name;
+        const dependency: QueryDependency = {
+          kind: "function",
+          access: "execute",
+          name: resolved?.name ?? expression.name.name,
+          ...(schema === undefined ? {} : { schema }),
+          certainty: resolved === undefined ? "syntactic" : "resolved",
+          range: expression.range,
+        };
+        dependencies.set(key(dependency), dependency);
+        volatilities.push(functionVolatility(expression, index));
+      } else if (expression.kind === "array") capabilities.add("arrays");
+      else if (expression.kind === "cast") capabilities.add("casts");
+      else if (expression.kind === "subquery" || expression.kind === "exists") capabilities.add("subqueries");
+    },
+    type(type) {
+      const dependency: QueryDependency = {
+        kind: "type",
+        access: "reference",
+        name: type.name,
+        certainty: "syntactic",
+        range: type.range,
+      };
+      dependencies.set(key(dependency), dependency);
+    },
+  });
+
+  const operationEvidence = syntax(
+    write ? "A data-changing statement occurs in the query tree." : "Every statement in the query tree is SELECT.",
+    statement.range,
+  );
+  const volatility: QueryVolatility = write
+    ? "volatile"
+    : volatilities.includes("unknown")
+      ? "unknown"
+      : volatilities.includes("volatile")
+        ? "volatile"
+        : volatilities.includes("stable") || hasRelation
+          ? "stable"
+          : "immutable";
+  const exactOne =
+    statement.kind === "select" &&
+    statement.from === undefined &&
+    statement.joins.length === 0 &&
+    statement.where === undefined &&
+    statement.groupBy.length === 0 &&
+    statement.having === undefined &&
+    statement.limit === undefined &&
+    statement.offset === undefined &&
+    !hasCall;
+  const command = statement.kind !== "select" && statement.returning.length === 0;
+
+  return defineQuerySemantics({
+    version: QUERY_SEMANTICS_VERSION,
+    operation: Object.freeze({ value: write ? "write" : "read", evidence: Object.freeze([operationEvidence]) }),
+    dependencies: Object.freeze([...dependencies.values()].sort((left, right) => key(left).localeCompare(key(right)))),
+    cardinality: Object.freeze({
+      minimum: exactOne ? 1 : 0,
+      maximum: command ? 0 : exactOne ? 1 : "many",
+      evidence: Object.freeze([
+        syntax(
+          command
+            ? "The command has no RETURNING clause."
+            : exactOne
+              ? "A scalar SELECT without row-eliminating clauses returns one row."
+              : "The statement can return a data-dependent number of rows.",
+          statement.range,
+        ),
+      ]),
+    }),
+    volatility: Object.freeze({
+      value: volatility,
+      evidence: Object.freeze([
+        syntax(
+          write
+            ? "Writes are volatile."
+            : hasCall
+              ? "Function volatility is derived from grammar built-ins and schema evidence."
+              : hasRelation
+                ? "Reading a relation is stable for the statement."
+                : "The statement contains only immutable syntax.",
+          statement.range,
+        ),
+      ]),
+    }),
+    locking: Object.freeze({
+      value: "none",
+      evidence: Object.freeze([syntax("The supported statement contains no locking clause.", statement.range)]),
+    }),
+    connectionAffinity: Object.freeze({
+      value: "none",
+      evidence: Object.freeze([
+        syntax("The supported statement contains no session or transaction control.", statement.range),
+      ]),
+    }),
+    capabilities: Object.freeze([...capabilities].sort()),
+  });
+}

--- a/packages/mysql/test/mysql.test.ts
+++ b/packages/mysql/test/mysql.test.ts
@@ -45,6 +45,7 @@ const schema = {
       databaseReturnType: "bigint",
       returnType: "bigint",
       nullable: true,
+      volatility: "stable",
     },
   },
 } as const satisfies SchemaSnapshot;
@@ -85,6 +86,41 @@ await describe("MySQL dialect", async () => {
     strict.strictEqual(sql`SELECT 1`.segments[0]?.kind, "text");
     strict.strictEqual(typePolicy, defaultMySqlTypePolicy);
     strict.strictEqual(mysql({ typePolicy }).defaultTypePolicy, typePolicy);
+  });
+
+  await it("emits conservative MySQL semantics and stable dependencies", () => {
+    const dialect = mysql();
+    const typedSchema = schema as typeof schema & { readonly dialect: "mysql" };
+    const read = dialect.analyze("SELECT id FROM users", typedSchema);
+    strict.strictEqual(read.semantics.operation.value, "read");
+    strict.strictEqual(read.semantics.volatility.value, "stable");
+    strict.ok(read.semantics.dependencies.some(({ kind, name }) => kind === "relation" && name === "users"));
+
+    const scalar = dialect.analyze("SELECT 1 AS value", typedSchema);
+    strict.strictEqual(scalar.semantics.cardinality.minimum, 1);
+    strict.strictEqual(scalar.semantics.cardinality.maximum, 1);
+    strict.strictEqual(scalar.semantics.volatility.value, "immutable");
+
+    const write = dialect.analyze("UPDATE users SET email = ? WHERE id = ?", typedSchema);
+    strict.strictEqual(write.semantics.operation.value, "write");
+    strict.strictEqual(write.semantics.volatility.value, "volatile");
+    strict.ok(write.semantics.dependencies.some(({ kind, access }) => kind === "relation" && access === "write"));
+
+    const volatile = dialect.analyze("SELECT UUID() AS value", typedSchema);
+    strict.strictEqual(volatile.semantics.volatility.value, "volatile");
+    const unresolved = dialect.analyze("SELECT not_catalogued() AS value", typedSchema);
+    strict.strictEqual(unresolved.semantics.volatility.value, "unknown");
+    strict.strictEqual(
+      dialect.analyze("SELECT user_count() AS value", typedSchema).semantics.volatility.value,
+      "stable",
+    );
+    strict.strictEqual(dialect.analyze("SELECT", typedSchema).semantics.operation.value, "unknown");
+    for (const unsupported of ["SELECT id FROM users FOR UPDATE", "CREATE TABLE audit (id bigint)"]) {
+      const analysis = dialect.analyze(unsupported, typedSchema);
+      strict.ok(analysis.diagnostics.some(({ severity }) => severity === "error"));
+      strict.strictEqual(analysis.semantics.operation.value, "unknown");
+      strict.strictEqual(analysis.semantics.locking.value, "unknown");
+    }
   });
 
   await it("resolves CTEs, aggregates, JSON, joins, subqueries, windows, and MySQL LIMIT", () => {

--- a/packages/mysql/test/provider-runtime.test.ts
+++ b/packages/mysql/test/provider-runtime.test.ts
@@ -78,7 +78,15 @@ class CatalogClient implements MySqlQueryable {
         },
       ].filter((row) => (values ?? []).includes(row.schema_name));
     else if (sqlText.includes("information_schema.ROUTINES"))
-      rows = [{ schema_name: "app", function_name: "user_count", database_return_type: "bigint" }];
+      rows = [
+        {
+          schema_name: "app",
+          function_name: "user_count",
+          database_return_type: "bigint",
+          is_deterministic: "YES",
+          sql_data_access: "READS SQL DATA",
+        },
+      ];
     else throw new Error("unexpected catalog query");
     return { rows: rows as readonly Row[] };
   }
@@ -167,6 +175,7 @@ await describe("MySQL provider and runtime", async () => {
     strict.strictEqual(snapshot.tables.users?.columns.status?.defaultExpression, "active");
     strict.strictEqual(snapshot.tables.users?.columns.budget?.nullable, true);
     strict.strictEqual(snapshot.functions?.["app.user_count()"]?.returnType, "bigint");
+    strict.strictEqual(snapshot.functions?.["app.user_count()"]?.volatility, "stable");
     strict.ok(
       client.calls
         .filter((call) => call.values !== undefined)

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -1,7 +1,8 @@
 import { parseStatement, SqlParseError } from "@typed-sql/ast";
-import { DIALECT_CONTRACT_VERSION, type DialectPlugin } from "@typed-sql/core";
+import { DIALECT_CONTRACT_VERSION, type DialectPlugin, unknownQuerySemantics } from "@typed-sql/core";
 import { parseSchemaSnapshot, type SchemaSnapshot } from "@typed-sql/schema";
 import { resolveStatement } from "./resolver.js";
+import { analyzePostgresSemantics } from "./semantics.js";
 import { defaultPostgresTypePolicy, type PostgresTypePolicy } from "./type-policy.js";
 
 export const POSTGRES_DIALECT_VERSION = "1.0.0";
@@ -54,13 +55,21 @@ export function postgres(
     },
     analyze(sql: string, snapshot: PostgresSchemaSnapshot, policy = defaultTypePolicy) {
       try {
-        return resolveStatement(parseStatement(sql), snapshot, { typePolicy: policy });
+        const statement = parseStatement(sql);
+        const resolved = resolveStatement(statement, snapshot, { typePolicy: policy });
+        return {
+          ...resolved,
+          semantics: resolved.diagnostics.some(({ severity }) => severity === "error")
+            ? unknownQuerySemantics(statement.range, "PostgreSQL semantic analysis reported an error.")
+            : analyzePostgresSemantics(statement, snapshot),
+        };
       } catch (error) {
         if (!(error instanceof SqlParseError)) throw error;
         return {
           columns: [],
           parameters: [],
           diagnostics: [{ code: error.code, message: error.message, severity: "error" as const, range: error.range }],
+          semantics: unknownQuerySemantics(error.range, "The SQL could not be parsed by the PostgreSQL grammar."),
         };
       }
     },

--- a/packages/postgres/src/provider.ts
+++ b/packages/postgres/src/provider.ts
@@ -71,6 +71,7 @@ interface FunctionCatalogRow extends Record<string, unknown> {
   readonly argument_types: string[];
   readonly database_return_type: string;
   readonly set_returning: boolean;
+  readonly volatility: "i" | "s" | "v";
 }
 
 interface VersionRow extends Record<string, unknown> {
@@ -133,7 +134,8 @@ export const postgresCatalogQueries = {
         ORDER BY position
       ) AS argument_types,
       format_type(p.prorettype, NULL) AS database_return_type,
-      p.proretset AS set_returning
+      p.proretset AS set_returning,
+      p.provolatile AS volatility
     FROM pg_catalog.pg_proc AS p
     JOIN pg_catalog.pg_namespace AS n ON n.oid = p.pronamespace
     WHERE p.prokind = 'f'
@@ -278,6 +280,7 @@ export class PostgresSchemaProvider implements SchemaProvider {
           returnType: mapPostgresType(row.database_return_type, policy, schemaForFunctions),
           nullable: true,
           ...(row.set_returning ? { setReturning: true } : {}),
+          volatility: row.volatility === "i" ? "immutable" : row.volatility === "s" ? "stable" : "volatile",
         };
       }
 

--- a/packages/postgres/src/resolver.ts
+++ b/packages/postgres/src/resolver.ts
@@ -137,7 +137,7 @@ class Resolver {
 
   constructor(schema: SchemaSnapshot, options: ResolveOptions) {
     this.#schema = schema;
-    this.#index = new ResolverSchemaIndex(schema);
+    this.#index = ResolverSchemaIndex.for(schema);
     this.#policy = options.typePolicy ?? defaultPostgresTypePolicy;
     this.#strictExpressions = options.strictExpressions ?? true;
   }

--- a/packages/postgres/src/semantics.ts
+++ b/packages/postgres/src/semantics.ts
@@ -58,7 +58,7 @@ function functionVolatility(expression: CallExpression, index: ResolverSchemaInd
 }
 
 export function analyzePostgresSemantics(statement: Statement, snapshot: SchemaSnapshot): QuerySemantics {
-  const index = new ResolverSchemaIndex(snapshot);
+  const index = ResolverSchemaIndex.for(snapshot);
   const dependencies = new Map<string, QueryDependency>();
   const capabilities = new Set<string>();
   const volatilities: QueryVolatility[] = [];
@@ -165,12 +165,12 @@ export function analyzePostgresSemantics(statement: Statement, snapshot: SchemaS
 
   return defineQuerySemantics({
     version: QUERY_SEMANTICS_VERSION,
-    operation: Object.freeze({ value: write ? "write" : "read", evidence: Object.freeze([operationEvidence]) }),
-    dependencies: Object.freeze([...dependencies.values()].sort((left, right) => key(left).localeCompare(key(right)))),
-    cardinality: Object.freeze({
+    operation: { value: write ? "write" : "read", evidence: [operationEvidence] },
+    dependencies: [...dependencies.values()],
+    cardinality: {
       minimum: exactOne ? 1 : 0,
       maximum: command ? 0 : exactOne ? 1 : "many",
-      evidence: Object.freeze([
+      evidence: [
         syntax(
           command
             ? "The command has no RETURNING clause."
@@ -179,11 +179,11 @@ export function analyzePostgresSemantics(statement: Statement, snapshot: SchemaS
               : "The statement can return a data-dependent number of rows.",
           statement.range,
         ),
-      ]),
-    }),
-    volatility: Object.freeze({
+      ],
+    },
+    volatility: {
       value: volatility,
-      evidence: Object.freeze([
+      evidence: [
         syntax(
           write
             ? "Writes are volatile."
@@ -194,18 +194,16 @@ export function analyzePostgresSemantics(statement: Statement, snapshot: SchemaS
                 : "The statement contains only immutable syntax.",
           statement.range,
         ),
-      ]),
-    }),
-    locking: Object.freeze({
+      ],
+    },
+    locking: {
       value: "none",
-      evidence: Object.freeze([syntax("The supported statement contains no locking clause.", statement.range)]),
-    }),
-    connectionAffinity: Object.freeze({
+      evidence: [syntax("The supported statement contains no locking clause.", statement.range)],
+    },
+    connectionAffinity: {
       value: "none",
-      evidence: Object.freeze([
-        syntax("The supported statement contains no session or transaction control.", statement.range),
-      ]),
-    }),
-    capabilities: Object.freeze([...capabilities].sort()),
+      evidence: [syntax("The supported statement contains no session or transaction control.", statement.range)],
+    },
+    capabilities: [...capabilities],
   });
 }

--- a/packages/postgres/src/semantics.ts
+++ b/packages/postgres/src/semantics.ts
@@ -1,0 +1,211 @@
+import { type CallExpression, type Statement, walkStatement } from "@typed-sql/ast";
+import {
+  defineQuerySemantics,
+  QUERY_SEMANTICS_VERSION,
+  type QueryDependency,
+  type QuerySemantics,
+  type QueryVolatility,
+  ResolverSchemaIndex,
+  type SemanticEvidence,
+} from "@typed-sql/core";
+import type { SchemaSnapshot } from "@typed-sql/schema";
+
+const builtinVolatility: Readonly<Record<string, QueryVolatility>> = Object.freeze({
+  ARRAY_AGG: "immutable",
+  AVG: "immutable",
+  BOOL_AND: "immutable",
+  BOOL_OR: "immutable",
+  COALESCE: "immutable",
+  COUNT: "immutable",
+  CURRVAL: "volatile",
+  EVERY: "immutable",
+  GREATEST: "immutable",
+  JSON_AGG: "immutable",
+  JSON_OBJECT_AGG: "immutable",
+  JSONB_AGG: "immutable",
+  JSONB_OBJECT_AGG: "immutable",
+  LEAST: "immutable",
+  MAX: "immutable",
+  MIN: "immutable",
+  NEXTVAL: "volatile",
+  NULLIF: "immutable",
+  RANDOM: "volatile",
+  SETVAL: "volatile",
+  STRING_AGG: "immutable",
+  SUM: "immutable",
+});
+
+function syntax(description: string, range: Statement["range"]): SemanticEvidence {
+  return { kind: "syntax", description, range };
+}
+
+function key(dependency: QueryDependency): string {
+  return [
+    dependency.kind,
+    dependency.access,
+    dependency.schema ?? "",
+    dependency.parent ?? "",
+    dependency.name,
+    dependency.range.start,
+  ].join("\0");
+}
+
+function functionVolatility(expression: CallExpression, index: ResolverSchemaIndex): QueryVolatility {
+  const builtin = builtinVolatility[expression.name.name.toUpperCase()];
+  if (builtin !== undefined && expression.schema === undefined) return builtin;
+  const candidates = index.functions(expression.name.name, expression.arguments.length, expression.schema?.name);
+  return candidates.length === 1 ? (candidates[0]!.volatility ?? "unknown") : "unknown";
+}
+
+export function analyzePostgresSemantics(statement: Statement, snapshot: SchemaSnapshot): QuerySemantics {
+  const index = new ResolverSchemaIndex(snapshot);
+  const dependencies = new Map<string, QueryDependency>();
+  const capabilities = new Set<string>();
+  const volatilities: QueryVolatility[] = [];
+  let write = false;
+  let hasRelation = false;
+  let hasCall = false;
+
+  walkStatement(statement, {
+    statement(current) {
+      if (current.kind !== "select") write = true;
+      if (current.with !== undefined) capabilities.add(current.with.recursive ? "recursiveCtes" : "ctes");
+      if (current.kind !== "select" && current.returning.length > 0) capabilities.add("returning");
+    },
+    table(table, owner, context) {
+      if (
+        table.kind !== "table" ||
+        (table.schema === undefined &&
+          context.ctes.some((cte) =>
+            cte.quoted ? cte.name === table.name.name : cte.name.toLowerCase() === table.name.name.toLowerCase(),
+          ))
+      )
+        return;
+      hasRelation = true;
+      const matches = index.tables(table.name.name, table.schema?.name, table.name.quoted || table.schema?.quoted);
+      const resolved = matches.length === 1 ? matches[0] : undefined;
+      const schema = resolved?.table.schema ?? table.schema?.name;
+      const dependency: QueryDependency = {
+        kind: "relation",
+        access: owner.kind !== "select" && owner.table === table ? "write" : "read",
+        name: resolved?.table.name ?? table.name.name,
+        ...(schema === undefined ? {} : { schema }),
+        certainty: resolved === undefined ? "syntactic" : "resolved",
+        range: table.range,
+      };
+      dependencies.set(key(dependency), dependency);
+    },
+    expression(expression, owner) {
+      if (expression.kind === "column") {
+        const dependency: QueryDependency = {
+          kind: "column",
+          access: owner.kind === "select" ? "read" : "unknown",
+          name: expression.column.name,
+          ...(expression.relation === undefined ? {} : { parent: expression.relation.name }),
+          certainty: "syntactic",
+          range: expression.range,
+        };
+        dependencies.set(key(dependency), dependency);
+      } else if (expression.kind === "call") {
+        hasCall = true;
+        if (expression.over !== undefined) capabilities.add("windows");
+        const candidates = index.functions(expression.name.name, expression.arguments.length, expression.schema?.name);
+        const resolved = candidates.length === 1 ? candidates[0] : undefined;
+        const schema = resolved?.schema ?? expression.schema?.name;
+        const dependency: QueryDependency = {
+          kind: "function",
+          access: "execute",
+          name: resolved?.name ?? expression.name.name,
+          ...(schema === undefined ? {} : { schema }),
+          certainty: resolved === undefined ? "syntactic" : "resolved",
+          range: expression.range,
+        };
+        dependencies.set(key(dependency), dependency);
+        volatilities.push(functionVolatility(expression, index));
+      } else if (expression.kind === "array") capabilities.add("arrays");
+      else if (expression.kind === "cast") capabilities.add("casts");
+      else if (expression.kind === "subquery" || expression.kind === "exists") capabilities.add("subqueries");
+    },
+    type(type) {
+      const dependency: QueryDependency = {
+        kind: "type",
+        access: "reference",
+        name: type.name,
+        certainty: "syntactic",
+        range: type.range,
+      };
+      dependencies.set(key(dependency), dependency);
+    },
+  });
+
+  const operationEvidence = syntax(
+    write ? "A data-changing statement occurs in the query tree." : "Every statement in the query tree is SELECT.",
+    statement.range,
+  );
+  const volatility: QueryVolatility = write
+    ? "volatile"
+    : volatilities.includes("unknown")
+      ? "unknown"
+      : volatilities.includes("volatile")
+        ? "volatile"
+        : volatilities.includes("stable") || hasRelation
+          ? "stable"
+          : "immutable";
+  const exactOne =
+    statement.kind === "select" &&
+    statement.from === undefined &&
+    statement.joins.length === 0 &&
+    statement.where === undefined &&
+    statement.groupBy.length === 0 &&
+    statement.having === undefined &&
+    statement.limit === undefined &&
+    statement.offset === undefined &&
+    !hasCall;
+  const command = statement.kind !== "select" && statement.returning.length === 0;
+
+  return defineQuerySemantics({
+    version: QUERY_SEMANTICS_VERSION,
+    operation: Object.freeze({ value: write ? "write" : "read", evidence: Object.freeze([operationEvidence]) }),
+    dependencies: Object.freeze([...dependencies.values()].sort((left, right) => key(left).localeCompare(key(right)))),
+    cardinality: Object.freeze({
+      minimum: exactOne ? 1 : 0,
+      maximum: command ? 0 : exactOne ? 1 : "many",
+      evidence: Object.freeze([
+        syntax(
+          command
+            ? "The command has no RETURNING clause."
+            : exactOne
+              ? "A scalar SELECT without row-eliminating clauses returns one row."
+              : "The statement can return a data-dependent number of rows.",
+          statement.range,
+        ),
+      ]),
+    }),
+    volatility: Object.freeze({
+      value: volatility,
+      evidence: Object.freeze([
+        syntax(
+          write
+            ? "Writes are volatile."
+            : hasCall
+              ? "Function volatility is derived from grammar built-ins and schema evidence."
+              : hasRelation
+                ? "Reading a relation is stable for the statement."
+                : "The statement contains only immutable syntax.",
+          statement.range,
+        ),
+      ]),
+    }),
+    locking: Object.freeze({
+      value: "none",
+      evidence: Object.freeze([syntax("The supported statement contains no locking clause.", statement.range)]),
+    }),
+    connectionAffinity: Object.freeze({
+      value: "none",
+      evidence: Object.freeze([
+        syntax("The supported statement contains no session or transaction control.", statement.range),
+      ]),
+    }),
+    capabilities: Object.freeze([...capabilities].sort()),
+  });
+}

--- a/packages/postgres/test/plugin.test.ts
+++ b/packages/postgres/test/plugin.test.ts
@@ -10,6 +10,17 @@ const schema = {
       columns: { id: { name: "id", databaseType: "integer", tsType: "number", nullable: false } },
     },
   },
+  functions: {
+    "public.user_count()": {
+      schema: "public",
+      name: "user_count",
+      argumentTypes: [],
+      databaseReturnType: "bigint",
+      returnType: "bigint",
+      nullable: false,
+      volatility: "stable",
+    },
+  },
 } as const satisfies PostgresSchemaSnapshot;
 
 await describe("PostgreSQL dialect plugin", async () => {
@@ -39,6 +50,62 @@ await describe("PostgreSQL dialect plugin", async () => {
     strict.strictEqual(sql`SELECT 1`.segments[0]?.kind, "text");
     strict.strictEqual(typePolicy, defaultPostgresTypePolicy);
     strict.strictEqual(postgres({ typePolicy }).defaultTypePolicy, typePolicy);
+  });
+
+  await it("emits evidence-backed semantics for reads, writes, CTEs, and parse failures", () => {
+    const dialect = postgres();
+    const read = dialect.analyze("SELECT id FROM users", schema);
+    strict.strictEqual(read.semantics.operation.value, "read");
+    strict.strictEqual(read.semantics.volatility.value, "stable");
+    strict.deepStrictEqual(read.semantics.cardinality, {
+      minimum: 0,
+      maximum: "many",
+      evidence: read.semantics.cardinality.evidence,
+    });
+    strict.ok(
+      read.semantics.dependencies.some(
+        ({ kind, access, name, certainty }) =>
+          kind === "relation" && access === "read" && name === "users" && certainty === "resolved",
+      ),
+    );
+
+    const scalar = dialect.analyze("SELECT 1 AS value", schema);
+    strict.deepStrictEqual(
+      { minimum: scalar.semantics.cardinality.minimum, maximum: scalar.semantics.cardinality.maximum },
+      { minimum: 1, maximum: 1 },
+    );
+    strict.strictEqual(scalar.semantics.volatility.value, "immutable");
+
+    const write = dialect.analyze("UPDATE users SET id = $1 RETURNING id", schema);
+    strict.strictEqual(write.semantics.operation.value, "write");
+    strict.strictEqual(write.semantics.volatility.value, "volatile");
+    strict.ok(write.semantics.capabilities.includes("returning"));
+    strict.ok(write.semantics.dependencies.some(({ kind, access }) => kind === "relation" && access === "write"));
+
+    const cte = dialect.analyze(
+      "WITH changed AS (UPDATE users SET id = $1 RETURNING id) SELECT id FROM changed",
+      schema,
+    );
+    strict.strictEqual(cte.semantics.operation.value, "write");
+    strict.ok(cte.semantics.capabilities.includes("ctes"));
+    strict.ok(!cte.semantics.dependencies.some(({ kind, name }) => kind === "relation" && name === "changed"));
+
+    const invalid = dialect.analyze("SELECT", schema);
+    strict.strictEqual(invalid.semantics.operation.value, "unknown");
+    strict.strictEqual(invalid.semantics.volatility.value, "unknown");
+    const knownFunction = dialect.analyze("SELECT user_count() AS value", schema);
+    strict.strictEqual(knownFunction.semantics.volatility.value, "stable");
+    strict.ok(
+      knownFunction.semantics.dependencies.some(
+        ({ kind, name, certainty }) => kind === "function" && name === "user_count" && certainty === "resolved",
+      ),
+    );
+    for (const unsupported of ["SELECT id FROM users FOR UPDATE", "CREATE TABLE audit (id integer)"]) {
+      const analysis = dialect.analyze(unsupported, schema);
+      strict.ok(analysis.diagnostics.some(({ severity }) => severity === "error"));
+      strict.strictEqual(analysis.semantics.operation.value, "unknown");
+      strict.strictEqual(analysis.semantics.locking.value, "unknown");
+    }
   });
 
   await it("accepts an explicit default type policy", () => {

--- a/packages/postgres/test/provider.test.ts
+++ b/packages/postgres/test/provider.test.ts
@@ -95,6 +95,7 @@ class CatalogClient implements PostgresIntrospectionClient {
           argument_types: [],
           database_return_type: "bigint",
           set_returning: false,
+          volatility: "s",
         },
       ];
     else throw new Error("Unexpected catalog query");
@@ -136,6 +137,7 @@ await describe("PostgreSQL schema provider", async () => {
     strict.strictEqual(snapshot.tables.users?.columns.budget?.tsType, "string");
     strict.strictEqual(snapshot.tables.users?.columns.display_name?.tsType, "string");
     strict.strictEqual(snapshot.functions?.["user_count()"]?.returnType, "bigint");
+    strict.strictEqual(snapshot.functions?.["user_count()"]?.volatility, "stable");
     strict.ok(client.filters.every((filter) => JSON.stringify(filter) === '["public"]'));
   });
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -18,7 +18,8 @@ import {
 } from "@typed-sql/schema";
 ```
 
-Snapshots record the dialect contract, server catalog, TypeScript mappings, and deterministic hash.
+Snapshots record the dialect contract, server catalog, TypeScript mappings, supported-function
+volatility evidence, and deterministic hash.
 Unknown future formats fail explicitly. Generated TypeScript is inspection metadata, not an
 application-facing `sql` or runtime-policy module.
 

--- a/packages/schema/src/loader.ts
+++ b/packages/schema/src/loader.ts
@@ -73,6 +73,14 @@ function parseFunction(value: unknown, path: string): FunctionSnapshot {
   if (value.setReturning !== undefined && typeof value.setReturning !== "boolean") {
     throw new TypeError(`${path}.setReturning must be a boolean`);
   }
+  if (
+    value.volatility !== undefined &&
+    value.volatility !== "immutable" &&
+    value.volatility !== "stable" &&
+    value.volatility !== "volatile"
+  ) {
+    throw new TypeError(`${path}.volatility must be immutable, stable, or volatile`);
+  }
   return {
     name: value.name,
     argumentTypes: value.argumentTypes as string[],
@@ -81,6 +89,7 @@ function parseFunction(value: unknown, path: string): FunctionSnapshot {
     ...(value.schema === undefined ? {} : { schema: value.schema }),
     ...(value.databaseReturnType === undefined ? {} : { databaseReturnType: value.databaseReturnType }),
     ...(value.setReturning === undefined ? {} : { setReturning: value.setReturning }),
+    ...(value.volatility === undefined ? {} : { volatility: value.volatility }),
   };
 }
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -52,6 +52,7 @@ export interface FunctionSnapshot {
   readonly returnType: string;
   readonly nullable: boolean;
   readonly setReturning?: boolean;
+  readonly volatility?: "immutable" | "stable" | "volatile";
 }
 
 export type TypePolicy = Readonly<Record<string, unknown>>;

--- a/packages/schema/test/loader.test.ts
+++ b/packages/schema/test/loader.test.ts
@@ -43,6 +43,7 @@ const fullSnapshot = {
       returnType: "bigint",
       nullable: false,
       setReturning: false,
+      volatility: "stable",
     },
   },
 } as const;
@@ -248,6 +249,16 @@ await describe("schema snapshot loader", async () => {
           functions: { f: { name: "f", argumentTypes: [], returnType: "number", nullable: false, setReturning: "no" } },
         },
         /setReturning/,
+      ],
+      [
+        {
+          dialect: "postgres",
+          tables: {},
+          functions: {
+            f: { name: "f", argumentTypes: [], returnType: "number", nullable: false, volatility: "sometimes" },
+          },
+        },
+        /volatility/,
       ],
     ];
     for (const [input, expected] of failures) strict.throws(() => parseSchemaSnapshot(input), expected);

--- a/performance-budgets.json
+++ b/performance-budgets.json
@@ -10,6 +10,7 @@
   "latencyMs": {
     "scanner.largeFile": { "p50": 10, "p95": 25 },
     "compiler.manyQueries": { "p50": 20, "p95": 50 },
+    "compiler.semanticMetadata": { "p50": 10, "p95": 25 },
     "compiler.correlatedConditions": { "p50": 5, "p95": 10 },
     "compiler.independentConditions": { "p50": 10, "p95": 25 },
     "compiler.structuralLimit": { "p50": 5, "p95": 10 },

--- a/scripts/performance-gate.mjs
+++ b/scripts/performance-gate.mjs
@@ -109,6 +109,21 @@ await latency("compiler.manyQueries", () => {
   assert.deepEqual(compiled.diagnostics, []);
 });
 
+const semanticQueries = Array.from(
+  { length: 250 },
+  (_, index) => `SELECT account.id, account.email FROM users AS account WHERE account.id >= $${index + 1}`,
+);
+await latency("compiler.semanticMetadata", () => {
+  for (const query of semanticQueries) {
+    const analysis = dialect.analyze(query, snapshot);
+    assert.equal(analysis.semantics.operation.value, "read");
+    assert.equal(
+      analysis.semantics.dependencies.some(({ kind }) => kind === "relation"),
+      true,
+    );
+  }
+});
+
 async function structuralMetric(name, conditions, expectedAnalyses, expectedCode) {
   let analyses = 0;
   const measuredDialect = {

--- a/test/contracts/grammar-conformance.test.ts
+++ b/test/contracts/grammar-conformance.test.ts
@@ -4,6 +4,7 @@ import {
   type DialectPlugin,
   type SchemaSnapshot,
   type SqlDiagnostic,
+  unknownQuerySemantics,
 } from "../../packages/core/src/index.js";
 import { mysql, typePolicy as mysqlTypePolicy } from "../../packages/mysql/src/index.js";
 import { mysqlRenderer } from "../../packages/mysql/src/runtime.js";
@@ -85,6 +86,7 @@ const synthetic: DialectPlugin<typeof syntheticSnapshot, SyntheticPolicy> = Obje
         columns: [{ name: "value", tsType: policy.scalar, nullable: false, databaseType: "scalar", range }],
         parameters: [{ index: 1, tsType: policy.scalar, nullable: false, databaseType: "scalar" }],
         diagnostics: [],
+        semantics: unknownQuerySemantics({ ...range, end: sql.length }, "Synthetic test grammar"),
       };
     }
     const diagnostic: SqlDiagnostic = {
@@ -93,7 +95,12 @@ const synthetic: DialectPlugin<typeof syntheticSnapshot, SyntheticPolicy> = Obje
       severity: "error",
       range: { ...range, end: sql.length },
     };
-    return { columns: [], parameters: [], diagnostics: [diagnostic] };
+    return {
+      columns: [],
+      parameters: [],
+      diagnostics: [diagnostic],
+      semantics: unknownQuerySemantics({ ...range, end: sql.length }, "Synthetic test grammar"),
+    };
   },
   validateSnapshot: validateSynthetic,
 });
@@ -127,6 +134,7 @@ await describe("public dialect-plugin conformance", async () => {
       expectedParameterType: "readonly [bigint]",
       unsupportedQuery: "SELECT value FROM widgets UNION SELECT value FROM widgets",
       unsupportedCode: "TSQ001",
+      expectedSemantics: { operation: "read", volatility: "stable", cardinalityMaximum: "many" },
       policyProbe: {
         query: "SELECT CAST(1 AS bigint) AS value",
         policy: { ...postgresTypePolicy, bigint: "string" },
@@ -150,6 +158,7 @@ await describe("public dialect-plugin conformance", async () => {
       expectedParameterType: "readonly [bigint]",
       unsupportedQuery: "SELECT * FROM widgets FULL JOIN widgets AS other ON widgets.value = other.value",
       unsupportedCode: "TSQ401",
+      expectedSemantics: { operation: "read", volatility: "stable", cardinalityMaximum: "many" },
       policyProbe: {
         query: "SELECT CAST(1 AS DECIMAL) AS value",
         policy: { ...mysqlTypePolicy, decimal: "number" },
@@ -173,6 +182,7 @@ await describe("public dialect-plugin conformance", async () => {
       expectedParameterType: "readonly [number]",
       unsupportedQuery: "UNSUPPORTED",
       unsupportedCode: "SYN001",
+      expectedSemantics: { operation: "unknown", volatility: "unknown", cardinalityMaximum: "unknown" },
       policyProbe: {
         query: "SELECT value FROM widgets WHERE value = ?1",
         policy: { scalar: "string" },

--- a/test/contracts/packed-consumer.test.ts
+++ b/test/contracts/packed-consumer.test.ts
@@ -202,6 +202,7 @@ await describe("packed public packages", async () => {
             DIALECT_CONTRACT_VERSION,
             assertDialectPlugin,
             sql,
+            unknownQuerySemantics,
           } from "@typed-sql/core";
           import { parseSchemaSnapshot } from "@typed-sql/schema";
 
@@ -245,6 +246,7 @@ await describe("packed public packages", async () => {
                   columns: [{ name: "value", tsType: policy.scalar, nullable: false, databaseType: "scalar", range }],
                   parameters: [{ index: 1, tsType: policy.scalar, nullable: false, databaseType: "scalar" }],
                   diagnostics: [],
+                  semantics: unknownQuerySemantics({ ...range, end: text.length }, "Synthetic grammar"),
                 };
               }
               return {
@@ -256,6 +258,7 @@ await describe("packed public packages", async () => {
                   severity: "error",
                   range: { ...range, end: text.length },
                 }],
+                semantics: unknownQuerySemantics({ ...range, end: text.length }, "Synthetic grammar"),
               };
             },
             validateSnapshot,

--- a/test/contracts/performance-policy.test.ts
+++ b/test/contracts/performance-policy.test.ts
@@ -33,6 +33,7 @@ await describe("performance regression policy", async () => {
       "compiler.correlatedConditions",
       "compiler.independentConditions",
       "compiler.manyQueries",
+      "compiler.semanticMetadata",
       "compiler.structuralLimit",
       "editor.cancelledRequest",
       "editor.coldAnalysis",

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, it, strict } from "poku";
+import type { SqlAstContext, SqlAstVisitor } from "../../packages/ast/src/index.js";
 import * as astApi from "../../packages/ast/src/index.js";
 import type {
   CheckFileOptions,
@@ -21,15 +22,26 @@ import type {
   OptionalSqlFragment,
   Query,
   QueryBatch,
+  QueryCardinality,
+  QueryConnectionAffinity,
+  QueryDependency,
+  QueryDependencyAccess,
+  QueryDependencyKind,
   QueryExecutor,
+  QueryLocking,
+  QueryOperation,
   QueryParameters,
   QueryRenderSkeleton,
   QueryResult,
   QueryResults,
   QueryRow,
+  QuerySemantics,
   QueryStream,
+  QueryVolatility,
   RenderedQuery,
   SchemaSnapshot,
+  SemanticEvidence,
+  SemanticFact,
   SqlDiagnostic,
   SqlDiagnosticFix,
   SqlFragment,
@@ -241,6 +253,15 @@ type ReferencedStableTypes =
   | DialectCapabilities
   | DialectPlugin
   | OptionalSqlFragment
+  | QueryCardinality
+  | QueryConnectionAffinity
+  | QueryDependency
+  | QueryDependencyAccess
+  | QueryDependencyKind
+  | QueryLocking
+  | QueryOperation
+  | QuerySemantics
+  | QueryVolatility
   | QueryBatch<readonly [ExactQuery]>
   | QueryExecutor
   | QueryRenderSkeleton
@@ -252,7 +273,11 @@ type ReferencedStableTypes =
   | SqlRenderer
   | SqlSegment
   | SqlTag
+  | SqlAstVisitor
+  | SqlAstContext
   | StreamOptions
+  | SemanticEvidence
+  | SemanticFact<string>
   | TransactionDatabase
   | TransactionRunner
   | TypedSqlConfig;
@@ -295,6 +320,7 @@ const expectedRuntimeExports = {
     "parseSelect",
     "parseStatement",
     "tokenize",
+    "walkStatement",
   ],
   compiler: ["checkFile", "compileSource", "extractStaticQueries", "mapSqlRange"],
   config: ["discoverConfig", "fromConfig", "loadConfig"],
@@ -308,13 +334,18 @@ const expectedRuntimeExports = {
     "closestName",
     "createDatabase",
     "defineConfig",
+    "defineQuerySemantics",
     "diagnosticRegistry",
     "isTypedSqlDiagnosticCode",
+    "mapQuerySemanticRanges",
+    "mergeQuerySemantics",
     "parameterTypeLiteral",
+    "QUERY_SEMANTICS_VERSION",
     "renderQuery",
     "rowTypeLiteral",
     "sql",
     "unionTypeLiterals",
+    "unknownQuerySemantics",
   ],
   mysql: [
     "MYSQL_DIALECT_VERSION",

--- a/test/grammar/conformance.ts
+++ b/test/grammar/conformance.ts
@@ -24,6 +24,11 @@ export interface DialectConformanceFixture<Snapshot extends SchemaSnapshot, Poli
   readonly expectedParameterType: string;
   readonly unsupportedQuery: string;
   readonly unsupportedCode: string;
+  readonly expectedSemantics: {
+    readonly operation: "read" | "write" | "unknown";
+    readonly volatility: "immutable" | "stable" | "volatile" | "unknown";
+    readonly cardinalityMaximum: 0 | 1 | "many" | "unknown";
+  };
   readonly policyProbe?: {
     readonly query: string;
     readonly policy: Policy;
@@ -63,6 +68,10 @@ export function assertDialectConformance<Snapshot extends SchemaSnapshot, Policy
   );
   assert.strictEqual(rowTypeLiteral(resolved.columns), fixture.expectedRowType);
   assert.strictEqual(parameterTypeLiteral(1, resolved.parameters), fixture.expectedParameterType);
+  assert.strictEqual(resolved.semantics.operation.value, fixture.expectedSemantics.operation);
+  assert.strictEqual(resolved.semantics.volatility.value, fixture.expectedSemantics.volatility);
+  assert.strictEqual(resolved.semantics.cardinality.maximum, fixture.expectedSemantics.cardinalityMaximum);
+  assert.strictEqual(resolved.semantics.version, 1);
 
   if (fixture.policyProbe !== undefined) {
     const policyResult = dialect.analyze(fixture.policyProbe.query, snapshot, fixture.policyProbe.policy);
@@ -74,6 +83,7 @@ export function assertDialectConformance<Snapshot extends SchemaSnapshot, Policy
   assert.ok(
     unsupported.diagnostics.some(({ code, severity }) => code === fixture.unsupportedCode && severity === "error"),
   );
+  assert.strictEqual(unsupported.semantics.operation.value, "unknown");
   const source = [
     `import { sql } from ${JSON.stringify(dialect.sqlModule)};`,
     "const query = sql`",


### PR DESCRIPTION
## Summary

- define a versioned, grammar-neutral `QuerySemantics` contract in `@typed-sql/core`
- add a reusable AST walker while keeping the AST package syntax-only
- classify PostgreSQL and MySQL operations, cardinality, dependencies, volatility, locking, connection affinity, and capabilities
- introspect function volatility from each database grammar's schema provider
- add deterministic query and structural-variant fingerprints to compiler output
- source-map and conservatively merge semantic metadata across structural query variants
- document the public contract, extension path, and schema snapshot behavior
- enforce public API, package-boundary, grammar-conformance, packed-consumer, coverage, and performance checks

## Contract changes

This advances the dialect contract to v4:

- `DialectAnalysis.semantics` is now required; third-party grammars can use `unknownQuerySemantics()` while adopting richer classification
- `CompiledQuery` now exposes required `fingerprint`, `variantFingerprints`, and `semantics` fields
- schema functions may expose optional volatility metadata

The changeset marks the affected packages accordingly.

## Design guarantees

- semantic vocabulary and merging live in neutral packages; dialect-specific classification remains in grammar packages
- incomplete or invalid analysis fails closed to explicit `unknown` facts
- structural variants widen facts conservatively and retain deterministic fingerprints
- no database driver becomes a runtime dependency of neutral packages

## Verification

- `pnpm verify`
- TypeScript 7.0.2 typecheck
- Node.js 24.10.0 build
- contract, packed-consumer, documentation, and package coverage suites
- 250-query semantic metadata benchmark: p50 `3.471 ms`, p95 `4.445 ms` against budgets of `10 ms` / `25 ms`

Closes #53
