### PR TITLE
feat: add adapter-neutral database observability

### DIFF
--- a/.changeset/red-spans-observe.md
+++ b/.changeset/red-spans-observe.md
@@ -1,0 +1,12 @@
+---
+"@typed-sql/core": major
+"@typed-sql/opentelemetry": major
+"@typed-sql/postgres": major
+"@typed-sql/mysql": major
+---
+
+Add an adapter-neutral, redacted database observation lifecycle for queries, cardinality contracts,
+batches, PostgreSQL pipelines, streams, cancellation, and nested transactions. Runtime fingerprints
+correlate with compiler structural variants while SQL, parameter values, connection configuration,
+and driver causes remain excluded by default. Publish the optional OpenTelemetry bridge with current
+database semantic conventions and explicit high-cardinality or exception-capture opt-ins.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ the structural-variant bound.
 | Package | Purpose | Track |
 | --- | --- | --- |
 | `@typed-sql/core` | Query, fragment, adapter, dialect, and diagnostic contracts | Stable |
+| `@typed-sql/opentelemetry` | Optional redacted OpenTelemetry database tracing | Stable |
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | Stable |
 | `@typed-sql/schema` | Versioned snapshots, hashes, migrations, and drift | Stable |
 | `@typed-sql/config` | Config discovery and loading | Stable |
@@ -136,6 +137,7 @@ the structural-variant bound.
 - [Documentation site](https://lojhan.github.io/typed-sql/)
 - [Documentation source](./docs/index.md)
 - [Execution adapters](./docs/guides/execution.md)
+- [Database observability](./docs/guides/observability.md)
 - [PostgreSQL grammar](./docs/dialects/postgresql.md)
 - [MySQL grammar](./docs/dialects/mysql.md)
 - [Inference and safety](./docs/concepts/type-safety.md)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -12,6 +12,7 @@ typed-sql separates the application query contract, SQL grammar, schema metadata
 | Package | Responsibility | Installs a runtime driver |
 | --- | --- | --- |
 | `@typed-sql/core` | SQL tag, query and fragment types, rendering, database and dialect contracts | No |
+| `@typed-sql/opentelemetry` | Optional bridge from the neutral observer contract to OpenTelemetry spans | No |
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | No |
 | `@typed-sql/config` | Dialect-neutral project config discovery and loading | No |
 | `@typed-sql/schema` | Snapshot envelope, deterministic generation, hashes, and drift | No |
@@ -30,6 +31,8 @@ Applications select one grammar and explicitly install its driver. Adding Postgr
 Grammar packages may refer to driver types, expose driver-specific adapters, and use drivers in their own tests. They do not install runtime drivers for applications.
 
 Driver adapters load the application dependency only when their explicit subpath is used. Missing drivers fail with an actionable install message. This avoids hidden clients, duplicate pools, unexpected install size, and driver lifecycle decisions made by typed-sql.
+
+Observability follows the same direction of dependency. Core defines redacted lifecycle events, runtime adapters emit them, and `@typed-sql/opentelemetry` translates them into spans through an application-owned OpenTelemetry API and provider. Core and dialect packages do not depend on OpenTelemetry.
 
 ## Dialect contract
 

--- a/docs/dialects/mysql.md
+++ b/docs/dialects/mysql.md
@@ -39,6 +39,8 @@ The adapter controls mysql2 options that affect row shape and decoding. Supplyin
 
 `all`, `one`, and `maybeOne` accept an `AbortSignal` and absolute deadline. mysql2 has no per-command `AbortSignal` contract, so typed-sql interrupts a buffered query by destroying its checked-out connection. The pool replaces it for later work, while a cancelled transaction is invalidated and cannot continue.
 
+The runtime constructors and mysql2 adapter accept a grammar-neutral `observer`. Query, prepared-query, batch, stream, cancellation, and nested-transaction lifecycles carry MySQL compiler-compatible fingerprints without exposing SQL or values. See [Observe database work](../guides/observability.md).
+
 ## Streaming
 
 MySQL streaming uses mysql2's protocol-backed execute stream and does not require another package. `batchSize` maps to the object-mode high-water mark, so it controls client-side buffering rather than server cursor page size.

--- a/docs/dialects/postgresql.md
+++ b/docs/dialects/postgresql.md
@@ -43,6 +43,8 @@ Use PostgreSQL's server-enforced `statement_timeout` when a pool-wide statement 
 
 `all`, `one`, and `maybeOne` accept an `AbortSignal` and absolute deadline. Because node-postgres does not expose a safe signal contract for an individual pool query, typed-sql leases a client and destroys that lease when a control fires. The cancelled transaction cannot continue. This is client-side interruption by conservative connection discard, not a PostgreSQL cancel request; use server-side statement timeouts when the database itself must enforce a limit.
 
+The runtime constructors and `pg` adapter accept a grammar-neutral `observer`. Query, prepared-query, batch, pipeline, stream, cancellation, and nested-transaction lifecycles carry PostgreSQL compiler-compatible fingerprints without exposing SQL or values. See [Observe database work](../guides/observability.md).
+
 `database.prepare(name, factory)` returns ordinary queries carrying instance-local prepared metadata. Buffered execution passes the stable name to `pg`, whose prepared statements are cached per PostgreSQL connection. The factory caches its first structural SQL skeleton and rejects duplicate names or structural drift between calls.
 
 `database.batch(queries)` checks out one `pg` client and dispatches the queries sequentially. It is not a pipeline and does not combine statements into one SQL string or network round trip. Root batches use PostgreSQL's ordinary autocommit behavior; transactional statements can use an explicit typed-sql transaction when atomicity is required.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,6 +31,16 @@ pnpm add -D @typed-sql/cli typescript@7.0.2
 
 The grammar package owns SQL parsing, catalog introspection, type resolution, and runtime codecs. Your application owns the driver version, connection configuration, pool, and lifecycle.
 
+## OpenTelemetry
+
+Database tracing is optional and independent of the selected dialect:
+
+```sh
+pnpm add @typed-sql/opentelemetry @opentelemetry/api
+```
+
+The integration does not install an SDK, exporter, or database driver. See [Observe database work](../guides/observability.md).
+
 ## Editor tooling
 
 The language server is optional and experimental:

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,130 @@
+---
+title: Observe database work
+description: Trace typed-sql queries, batches, pipelines, streams, and transactions without logging SQL values.
+---
+
+# Observe database work
+
+typed-sql exposes one adapter-neutral database observer contract and an optional OpenTelemetry bridge. Observation is disabled unless an observer is passed to a database adapter. The disabled query path does not hash a query, construct an event, or wrap a stream.
+
+## Add OpenTelemetry tracing
+
+Install the bridge and the OpenTelemetry API alongside the driver owned by your application:
+
+```sh
+pnpm add @typed-sql/opentelemetry @opentelemetry/api
+```
+
+Pass one observer when the database is created:
+
+```ts
+import { createOpenTelemetryObserver } from "@typed-sql/opentelemetry";
+import { typePolicy } from "@typed-sql/postgres";
+import { createPgDatabase } from "@typed-sql/postgres/pg";
+
+const database = await createPgDatabase({
+  connectionString: process.env.DATABASE_URL!,
+  typePolicy,
+  observer: createOpenTelemetryObserver(),
+});
+```
+
+The bridge uses the globally registered OpenTelemetry tracer provider by default. SDK setup and export remain application-owned. For example, an application exporting OTLP over HTTP can initialize its provider before creating the database:
+
+```ts
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const telemetry = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+});
+
+telemetry.start();
+```
+
+Queries then run in their span context, so child work started during driver dispatch can use the active database span. Call `telemetry.shutdown()` during application shutdown according to the SDK lifecycle used by the application.
+
+## Default span policy
+
+The integration follows the current OpenTelemetry SQL database span conventions: database work uses client spans, `db.system.name` identifies the database system, and group operations use low-cardinality operation names.
+
+Default spans contain only structural metadata:
+
+- dialect and grammar version;
+- operation kind and transaction depth;
+- one query fingerprint, cardinality contract, and prepared status for query operations;
+- batch or pipeline size;
+- stable error type and cancellation reason when an operation fails.
+
+The following data is absent by default:
+
+- SQL text and rendered literals;
+- parameter values;
+- connection strings, hostnames, credentials, and pool configuration;
+- driver error objects or messages;
+- batch fingerprint arrays and returned-row counts.
+
+Returned-row counts and batch fingerprint arrays are OpenTelemetry opt-ins because they can add cost or cardinality. Driver exception recording is a separate, visibly unsafe opt-in because driver messages may contain SQL or values:
+
+```ts
+const observer = createOpenTelemetryObserver({
+  recordReturnedRows: true,
+  recordBatchFingerprints: true,
+  recordExceptions: true, // Review driver error redaction before enabling this.
+});
+```
+
+`recordExceptions` is the only option that asks core to carry the original error object to the integration. It should not be enabled until the application's driver and exporter redaction behavior has been reviewed.
+
+## Lifecycle semantics
+
+An installed observer receives one start event and at most one end event for each operation it accepts.
+
+| Operation | Starts | Ends |
+| --- | --- | --- |
+| `execute`, `all`, `one`, `maybeOne` | Before driver dispatch | Success, cardinality error, driver error, or cancellation |
+| `batch` | Once for the ordered group | After the group succeeds or fails |
+| PostgreSQL `pipeline` | Once for the dispatched group | After every response settles |
+| `stream` | Lazily on first iteration | Natural completion, error, cancellation, explicit close, disposal, or early iterator return |
+| `transaction` | Before begin or savepoint work | After commit/release succeeds, or rollback failure is reported |
+
+Nested transaction events use depth `1` for the first transaction and increase for each savepoint. Query and stream events inside a transaction carry that same depth. Observer `start()` and `end()` failures are isolated from database results. An observer can return `undefined` from `start()` to decline one operation.
+
+## Correlate compiler and runtime work
+
+A runtime query fingerprint is SHA-256 over the dialect id, grammar version, and rendered structural SQL. Parameter values and checkout paths are not inputs.
+
+For an unconditional query, the runtime fingerprint equals `CompiledQuery.fingerprint`. A conditionally composed query can produce several complete structural statements; its runtime fingerprint equals one member of `CompiledQuery.variantFingerprints`. The compiled query's top-level fingerprint is the deterministic identity of that complete variant set. This lets generated manifests index runtime spans without storing SQL or values.
+
+Fingerprints are stable correlation identifiers, not authorization tokens or cryptographic attestations.
+
+## Install a custom observer
+
+Use the core contract when an application already has a metrics or logging abstraction:
+
+```ts
+import type { DatabaseObserver } from "@typed-sql/core";
+
+const observer: DatabaseObserver = {
+  start(operation) {
+    const startedAt = performance.now();
+
+    return {
+      run(callback) {
+        return callback();
+      },
+      end(completion) {
+        metrics.databaseOperation.record(completion.durationMilliseconds, {
+          dialect: operation.dialect,
+          kind: operation.kind,
+          status: completion.status,
+        });
+      },
+    };
+  },
+};
+```
+
+Start events and completion events are frozen. Keep metric dimensions low-cardinality: dialect, operation kind, status, and cancellation reason are suitable defaults. A query fingerprint is useful for tracing and targeted diagnostics, but it should not normally become an unbounded metrics label.
+
+See [Query API](../reference/api.md#database-observation) and the [PostgreSQL](../dialects/postgresql.md) or [MySQL](../dialects/mysql.md) runtime notes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ It is not an ORM or a query builder. SQL remains visible, database drivers remai
 
 - [Compose conditional SQL](./guides/composition.md) without creating a parallel query-builder API.
 - [Generate snapshots and detect drift](./guides/schema-snapshots.md).
+- [Trace database work safely](./guides/observability.md) through the neutral observer contract.
 - [Configure Zed, VS Code, or another LSP client](./guides/editors.md).
 - Review the [PostgreSQL](./dialects/postgresql.md) and [MySQL](./dialects/mysql.md) grammar boundaries.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -135,6 +135,18 @@ Transaction streams are scoped resources. They must reach completion or close be
 
 Streaming is an adapter capability rather than a method on the minimal core `Database` contract. PostgreSQL maps it to an application-owned cursor; MySQL maps it to protocol streaming. See [Execute queries](../guides/execution.md#stream-large-result-sets) for consumer examples.
 
+### Database observation
+
+`DatabaseObserver` is the grammar- and adapter-neutral execution lifecycle contract. Pass an observer through `createPgDatabase`, `createMySql2Database`, or the driver-neutral runtime constructors. Applications adapting an existing pool pass the result of `adaptPgPool` or `adaptMySql2Pool` to that dialect's runtime constructor alongside the observer.
+
+`DatabaseOperationStart` is a discriminated union for `query`, `batch`, `pipeline`, `stream`, and `transaction`. Every member contains `dialect`, `grammarVersion`, and `transactionDepth`; query-like members add structural fingerprints and execution metadata. Events do not contain SQL text, parameter values, or connection configuration.
+
+`DatabaseObservation` can provide `run(callback)` to establish observer-owned context and must provide `end(completion)`. A completion reports `success`, `error`, or `cancelled`, a duration, and available row count or sanitized error classification. Core isolates observer start and end failures and closes accepted operations at most once.
+
+Set `DatabaseObserver.captureErrorCause` only when an integration explicitly needs the original driver error. Causes are absent by default because driver errors can contain sensitive SQL or values.
+
+`@typed-sql/opentelemetry` exports `createOpenTelemetryObserver(options?)`. Its OpenTelemetry API dependency is an application-owned peer. See [Observe database work](../guides/observability.md) for lifecycle ordering, redaction policy, and tracing setup.
+
 ## Configuration and schema contracts
 
 `defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, and compiler options.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -38,7 +38,7 @@ Driver configurations that change decoded value shapes can violate static types.
 
 | Surface | Status |
 | --- | --- |
-| `core`, `ast`, `schema`, `config`, `compiler`, `conformance`, `postgres`, `mysql`, `cli` | Stable package contract |
+| `core`, `opentelemetry`, `ast`, `schema`, `config`, `compiler`, `conformance`, `postgres`, `mysql`, `cli` | Stable package contract |
 | `ts-bridge`, `language-server` | Experimental while they depend on preview TypeScript APIs |
 | VS Code and Zed integrations | Experimental distribution |
 

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Query } from "@typed-sql/core";
+import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart, Query } from "@typed-sql/core";
 import { type MySqlSchemaSnapshot, mysql, sql, typePolicy } from "@typed-sql/mysql";
 import { createMySql2Database } from "@typed-sql/mysql/mysql2";
 import { analyzeSource } from "@typed-sql/ts-bridge";
@@ -355,10 +355,16 @@ try {
     });
 
     await it("enforces cardinality and discards interrupted mysql2 connections", async () => {
+      const completions: DatabaseOperationEnd[] = [];
       const database = await createMySql2Database({
         connectionUri,
         typePolicy,
         poolConfig: { connectionLimit: 1 },
+        observer: {
+          start() {
+            return { end: (completion) => completions.push(completion) };
+          },
+        },
       });
       try {
         const account = await database.one(sql<{ id: bigint }>`SELECT id FROM users WHERE id = ${1n}`);
@@ -391,6 +397,19 @@ try {
           return true;
         });
         strict.deepStrictEqual(await database.one(sql<{ value: bigint }>`SELECT 2 AS value`), { value: 2n });
+        strict.ok(
+          completions.some(
+            ({ status, errorType, cancellationReason }) =>
+              status === "cancelled" && errorType === "TSQL_CANCELLED" && cancellationReason === "deadline",
+          ),
+        );
+        strict.ok(
+          completions.some(
+            ({ status, errorType, cancellationReason }) =>
+              status === "cancelled" && errorType === "TSQL_CANCELLED" && cancellationReason === "signal",
+          ),
+        );
+        strict.ok(completions.every((completion) => !("cause" in completion)));
       } finally {
         await database.close();
       }
@@ -407,7 +426,15 @@ try {
       // ordinary E2E tsc pass does not install the preview bridge, so retain that verified type at
       // the harness boundary while exercising the original immutable Query object at runtime.
       const accountsQuery = streamAccountsQuery as unknown as Query<Account, readonly []>;
-      const database = await createMySql2Database({ connectionUri, typePolicy });
+      const observationStarts: DatabaseOperationStart[] = [];
+      const observationEnds: DatabaseOperationEnd[] = [];
+      const observer: DatabaseObserver = {
+        start(operation) {
+          observationStarts.push(operation);
+          return { end: (completion) => observationEnds.push(completion) };
+        },
+      };
+      const database = await createMySql2Database({ connectionUri, typePolicy, observer });
       try {
         const preparedAccounts = database.prepare("e2e-accounts", () => accountsQuery);
         strict.strictEqual(preparedAccounts.statementName, "e2e-accounts");
@@ -454,6 +481,17 @@ try {
         const rowsAfterTransaction = await database.execute(preparedAccounts());
         strict.strictEqual(rowsAfterTransaction.length, 2);
         strict.strictEqual(rowsAfterTransaction[1]?.status, "suspended");
+        const kinds = new Set(observationStarts.map(({ kind }) => kind));
+        for (const kind of ["query", "batch", "stream", "transaction"] as const) {
+          strict.ok(kinds.has(kind), `Missing real MySQL ${kind} observation`);
+        }
+        strict.strictEqual(observationEnds.length, observationStarts.length);
+        strict.ok(observationEnds.every(({ status }) => status === "success"));
+        for (const operation of observationStarts) {
+          strict.ok(!("text" in operation));
+          strict.ok(!("values" in operation));
+          strict.ok(!("connectionUri" in operation));
+        }
       } finally {
         await database.close();
       }

--- a/e2e/postgres/test/developer-flow.e2e.test.ts
+++ b/e2e/postgres/test/developer-flow.e2e.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart } from "@typed-sql/core";
 import { type PostgresSchemaSnapshot, postgres, sql, typePolicy } from "@typed-sql/postgres";
 import { createPgDatabase } from "@typed-sql/postgres/pg";
 import { analyzeSource } from "@typed-sql/ts-bridge";
@@ -452,10 +453,16 @@ try {
     });
 
     await it("enforces cardinality and discards interrupted pg connections", async () => {
+      const completions: DatabaseOperationEnd[] = [];
       const database = await createPgDatabase({
         connectionString,
         typePolicy,
         poolConfig: { max: 1, connectionTimeoutMillis: 2_000 },
+        observer: {
+          start() {
+            return { end: (completion) => completions.push(completion) };
+          },
+        },
       });
       try {
         const account = await database.one(sql<{ id: bigint }>`SELECT id FROM users WHERE id = ${1n}`);
@@ -488,15 +495,37 @@ try {
           return true;
         });
         strict.deepStrictEqual(await database.one(sql<{ value: bigint }>`SELECT 2::bigint AS value`), { value: 2n });
+        strict.ok(
+          completions.some(
+            ({ status, errorType, cancellationReason }) =>
+              status === "cancelled" && errorType === "TSQL_CANCELLED" && cancellationReason === "deadline",
+          ),
+        );
+        strict.ok(
+          completions.some(
+            ({ status, errorType, cancellationReason }) =>
+              status === "cancelled" && errorType === "TSQL_CANCELLED" && cancellationReason === "signal",
+          ),
+        );
+        strict.ok(completions.every((completion) => !("cause" in completion)));
       } finally {
         await database.close();
       }
     });
 
     await it("batches and streams inferred and prepared queries through a reusable one-client pool", async () => {
+      const observationStarts: DatabaseOperationStart[] = [];
+      const observationEnds: DatabaseOperationEnd[] = [];
+      const observer: DatabaseObserver = {
+        start(operation) {
+          observationStarts.push(operation);
+          return { end: (completion) => observationEnds.push(completion) };
+        },
+      };
       const database = await createPgDatabase({
         connectionString,
         typePolicy,
+        observer,
         poolConfig: { max: 1, connectionTimeoutMillis: 2_000, pipeline: true },
         // The workspace package is symlinked outside this fixture's node_modules tree. Supplying
         // the application-owned loader preserves pnpm's strict dependency boundary in this E2E.
@@ -585,6 +614,17 @@ try {
 
         const health = await database.execute(sql<{ total: bigint }>`SELECT active_user_count() AS total`);
         strict.deepStrictEqual(health, [{ total: 1n }]);
+        const kinds = new Set(observationStarts.map(({ kind }) => kind));
+        for (const kind of ["query", "batch", "pipeline", "stream", "transaction"] as const) {
+          strict.ok(kinds.has(kind), `Missing real PostgreSQL ${kind} observation`);
+        }
+        strict.strictEqual(observationEnds.length, observationStarts.length);
+        strict.ok(observationEnds.every(({ status }) => status === "success"));
+        for (const operation of observationStarts) {
+          strict.ok(!("text" in operation));
+          strict.ok(!("values" in operation));
+          strict.ok(!("connectionString" in operation));
+        }
       } finally {
         await database.close();
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release:stable": "pnpm release:assert stable && node scripts/publish-prerelease.mjs stable",
     "release:rehearse": "node scripts/rehearse-stable-release.mjs",
     "release:check": "pnpm verify && pnpm --filter @typed-sql/e2e-packed e2e && pnpm audit --prod --audit-level high",
-    "coverage": "pnpm --filter @typed-sql/core coverage && pnpm --filter @typed-sql/ast coverage && pnpm --filter @typed-sql/schema coverage && pnpm --filter @typed-sql/config coverage && pnpm --filter @typed-sql/compiler coverage && pnpm --filter @typed-sql/conformance coverage && pnpm --filter @typed-sql/postgres coverage && pnpm --filter @typed-sql/mysql coverage",
+    "coverage": "pnpm --filter @typed-sql/core coverage && pnpm --filter @typed-sql/ast coverage && pnpm --filter @typed-sql/schema coverage && pnpm --filter @typed-sql/config coverage && pnpm --filter @typed-sql/compiler coverage && pnpm --filter @typed-sql/conformance coverage && pnpm --filter @typed-sql/opentelemetry coverage && pnpm --filter @typed-sql/postgres coverage && pnpm --filter @typed-sql/mysql coverage",
     "test:watch": "poku --config=poku.config.js --watch",
     "typecheck": "node scripts/require-typescript-7.mjs && tsc -b --pretty false",
     "version-packages": "node scripts/version-packages.mjs"
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.10",
     "@changesets/cli": "3.0.1",
+    "@opentelemetry/api": "1.9.1",
     "@pokujs/c8": "^2.0.0",
     "@typed-sql/core": "workspace:*",
     "@typed-sql/mysql": "workspace:*",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,6 +31,9 @@ preserve the inferred row, accept optional signals or absolute deadlines, and ex
 cardinality and cancellation errors. Adapter capabilities are explicit; unsupported controls are
 never silently ignored.
 
+`DatabaseObserver` provides redacted query, batch, pipeline, stream, cancellation, and nested
+transaction lifecycles. It is disabled by default and does not add a telemetry dependency to core.
+
 Grammar and adapter authors can use `DialectPlugin`, `DIALECT_CONTRACT_VERSION`,
 `assertDialectPlugin`, `defineQuerySemantics`, `mergeQuerySemantics`, `createDatabase`, `renderQuery`,
 the prepared-query skeleton helpers, and the neutral resolver primitives from the package root. The package has no parser, grammar,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,21 @@ export {
   UnsupportedExecutionCapabilityError,
 } from "./execution.js";
 export type {
+  ActiveDatabaseObservation,
+  BatchOperationStart,
+  DatabaseObservation,
+  DatabaseObservationStatus,
+  DatabaseObserver,
+  DatabaseOperationCompletion,
+  DatabaseOperationEnd,
+  DatabaseOperationStart,
+  QueryObservationCardinality,
+  QueryOperationStart,
+  StreamOperationStart,
+  TransactionOperationStart,
+} from "./observation.js";
+export { databaseErrorCompletion, observeQueryStream, startDatabaseObservation } from "./observation.js";
+export type {
   ControlledQueryExecutor,
   Database,
   OptionalSqlFragment,

--- a/packages/core/src/observation.ts
+++ b/packages/core/src/observation.ts
@@ -1,0 +1,214 @@
+import type { QueryCancellationReason, QueryCardinalityExpectation, QueryStream } from "./execution.js";
+
+export type QueryObservationCardinality = QueryCardinalityExpectation | "many";
+export type DatabaseObservationStatus = "success" | "error" | "cancelled";
+
+interface DatabaseOperationCommon {
+  readonly dialect: string;
+  readonly grammarVersion: string;
+  readonly transactionDepth: number;
+}
+
+export interface QueryOperationStart extends DatabaseOperationCommon {
+  readonly kind: "query";
+  readonly fingerprint: string;
+  readonly cardinality: QueryObservationCardinality;
+  readonly prepared: boolean;
+}
+
+export interface BatchOperationStart extends DatabaseOperationCommon {
+  readonly kind: "batch" | "pipeline";
+  readonly fingerprints: readonly string[];
+  readonly size: number;
+}
+
+export interface StreamOperationStart extends DatabaseOperationCommon {
+  readonly kind: "stream";
+  readonly fingerprint: string;
+  readonly prepared: boolean;
+}
+
+export interface TransactionOperationStart extends DatabaseOperationCommon {
+  readonly kind: "transaction";
+}
+
+export type DatabaseOperationStart =
+  | QueryOperationStart
+  | BatchOperationStart
+  | StreamOperationStart
+  | TransactionOperationStart;
+
+export interface DatabaseOperationCompletion {
+  readonly status: DatabaseObservationStatus;
+  readonly rowCount?: number;
+  readonly errorType?: string;
+  readonly cancellationReason?: QueryCancellationReason;
+}
+
+export interface DatabaseOperationEnd extends DatabaseOperationCompletion {
+  readonly durationMilliseconds: number;
+  /** Present only when the observer explicitly enables error-cause capture. */
+  readonly cause?: unknown;
+}
+
+export interface DatabaseObservation {
+  /** Runs dispatch in observer-owned context, such as an OpenTelemetry span context. */
+  run?<Value>(operation: () => Value): Value;
+  end(completion: DatabaseOperationEnd): void;
+}
+
+export interface DatabaseObserver {
+  /** Error objects may include sensitive driver text and are excluded by default. */
+  readonly captureErrorCause?: boolean;
+  start(operation: DatabaseOperationStart): DatabaseObservation | undefined;
+}
+
+export interface ActiveDatabaseObservation {
+  run<Value>(operation: () => Value): Value;
+  end(completion: DatabaseOperationCompletion, cause?: unknown): void;
+}
+
+function classifiedErrorType(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    if ("code" in error && typeof error.code === "string") return error.code;
+    if (error instanceof Error && error.name.length > 0) return error.name;
+  }
+  return typeof error;
+}
+
+/** Starts one redacted operation lifecycle. Observer start/end failures never replace database results. */
+export function startDatabaseObservation(
+  observer: DatabaseObserver | undefined,
+  operation: DatabaseOperationStart,
+): ActiveDatabaseObservation | undefined {
+  if (observer === undefined) return undefined;
+  const started = performance.now();
+  let observation: DatabaseObservation | undefined;
+  try {
+    observation = observer.start(Object.freeze(operation));
+  } catch {
+    return undefined;
+  }
+  if (observation === undefined) return undefined;
+  let ended = false;
+  return {
+    run<Value>(callback: () => Value): Value {
+      return observation.run === undefined ? callback() : observation.run(callback);
+    },
+    end(completion: DatabaseOperationCompletion, cause?: unknown): void {
+      if (ended) return;
+      ended = true;
+      const event = Object.freeze({
+        ...completion,
+        durationMilliseconds: Math.max(0, performance.now() - started),
+        ...(observer.captureErrorCause === true && cause !== undefined ? { cause } : {}),
+      });
+      try {
+        observation.end(event);
+      } catch {
+        /* Observation must not replace a database result or failure. */
+      }
+    },
+  };
+}
+
+export function databaseErrorCompletion(error: unknown): DatabaseOperationCompletion {
+  const cancellationReason =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "TSQL_CANCELLED" &&
+    "reason" in error &&
+    (error.reason === "signal" || error.reason === "deadline")
+      ? error.reason
+      : undefined;
+  return Object.freeze({
+    status: cancellationReason === undefined ? "error" : "cancelled",
+    errorType: classifiedErrorType(error),
+    ...(cancellationReason === undefined ? {} : { cancellationReason }),
+  });
+}
+
+/** Adds a lazy, exactly-once observation lifecycle to an adapter-owned query stream. */
+export function observeQueryStream<Row>(
+  stream: QueryStream<Row>,
+  observer: DatabaseObserver | undefined,
+  operation: StreamOperationStart,
+): QueryStream<Row> {
+  if (observer === undefined) return stream;
+  let observation: ActiveDatabaseObservation | undefined;
+  let startAttempted = false;
+  let rowCount = 0;
+  let ended = false;
+  const start = (): ActiveDatabaseObservation | undefined => {
+    if (!startAttempted) {
+      startAttempted = true;
+      observation = startDatabaseObservation(observer, operation);
+    }
+    return observation;
+  };
+  const end = (completion: DatabaseOperationCompletion, cause?: unknown): void => {
+    if (ended) return;
+    ended = true;
+    observation?.end({ ...completion, rowCount }, cause);
+  };
+  const observed: QueryStream<Row> = {
+    async next(): Promise<IteratorResult<Row>> {
+      const active = start();
+      try {
+        const result = await (active === undefined ? stream.next() : active.run(() => stream.next()));
+        if (result.done) end({ status: "success" });
+        else rowCount += 1;
+        return result;
+      } catch (error) {
+        end(databaseErrorCompletion(error), error);
+        throw error;
+      }
+    },
+    async return(value?: unknown): Promise<IteratorResult<Row>> {
+      try {
+        const callback = (): Promise<IteratorResult<Row>> =>
+          stream.return === undefined
+            ? stream.close().then(() => ({ done: true, value: value as Row }))
+            : stream.return(value);
+        const result = await (observation === undefined ? callback() : observation.run(callback));
+        end({ status: "success" });
+        return result;
+      } catch (error) {
+        end(databaseErrorCompletion(error), error);
+        throw error;
+      }
+    },
+    async throw(error?: unknown): Promise<IteratorResult<Row>> {
+      try {
+        const callback = (): Promise<IteratorResult<Row>> =>
+          stream.throw === undefined ? Promise.reject(error) : stream.throw(error);
+        const result = await (observation === undefined ? callback() : observation.run(callback));
+        if (result.done) {
+          if (error === undefined) end({ status: "success" });
+          else end(databaseErrorCompletion(error), error);
+        }
+        return result;
+      } catch (failure) {
+        end(databaseErrorCompletion(failure), failure);
+        throw failure;
+      }
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async close(): Promise<void> {
+      try {
+        await (observation === undefined ? stream.close() : observation.run(() => stream.close()));
+        end({ status: "success" });
+      } catch (error) {
+        end(databaseErrorCompletion(error), error);
+        throw error;
+      }
+    },
+    async [Symbol.asyncDispose](): Promise<void> {
+      await this.close();
+    },
+  };
+  return observed;
+}

--- a/packages/core/test/observation.test.ts
+++ b/packages/core/test/observation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, strict } from "poku";
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  databaseErrorCompletion,
+  observeQueryStream,
+  QueryCancelledError,
+  type QueryStream,
+  startDatabaseObservation,
+} from "../src/index.js";
+
+const queryStart = {
+  kind: "query",
+  dialect: "synthetic",
+  grammarVersion: "1",
+  transactionDepth: 0,
+  fingerprint: "sha256:test",
+  cardinality: "one",
+  prepared: false,
+} as const;
+
+const streamStart = {
+  kind: "stream",
+  dialect: "synthetic",
+  grammarVersion: "1",
+  transactionDepth: 0,
+  fingerprint: "sha256:stream",
+  prepared: false,
+} as const;
+
+await describe("redacted database observation lifecycle", async () => {
+  await it("runs in observer context and emits one immutable duration-bearing completion", () => {
+    const ends: DatabaseOperationEnd[] = [];
+    const observer: DatabaseObserver = {
+      start(operation) {
+        strict.ok(Object.isFrozen(operation));
+        strict.ok(!("text" in operation));
+        strict.ok(!("values" in operation));
+        return {
+          run(callback) {
+            return callback();
+          },
+          end(event) {
+            ends.push(event);
+          },
+        };
+      },
+    };
+    const observation = startDatabaseObservation(observer, queryStart)!;
+    strict.strictEqual(
+      observation.run(() => 42),
+      42,
+    );
+    observation.end({ status: "success", rowCount: 1 });
+    observation.end({ status: "error", errorType: "ignored" });
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "success");
+    strict.strictEqual(ends[0]?.rowCount, 1);
+    strict.ok((ends[0]?.durationMilliseconds ?? -1) >= 0);
+    strict.ok(Object.isFrozen(ends[0]));
+    strict.ok(!("cause" in ends[0]!));
+  });
+
+  await it("isolates observer start/end failures and captures causes only by explicit opt-in", () => {
+    strict.strictEqual(
+      startDatabaseObservation(
+        {
+          start() {
+            throw new Error("observer unavailable");
+          },
+        },
+        queryStart,
+      ),
+      undefined,
+    );
+
+    const failure = new Error("driver text may be sensitive");
+    let captured: DatabaseOperationEnd | undefined;
+    const observation = startDatabaseObservation(
+      {
+        captureErrorCause: true,
+        start() {
+          return {
+            end(event) {
+              captured = event;
+              throw new Error("exporter failed");
+            },
+          };
+        },
+      },
+      queryStart,
+    )!;
+    strict.doesNotThrow(() => observation.end(databaseErrorCompletion(failure), failure));
+    strict.strictEqual(captured?.cause, failure);
+    strict.strictEqual(captured?.errorType, "Error");
+  });
+
+  await it("classifies stable typed-sql errors without serializing their messages", () => {
+    const completion = databaseErrorCompletion(new QueryCancelledError("deadline"));
+    strict.deepStrictEqual(completion, {
+      status: "cancelled",
+      errorType: "TSQL_CANCELLED",
+      cancellationReason: "deadline",
+    });
+    strict.ok(Object.isFrozen(completion));
+  });
+
+  await it("observes lazy streams once across rows, early return, and repeated close", async () => {
+    const ends: DatabaseOperationEnd[] = [];
+    let starts = 0;
+    let current = 0;
+    const source: QueryStream<number> = {
+      async next() {
+        current += 1;
+        return current <= 2 ? { done: false as const, value: current } : { done: true as const, value: undefined };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async close() {},
+      async [Symbol.asyncDispose]() {},
+    };
+    strict.strictEqual(observeQueryStream(source, undefined, streamStart), source);
+    const stream = observeQueryStream(
+      source,
+      {
+        start() {
+          starts += 1;
+          return { end: (event) => ends.push(event) };
+        },
+      },
+      streamStart,
+    );
+    strict.strictEqual(starts, 0);
+    strict.deepStrictEqual(await stream.next(), { done: false, value: 1 });
+    strict.strictEqual(starts, 1);
+    await stream.return?.();
+    await stream.close();
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "success");
+    strict.strictEqual(ends[0]?.rowCount, 1);
+  });
+
+  await it("ends a handled iterator throw when the source terminates", async () => {
+    const ends: DatabaseOperationEnd[] = [];
+    const failure = new Error("consumer failed");
+    const source: QueryStream<number> = {
+      async next() {
+        return { done: false, value: 1 };
+      },
+      async throw() {
+        return { done: true, value: undefined };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async close() {},
+      async [Symbol.asyncDispose]() {},
+    };
+    const stream = observeQueryStream(
+      source,
+      {
+        start() {
+          return { end: (event) => ends.push(event) };
+        },
+      },
+      streamStart,
+    );
+    await stream.next();
+    strict.deepStrictEqual(await stream.throw?.(failure), { done: true, value: undefined });
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "error");
+    strict.strictEqual(ends[0]?.errorType, "Error");
+  });
+});

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -25,6 +25,7 @@ const query = sql`
 const database = await createMySql2Database({
   connectionUri: process.env.DATABASE_URL!,
   typePolicy,
+  // observer: createOpenTelemetryObserver(),
 });
 
 const rows = await database.execute(query);
@@ -48,6 +49,7 @@ codecs.
 
 Read the [MySQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/mysql.md),
 [execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
+[observability guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/observability.md),
 [configuration](https://github.com/Lojhan/typed-sql/blob/main/docs/getting-started/configuration.md), and
 [database type mappings](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/type-mappings.md).
 

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -4,8 +4,9 @@ import { parseSchemaSnapshot, type SchemaSnapshot } from "@typed-sql/schema";
 import { resolveMySqlStatement } from "./resolver.js";
 import { analyzeMySqlSemantics } from "./semantics.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
+import { MYSQL_DIALECT_VERSION } from "./version.js";
 
-export const MYSQL_DIALECT_VERSION = "1.0.0";
+export { MYSQL_DIALECT_VERSION } from "./version.js";
 export type MySqlSchemaSnapshot = SchemaSnapshot & { readonly dialect: "mysql" };
 
 export interface MySqlDialectOptions {

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -1,3 +1,4 @@
+import type { DatabaseObserver } from "@typed-sql/core";
 import type { Connection as CallbackConnection, Query as CallbackQuery } from "mysql2";
 import type { FieldPacket, Pool, PoolConnection, PoolOptions } from "mysql2/promise";
 import type { MySqlSchemaSnapshot } from "./index.js";
@@ -30,6 +31,7 @@ export interface MySql2Options {
   readonly decimal?: (value: string) => unknown;
   /** Test or host-injected loader. Applications normally leave this unset. */
   readonly driverImporter?: () => Promise<typeof import("mysql2/promise")>;
+  readonly observer?: DatabaseObserver;
 }
 
 export interface MySql2SchemaProviderOptions {
@@ -275,6 +277,7 @@ export async function createMySql2Database(options: MySql2Options): Promise<MySq
     ownsPool: true,
     ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),
     ...(options.decimal === undefined ? {} : { decimal: options.decimal }),
+    ...(options.observer === undefined ? {} : { observer: options.observer }),
   });
 }
 

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,8 +1,12 @@
+import { createHash } from "node:crypto";
 import {
   assertExecutionCapabilities,
   type Database,
+  type DatabaseObserver,
+  databaseErrorCompletion,
   type ExecutionCapabilities,
   type ExecutionOptions,
+  observeQueryStream,
   type Query,
   type QueryBatch,
   type QueryCancelledError,
@@ -13,6 +17,7 @@ import {
   runControlledExecution,
   type SqlRenderer,
   type StreamOptions,
+  startDatabaseObservation,
   UnsupportedExecutionCapabilityError,
 } from "@typed-sql/core";
 import {
@@ -30,6 +35,7 @@ import {
 } from "./prepared.js";
 import { createMySqlQueryStream, type MySqlStreamingConnection, validateMySqlStreamBatchSize } from "./stream.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
+import { MYSQL_DIALECT_VERSION } from "./version.js";
 
 export type { MySqlFieldLike } from "./decoding.js";
 export type { MySqlPreparedQueryFactory } from "./prepared.js";
@@ -81,10 +87,33 @@ export interface MySqlDatabaseOptions {
   readonly ownsPool?: boolean;
   readonly typePolicy?: Pick<MySqlTypePolicy, "bigint" | "decimal" | "date" | "json" | "tinyint1">;
   readonly decimal?: (value: string) => unknown;
+  readonly observer?: DatabaseObserver;
 }
 
 const defaultRuntimeTypePolicy: MySqlRuntimeTypePolicy = defaultMySqlTypePolicy;
 const emptyBatchResults = Object.freeze([]);
+
+interface MySqlObservationState {
+  readonly observer: DatabaseObserver | undefined;
+  readonly fingerprints: WeakMap<Query<unknown, readonly unknown[]>, string> | undefined;
+}
+
+function createMySqlObservationState(observer: DatabaseObserver | undefined): MySqlObservationState {
+  return { observer, fingerprints: observer === undefined ? undefined : new WeakMap() };
+}
+
+function mysqlQueryFingerprint<Row, Params extends readonly unknown[]>(
+  state: MySqlObservationState,
+  query: Query<Row, Params>,
+): string {
+  const key = query as unknown as Query<unknown, readonly unknown[]>;
+  const cached = state.fingerprints!.get(key);
+  if (cached !== undefined) return cached;
+  const text = renderQuery(query, mysqlRenderer).text;
+  const fingerprint = `sha256:${createHash("sha256").update(`mysql\0${MYSQL_DIALECT_VERSION}\0${text}`).digest("hex")}`;
+  state.fingerprints!.set(key, fingerprint);
+  return fingerprint;
+}
 
 export const mysqlRenderer: SqlRenderer = Object.freeze({
   placeholder: () => "?",
@@ -118,6 +147,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #ownsPool: boolean;
   readonly #depth: number;
   readonly #prepared: MySqlPreparedQueryState;
+  readonly #observation: MySqlObservationState;
   readonly #decoderPlans: MySqlDecoderPlanCache;
   readonly #executes: Set<MySqlConnectionOperation> | undefined;
   readonly #streams: Set<QueryStream<unknown>> | undefined;
@@ -132,6 +162,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     depth: number,
     prepared: MySqlPreparedQueryState,
     decoderPlans: MySqlDecoderPlanCache,
+    observation: MySqlObservationState,
     transactionState?: MySqlTransactionConnectionState,
   ) {
     this.#pool = pool;
@@ -140,6 +171,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     this.#depth = depth;
     this.#prepared = prepared;
     this.#decoderPlans = decoderPlans;
+    this.#observation = observation;
     this.#executes = connection === undefined ? undefined : new Set();
     this.#streams = connection === undefined ? undefined : new Set();
     this.#transactionState = transactionState;
@@ -150,6 +182,11 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return this.#executeUnobserved(query);
+    return this.#observeQuery(query, "many", () => this.#executeUnobserved(query));
+  }
+
+  async #executeUnobserved<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
     this.#assertScopeOpen();
     this.#assertConnectionAvailable("execute a query");
     if (this.#connection === undefined) return this.#executeOn(this.#pool, query);
@@ -169,8 +206,16 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return this.#allUnobserved(query, options);
+    return this.#observeQuery(query, "many", () => this.#allUnobserved(query, options));
+  }
+
+  async #allUnobserved<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    options?: ExecutionOptions,
+  ): Promise<readonly Row[]> {
     if (options === undefined || (options.signal === undefined && options.deadline === undefined))
-      return this.execute(query);
+      return this.#executeUnobserved(query);
     assertExecutionCapabilities(this.executionCapabilities, options);
     this.#assertScopeOpen();
     this.#assertConnectionAvailable("execute a query");
@@ -232,8 +277,16 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<Row> {
-    const rows = await this.all(query, options);
-    if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
+    if (this.#observation.observer === undefined) {
+      const rows = await this.#allUnobserved(query, options);
+      if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
+      return rows[0]!;
+    }
+    const rows = await this.#observeQuery(query, "one", async () => {
+      const result = await this.#allUnobserved(query, options);
+      if (result.length !== 1) throw new QueryCardinalityError("one", result.length);
+      return result;
+    });
     return rows[0]!;
   }
 
@@ -241,9 +294,43 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<Row | undefined> {
-    const rows = await this.all(query, options);
-    if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
+    if (this.#observation.observer === undefined) {
+      const rows = await this.#allUnobserved(query, options);
+      if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
+      return rows[0];
+    }
+    const rows = await this.#observeQuery(query, "maybeOne", async () => {
+      const result = await this.#allUnobserved(query, options);
+      if (result.length > 1) throw new QueryCardinalityError("maybeOne", result.length);
+      return result;
+    });
     return rows[0];
+  }
+
+  async #observeQuery<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    cardinality: "many" | "one" | "maybeOne",
+    operation: () => Promise<readonly Row[]>,
+  ): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return operation();
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind: "query",
+      dialect: "mysql",
+      grammarVersion: MYSQL_DIALECT_VERSION,
+      transactionDepth: this.#depth,
+      fingerprint: mysqlQueryFingerprint(this.#observation, query),
+      cardinality,
+      prepared: this.#prepared.queries.has(query),
+    });
+    if (observation === undefined) return operation();
+    try {
+      const rows = await observation.run(operation);
+      observation.end({ status: "success", rowCount: rows.length });
+      return rows;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
   }
 
   async #executeOn<Row, Params extends readonly unknown[]>(
@@ -259,6 +346,14 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
+    if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
+    if (this.#observation.observer === undefined) return this.#batchUnobserved(queries);
+    return this.#observeBatch(queries, () => this.#batchUnobserved(queries));
+  }
+
+  async #batchUnobserved<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+  ): Promise<QueryResults<Queries>> {
     this.#assertScopeOpen();
     this.#assertConnectionAvailable("execute a batch");
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
@@ -292,6 +387,35 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     return results;
   }
 
+  async #observeBatch<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+    operation: () => Promise<QueryResults<Queries>>,
+  ): Promise<QueryResults<Queries>> {
+    if (this.#observation.observer === undefined) return operation();
+    const fingerprints = Object.freeze(
+      [...queries].map((query) =>
+        mysqlQueryFingerprint(this.#observation, query as unknown as Query<unknown, readonly unknown[]>),
+      ),
+    );
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind: "batch",
+      dialect: "mysql",
+      grammarVersion: MYSQL_DIALECT_VERSION,
+      transactionDepth: this.#depth,
+      fingerprints,
+      size: queries.length,
+    });
+    if (observation === undefined) return operation();
+    try {
+      const results = await observation.run(operation);
+      observation.end({ status: "success" });
+      return results;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
+  }
+
   async #executeBatchOn<const Queries extends readonly unknown[]>(
     connection: MySqlConnectionLike,
     queries: QueryBatch<Queries>,
@@ -313,13 +437,13 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     const prepared = this.#prepared.queries.get(query);
     const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
     const batchSize = validateMySqlStreamBatchSize(options.batchSize);
-    let queryStream: QueryStream<Row>;
-    queryStream = createMySqlQueryStream<Row>({
+    let exposedStream: QueryStream<Row>;
+    const queryStream: QueryStream<Row> = createMySqlQueryStream<Row>({
       openConnection: async () => {
         if (this.#connection !== undefined) {
           this.#assertScopeOpen();
           this.#assertConnectionAvailable("start another query stream");
-          this.#transactionState!.active = queryStream as QueryStream<unknown>;
+          this.#transactionState!.active = exposedStream as QueryStream<unknown>;
           return { connection: this.#connection, release: false };
         }
         return { connection: await this.#pool.getConnection(), release: true };
@@ -329,12 +453,23 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       batchSize,
       decoderPlans: this.#decoderPlans,
       onClose: () => {
-        this.#streams?.delete(queryStream as QueryStream<unknown>);
-        if (this.#transactionState?.active === queryStream) this.#transactionState.active = undefined;
+        this.#streams?.delete(exposedStream as QueryStream<unknown>);
+        if (this.#transactionState?.active === exposedStream) this.#transactionState.active = undefined;
       },
     });
-    this.#streams?.add(queryStream as QueryStream<unknown>);
-    return queryStream;
+    exposedStream =
+      this.#observation.observer === undefined
+        ? queryStream
+        : observeQueryStream(queryStream, this.#observation.observer, {
+            kind: "stream",
+            dialect: "mysql",
+            grammarVersion: MYSQL_DIALECT_VERSION,
+            transactionDepth: this.#depth,
+            fingerprint: mysqlQueryFingerprint(this.#observation, query),
+            prepared: prepared !== undefined,
+          });
+    this.#streams?.add(exposedStream as QueryStream<unknown>);
+    return exposedStream;
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
@@ -346,6 +481,25 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async transaction<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
+    if (this.#observation.observer === undefined) return this.#transactionUnobserved(fn);
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind: "transaction",
+      dialect: "mysql",
+      grammarVersion: MYSQL_DIALECT_VERSION,
+      transactionDepth: this.#depth + 1,
+    });
+    if (observation === undefined) return this.#transactionUnobserved(fn);
+    try {
+      const result = await observation.run(() => this.#transactionUnobserved(fn));
+      observation.end({ status: "success" });
+      return result;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
+  }
+
+  async #transactionUnobserved<T>(fn: (database: MySqlTransaction) => Promise<T>): Promise<T> {
     this.#assertScopeOpen();
     if (this.#connection !== undefined) return this.#nested(fn);
     const connection = await this.#pool.getConnection();
@@ -360,6 +514,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         1,
         this.#prepared,
         this.#decoderPlans,
+        this.#observation,
         { active: undefined, batch: undefined, execute: undefined, discarded: false, usable: true },
       );
       result = await fn(transaction);
@@ -407,6 +562,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         depth,
         this.#prepared,
         this.#decoderPlans,
+        this.#observation,
         this.#transactionState,
       );
       const result = await fn(transaction);
@@ -532,5 +688,6 @@ export function createMySqlDatabase(options: MySqlDatabaseOptions): MySqlDatabas
     0,
     createMySqlPreparedQueryState(),
     new MySqlDecoderPlanCache(typePolicy, options.decimal),
+    createMySqlObservationState(options.observer),
   );
 }

--- a/packages/mysql/src/version.ts
+++ b/packages/mysql/src/version.ts
@@ -1,0 +1,1 @@
+export const MYSQL_DIALECT_VERSION = "1.0.0";

--- a/packages/mysql/test/execute-lifecycle.test.ts
+++ b/packages/mysql/test/execute-lifecycle.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart } from "@typed-sql/core";
 import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import {
@@ -101,7 +103,7 @@ class ExecutePool implements MySqlPoolLike {
   readonly connection = new ExecuteConnection();
 
   execute(): Promise<MySqlExecutionResult> {
-    throw new Error("transaction tests must use their leased connection");
+    return Promise.resolve(accountResult());
   }
 
   getConnection(): Promise<MySqlConnectionLike> {
@@ -116,6 +118,53 @@ class ExecutePool implements MySqlPoolLike {
 const nextTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 await describe("MySQL transaction execute ownership", async () => {
+  await it("emits redacted fingerprinted query, batch, and transaction lifecycles", async () => {
+    const starts: DatabaseOperationStart[] = [];
+    const ends: DatabaseOperationEnd[] = [];
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts.push(operation);
+        return { end: (completion) => ends.push(completion) };
+      },
+    };
+    const pool = new ExecutePool();
+    const database = createMySqlDatabase({ pool, observer });
+    const prepared = database.prepare("observed-account", () => accountQuery);
+    const query = prepared();
+    strict.deepStrictEqual(await database.one(query), { id: 1n });
+    await database.batch([query]);
+    await database.transaction(async (transaction) => {
+      await transaction.execute(query);
+      await transaction.transaction(async (nested) => nested.execute(query));
+    });
+
+    const expectedFingerprint = `sha256:${createHash("sha256")
+      .update("mysql\u00001.0.0\u0000SELECT id FROM accounts")
+      .digest("hex")}`;
+    strict.deepStrictEqual(
+      starts.map((operation) => operation.kind),
+      ["query", "batch", "transaction", "query", "transaction", "query"],
+    );
+    const first = starts[0];
+    if (first?.kind !== "query") strict.fail("Expected query observation");
+    strict.strictEqual(first.fingerprint, expectedFingerprint);
+    strict.strictEqual(first.cardinality, "one");
+    strict.strictEqual(first.prepared, true);
+    strict.deepStrictEqual(
+      starts.slice(2).map(({ transactionDepth }) => transactionDepth),
+      [1, 1, 2, 2],
+    );
+    for (const operation of starts) {
+      strict.ok(!("text" in operation));
+      strict.ok(!("values" in operation));
+    }
+    strict.deepStrictEqual(
+      ends.map(({ status }) => status),
+      ["success", "success", "success", "success", "success", "success"],
+    );
+    strict.strictEqual(ends[0]?.rowCount, 1);
+  });
+
   await it("cancels transaction work by destroying the lease without reusing or releasing it", async () => {
     const pool = new ExecutePool();
     const blocked = pool.connection.block("SELECT id FROM accounts");

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
-import { sql } from "@typed-sql/core";
+import { type DatabaseOperationEnd, sql } from "@typed-sql/core";
 import type { Pool } from "mysql2/promise";
 import { describe, it, strict } from "poku";
 import { adaptMySql2Pool, createMySql2Database, loadMySql2Driver, mysql2 } from "../src/mysql2.js";
@@ -118,7 +118,11 @@ function fakeDriver(pool: FakeRawPool): typeof import("mysql2/promise") {
 await describe("application-owned mysql2 integration", async () => {
   await it("cancels an in-flight query by destroying its checked-out mysql2 connection", async () => {
     const raw = new HangingRawPool();
-    const database = createMySqlDatabase({ pool: adaptMySql2Pool(raw as unknown as Pool) });
+    let completion: DatabaseOperationEnd | undefined;
+    const database = createMySqlDatabase({
+      pool: adaptMySql2Pool(raw as unknown as Pool),
+      observer: { start: () => ({ end: (event) => (completion = event) }) },
+    });
     const controller = new AbortController();
     const running = database.all(sql`SELECT SLEEP(10)`, { signal: controller.signal });
     while (raw.pooledConnection.executeCount === 0) await Promise.resolve();
@@ -133,6 +137,9 @@ await describe("application-owned mysql2 integration", async () => {
     strict.strictEqual(raw.getConnectionCount, 1);
     strict.strictEqual(raw.pooledConnection.destroyCount, 1);
     strict.strictEqual(raw.pooledConnection.released, false);
+    strict.strictEqual(completion?.status, "cancelled");
+    strict.strictEqual(completion?.cancellationReason, "signal");
+    strict.ok(!("cause" in completion!));
   });
 
   await it("rejects an already expired deadline without checking out a mysql2 connection", async () => {

--- a/packages/mysql/test/streaming.test.ts
+++ b/packages/mysql/test/streaming.test.ts
@@ -1,4 +1,4 @@
-import { type QueryStream, sql } from "@typed-sql/core";
+import { type DatabaseObserver, type DatabaseOperationEnd, type QueryStream, sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import {
   createMySqlDatabase,
@@ -131,6 +131,31 @@ class FakeStreamingPool implements MySqlPoolLike {
 const accountsQuery = sql.__typed<AccountRow, readonly [bigint]>()`SELECT id, active FROM accounts WHERE id >= ${1n}`;
 
 await describe("MySQL protocol streaming", async () => {
+  await it("starts observation lazily and ends it once after an early return", async () => {
+    const pool = new FakeStreamingPool();
+    const ends: DatabaseOperationEnd[] = [];
+    let starts = 0;
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts += 1;
+        strict.strictEqual(operation.kind, "stream");
+        return { end: (completion) => ends.push(completion) };
+      },
+    };
+    const stream = createMySqlDatabase({ pool, observer }).stream(accountsQuery);
+    strict.strictEqual(starts, 0);
+    strict.deepStrictEqual(await stream.next(), {
+      done: false,
+      value: { id: 9_007_199_254_740_993n, active: true },
+    });
+    strict.strictEqual(starts, 1);
+    await stream.return?.();
+    await stream.close();
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "success");
+    strict.strictEqual(ends[0]?.rowCount, 1);
+  });
+
   await it("is lazy, typed, decoded, bounded, and releases a root lease after natural completion", async () => {
     const pool = new FakeStreamingPool();
     const database = createMySqlDatabase({ pool });
@@ -328,9 +353,17 @@ await describe("MySQL protocol streaming", async () => {
 
   await it("rolls back leaked started and unstarted streams before commit", async () => {
     const startedPool = new FakeStreamingPool();
+    const ends: DatabaseOperationEnd[] = [];
     await strict.rejects(
       () =>
-        createMySqlDatabase({ pool: startedPool }).transaction(async (transaction) => {
+        createMySqlDatabase({
+          pool: startedPool,
+          observer: {
+            start() {
+              return { end: (event) => ends.push(event) };
+            },
+          },
+        }).transaction(async (transaction) => {
           await transaction.stream(accountsQuery).next();
         }),
       /returned with 1 active query stream/,
@@ -339,6 +372,11 @@ await describe("MySQL protocol streaming", async () => {
     strict.ok(
       startedPool.connection.commands.indexOf("STREAM CLOSE") < startedPool.connection.commands.indexOf("ROLLBACK"),
     );
+    strict.deepStrictEqual(
+      ends.map(({ status }) => status),
+      ["success", "error"],
+    );
+    strict.strictEqual(ends[0]?.rowCount, 1);
 
     const idlePool = new FakeStreamingPool();
     let escaped: QueryStream<AccountRow> | undefined;

--- a/packages/opentelemetry/.c8rc.json
+++ b/packages/opentelemetry/.c8rc.json
@@ -1,0 +1,12 @@
+{
+  "all": true,
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**"],
+  "reporter": ["text", "json-summary"],
+  "reports-dir": "../../coverage/opentelemetry",
+  "check-coverage": true,
+  "lines": 90,
+  "functions": 90,
+  "statements": 90,
+  "branches": 80
+}

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @typed-sql/opentelemetry
+
+## 1.0.0
+
+- Add an optional OpenTelemetry adapter for typed-sql's redacted database observation lifecycle.

--- a/packages/opentelemetry/LICENSE
+++ b/packages/opentelemetry/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 typed-sql contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -1,0 +1,29 @@
+# @typed-sql/opentelemetry
+
+Optional OpenTelemetry tracing for typed-sql's redacted database observer contract.
+
+This package has a stable public contract. The OpenTelemetry API is an application-owned peer;
+typed-sql does not install an SDK or exporter.
+
+```sh
+pnpm add @typed-sql/opentelemetry @opentelemetry/api
+```
+
+```ts
+import { createOpenTelemetryObserver } from "@typed-sql/opentelemetry";
+import { createPgDatabase } from "@typed-sql/postgres/pg";
+
+const database = await createPgDatabase({
+  connectionString: process.env.DATABASE_URL!,
+  observer: createOpenTelemetryObserver(),
+});
+```
+
+The default attributes contain a stable query fingerprint, dialect, grammar version, execution kind,
+cardinality contract, and transaction depth. SQL text, parameter values, connection strings, driver
+errors, batch fingerprint lists, and returned-row counts are excluded by default.
+
+See the [observability guide](../../docs/guides/observability.md) for lifecycle semantics, opt-ins,
+custom observers, and complete tracing setup.
+
+MIT © typed-sql contributors

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@typed-sql/opentelemetry",
+  "version": "1.0.0",
+  "description": "Optional OpenTelemetry tracing integration for typed-sql database observers.",
+  "license": "MIT",
+  "author": "Lojhan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lojhan/typed-sql.git",
+    "directory": "packages/opentelemetry"
+  },
+  "homepage": "https://github.com/Lojhan/typed-sql#readme",
+  "bugs": {
+    "url": "https://github.com/Lojhan/typed-sql/issues"
+  },
+  "engines": {
+    "node": ">=22.11"
+  },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.map",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "typedSql": {
+    "releaseTrack": "stable"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "test": "poku test --reporter=compact --enforce",
+    "coverage": "poku test --coverage=@pokujs/c8 --coverageConfig=.c8rc.json --reporter=compact --enforce"
+  },
+  "exports": {
+    ".": "./dist/packages/opentelemetry/src/index.js"
+  },
+  "dependencies": {
+    "@typed-sql/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.9.0 <2"
+  }
+}

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,0 +1,102 @@
+import { type Attributes, context, type Span, SpanKind, SpanStatusCode, type Tracer, trace } from "@opentelemetry/api";
+import type {
+  DatabaseObservation,
+  DatabaseObserver,
+  DatabaseOperationEnd,
+  DatabaseOperationStart,
+} from "@typed-sql/core";
+
+export interface OpenTelemetryObserverOptions {
+  readonly tracer?: Tracer;
+  readonly instrumentationName?: string;
+  readonly instrumentationVersion?: string;
+  /** Opt-in because database row counts are an opt-in OpenTelemetry attribute. */
+  readonly recordReturnedRows?: boolean;
+  /** Opt-in because driver errors can contain query text or values. */
+  readonly recordExceptions?: boolean;
+  /** Opt-in because a fingerprint list can be high-cardinality for dynamic batches. */
+  readonly recordBatchFingerprints?: boolean;
+}
+
+function databaseSystem(dialect: string): string {
+  if (dialect === "postgres") return "postgresql";
+  return dialect;
+}
+
+function spanName(operation: DatabaseOperationStart): string {
+  const system = databaseSystem(operation.dialect);
+  if (operation.kind === "batch") return `BATCH ${system}`;
+  if (operation.kind === "pipeline") return `PIPELINE ${system}`;
+  if (operation.kind === "transaction") return `TRANSACTION ${system}`;
+  return system;
+}
+
+function startAttributes(operation: DatabaseOperationStart, options: OpenTelemetryObserverOptions): Attributes {
+  const attributes: Attributes = {
+    "db.system.name": databaseSystem(operation.dialect),
+    "typed_sql.grammar.version": operation.grammarVersion,
+    "typed_sql.operation.kind": operation.kind,
+    "typed_sql.transaction.depth": operation.transactionDepth,
+  };
+  if (operation.kind === "query") {
+    attributes["typed_sql.query.fingerprint"] = operation.fingerprint;
+    attributes["typed_sql.query.cardinality"] = operation.cardinality;
+    attributes["typed_sql.query.prepared"] = operation.prepared;
+  } else if (operation.kind === "stream") {
+    attributes["typed_sql.query.fingerprint"] = operation.fingerprint;
+    attributes["typed_sql.query.prepared"] = operation.prepared;
+  } else if (operation.kind === "batch" || operation.kind === "pipeline") {
+    attributes["db.operation.name"] = operation.kind === "batch" ? "BATCH" : "PIPELINE";
+    attributes["db.operation.batch.size"] = operation.size;
+    if (options.recordBatchFingerprints === true) {
+      attributes["typed_sql.query.fingerprints"] = [...operation.fingerprints];
+    }
+  } else attributes["db.operation.name"] = "TRANSACTION";
+  return attributes;
+}
+
+function endSpan(span: Span, completion: DatabaseOperationEnd, options: OpenTelemetryObserverOptions): void {
+  span.setAttribute("typed_sql.duration_ms", completion.durationMilliseconds);
+  if (options.recordReturnedRows === true && completion.rowCount !== undefined) {
+    span.setAttribute("db.response.returned_rows", completion.rowCount);
+  }
+  if (completion.status !== "success") {
+    const errorType =
+      completion.cancellationReason === "deadline"
+        ? "timeout"
+        : completion.cancellationReason === "signal"
+          ? "cancelled"
+          : (completion.errorType ?? "unknown");
+    span.setAttribute("error.type", errorType);
+    if (completion.cancellationReason !== undefined) {
+      span.setAttribute("typed_sql.cancellation.reason", completion.cancellationReason);
+    }
+    if (options.recordExceptions === true && completion.cause instanceof Error) span.recordException(completion.cause);
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+  span.end();
+}
+
+export function createOpenTelemetryObserver(options: OpenTelemetryObserverOptions = {}): DatabaseObserver {
+  const tracer =
+    options.tracer ??
+    trace.getTracer(options.instrumentationName ?? "@typed-sql/opentelemetry", options.instrumentationVersion);
+  return Object.freeze({
+    captureErrorCause: options.recordExceptions === true,
+    start(operation: DatabaseOperationStart): DatabaseObservation {
+      const span = tracer.startSpan(spanName(operation), {
+        kind: SpanKind.CLIENT,
+        attributes: startAttributes(operation, options),
+      });
+      const active = trace.setSpan(context.active(), span);
+      return {
+        run<Value>(callback: () => Value): Value {
+          return context.with(active, callback);
+        },
+        end(completion: DatabaseOperationEnd): void {
+          endSpan(span, completion, options);
+        },
+      };
+    },
+  });
+}

--- a/packages/opentelemetry/test/opentelemetry.test.ts
+++ b/packages/opentelemetry/test/opentelemetry.test.ts
@@ -1,0 +1,208 @@
+import {
+  type Attributes,
+  type Span,
+  SpanKind,
+  type SpanOptions,
+  SpanStatusCode,
+  type Tracer,
+} from "@opentelemetry/api";
+import { describe, it, strict } from "poku";
+import { startDatabaseObservation } from "../../core/src/index.js";
+import { createOpenTelemetryObserver } from "../src/index.js";
+
+class FakeSpan {
+  readonly attributes: Record<string, unknown> = {};
+  readonly exceptions: unknown[] = [];
+  status: unknown;
+  endCount = 0;
+
+  setAttribute(name: string, value: unknown): this {
+    this.attributes[name] = value;
+    return this;
+  }
+
+  recordException(error: unknown): void {
+    this.exceptions.push(error);
+  }
+
+  setStatus(status: unknown): this {
+    this.status = status;
+    return this;
+  }
+
+  end(): void {
+    this.endCount += 1;
+  }
+}
+
+class FakeTracer {
+  readonly starts: { readonly name: string; readonly options?: SpanOptions; readonly span: FakeSpan }[] = [];
+
+  startSpan(name: string, options?: SpanOptions): Span {
+    const span = new FakeSpan();
+    Object.assign(span.attributes, options?.attributes as Attributes | undefined);
+    this.starts.push({ name, ...(options === undefined ? {} : { options }), span });
+    return span as unknown as Span;
+  }
+}
+
+await describe("OpenTelemetry database observer", async () => {
+  await it("emits stable database attributes without SQL, values, or batch fingerprints by default", () => {
+    const tracer = new FakeTracer();
+    const observer = createOpenTelemetryObserver({ tracer: tracer as unknown as Tracer });
+    const observation = startDatabaseObservation(observer, {
+      kind: "query",
+      dialect: "postgres",
+      grammarVersion: "1.0.0",
+      transactionDepth: 0,
+      fingerprint: "sha256:account",
+      cardinality: "one",
+      prepared: true,
+    })!;
+    strict.strictEqual(
+      observation.run(() => "active"),
+      "active",
+    );
+    observation.end({ status: "success", rowCount: 1 });
+
+    const started = tracer.starts[0]!;
+    strict.strictEqual(started.name, "postgresql");
+    strict.strictEqual(started.options?.kind, SpanKind.CLIENT);
+    strict.strictEqual(started.span.attributes["db.system.name"], "postgresql");
+    strict.strictEqual(started.span.attributes["typed_sql.query.fingerprint"], "sha256:account");
+    strict.strictEqual(started.span.attributes["typed_sql.query.cardinality"], "one");
+    strict.ok(!("db.query.text" in started.span.attributes));
+    strict.ok(!Object.keys(started.span.attributes).some((name) => name.includes("parameter")));
+    strict.ok(!("db.response.returned_rows" in started.span.attributes));
+    strict.strictEqual(started.span.endCount, 1);
+  });
+
+  await it("records sanitized cancellation and opt-in exception or row details", () => {
+    const tracer = new FakeTracer();
+    const observer = createOpenTelemetryObserver({
+      tracer: tracer as unknown as Tracer,
+      recordExceptions: true,
+      recordReturnedRows: true,
+    });
+    const failure = new Error("driver may include sensitive SQL");
+    const observation = startDatabaseObservation(observer, {
+      kind: "stream",
+      dialect: "mysql",
+      grammarVersion: "1.0.0",
+      transactionDepth: 1,
+      fingerprint: "sha256:stream",
+      prepared: false,
+    })!;
+    observation.end(
+      { status: "cancelled", errorType: "TSQL_CANCELLED", cancellationReason: "deadline", rowCount: 4 },
+      failure,
+    );
+
+    const span = tracer.starts[0]!.span;
+    strict.strictEqual(span.attributes["error.type"], "timeout");
+    strict.strictEqual(span.attributes["typed_sql.cancellation.reason"], "deadline");
+    strict.strictEqual(span.attributes["db.response.returned_rows"], 4);
+    strict.deepStrictEqual(span.exceptions, [failure]);
+    strict.deepStrictEqual(span.status, { code: SpanStatusCode.ERROR });
+    strict.strictEqual(span.endCount, 1);
+  });
+
+  await it("uses batch conventions while keeping fingerprint arrays opt-in", () => {
+    const tracer = new FakeTracer();
+    const observation = startDatabaseObservation(
+      createOpenTelemetryObserver({ tracer: tracer as unknown as Tracer, recordBatchFingerprints: true }),
+      {
+        kind: "batch",
+        dialect: "mysql",
+        grammarVersion: "1.0.0",
+        transactionDepth: 0,
+        fingerprints: ["sha256:a", "sha256:b"],
+        size: 2,
+      },
+    )!;
+    observation.end({ status: "success" });
+    const started = tracer.starts[0]!;
+    strict.strictEqual(started.name, "BATCH mysql");
+    strict.strictEqual(started.span.attributes["db.operation.name"], "BATCH");
+    strict.strictEqual(started.span.attributes["db.operation.batch.size"], 2);
+    strict.deepStrictEqual(started.span.attributes["typed_sql.query.fingerprints"], ["sha256:a", "sha256:b"]);
+  });
+
+  await it("names pipeline and transaction spans without query text", () => {
+    const tracer = new FakeTracer();
+    const observer = createOpenTelemetryObserver({ tracer: tracer as unknown as Tracer });
+    const pipeline = startDatabaseObservation(observer, {
+      kind: "pipeline",
+      dialect: "postgres",
+      grammarVersion: "1.0.0",
+      transactionDepth: 0,
+      fingerprints: ["sha256:a"],
+      size: 1,
+    })!;
+    pipeline.end({ status: "success" });
+    const transaction = startDatabaseObservation(observer, {
+      kind: "transaction",
+      dialect: "mysql",
+      grammarVersion: "1.0.0",
+      transactionDepth: 1,
+    })!;
+    transaction.end({ status: "success" });
+
+    strict.deepStrictEqual(
+      tracer.starts.map(({ name }) => name),
+      ["PIPELINE postgresql", "TRANSACTION mysql"],
+    );
+    strict.strictEqual(tracer.starts[0]?.span.attributes["db.operation.name"], "PIPELINE");
+    strict.strictEqual(tracer.starts[1]?.span.attributes["db.operation.name"], "TRANSACTION");
+  });
+
+  await it("maps signal and ordinary errors to stable error.type values", () => {
+    const tracer = new FakeTracer();
+    const observer = createOpenTelemetryObserver({
+      tracer: tracer as unknown as Tracer,
+      recordExceptions: true,
+    });
+    const operation = {
+      kind: "query",
+      dialect: "mysql",
+      grammarVersion: "1.0.0",
+      transactionDepth: 0,
+      fingerprint: "sha256:error",
+      cardinality: "many",
+      prepared: false,
+    } as const;
+    startDatabaseObservation(observer, operation)!.end({
+      status: "cancelled",
+      errorType: "TSQL_CANCELLED",
+      cancellationReason: "signal",
+    });
+    startDatabaseObservation(observer, operation)!.end({ status: "error", errorType: "ER_LOCK_DEADLOCK" }, "safe");
+    startDatabaseObservation(observer, operation)!.end({ status: "error" });
+
+    strict.strictEqual(tracer.starts[0]?.span.attributes["error.type"], "cancelled");
+    strict.strictEqual(tracer.starts[1]?.span.attributes["error.type"], "ER_LOCK_DEADLOCK");
+    strict.strictEqual(tracer.starts[2]?.span.attributes["error.type"], "unknown");
+    strict.deepStrictEqual(
+      tracer.starts.flatMap(({ span }) => span.exceptions),
+      [],
+    );
+  });
+
+  await it("uses the globally registered no-op tracer when none is supplied", () => {
+    const observer = createOpenTelemetryObserver({
+      instrumentationName: "typed-sql-test",
+      instrumentationVersion: "1.0.0",
+    });
+    const observation = startDatabaseObservation(observer, {
+      kind: "transaction",
+      dialect: "synthetic",
+      grammarVersion: "1",
+      transactionDepth: 1,
+    })!;
+    strict.strictEqual(
+      observation.run(() => 42),
+      42,
+    );
+    observation.end({ status: "success" });
+  });
+});

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -30,6 +30,7 @@ const database = await createPgDatabase({
   connectionString: process.env.DATABASE_URL!,
   poolConfig: { pipeline: true },
   typePolicy,
+  // observer: createOpenTelemetryObserver(),
 });
 
 // pipeline() requires the application-owned pg 8.23.0 or newer.
@@ -56,6 +57,7 @@ rendering and codecs.
 
 Read the [PostgreSQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/postgresql.md),
 [execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
+[observability guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/observability.md),
 [configuration](https://github.com/Lojhan/typed-sql/blob/main/docs/getting-started/configuration.md), and
 [database type mappings](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/type-mappings.md).
 

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -4,8 +4,9 @@ import { parseSchemaSnapshot, type SchemaSnapshot } from "@typed-sql/schema";
 import { resolveStatement } from "./resolver.js";
 import { analyzePostgresSemantics } from "./semantics.js";
 import { defaultPostgresTypePolicy, type PostgresTypePolicy } from "./type-policy.js";
+import { POSTGRES_DIALECT_VERSION } from "./version.js";
 
-export const POSTGRES_DIALECT_VERSION = "1.0.0";
+export { POSTGRES_DIALECT_VERSION } from "./version.js";
 
 export type PostgresSchemaSnapshot = SchemaSnapshot & { readonly dialect: "postgres" };
 export interface PostgresDialectOptions {

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -1,3 +1,4 @@
+import type { DatabaseObserver } from "@typed-sql/core";
 import type { Pool as PgPool, PoolClient, PoolConfig, QueryConfig } from "pg";
 import type { PostgresSchemaSnapshot, PostgresTypePolicy } from "./index.js";
 import { type PostgresQueryable, PostgresSchemaProvider } from "./provider.js";
@@ -65,6 +66,7 @@ export interface PgOptions {
   readonly decimal?: (value: string) => unknown;
   /** Host-injected loader for workspaces or runtimes with nonstandard package resolution. */
   readonly cursorImporter?: PgCursorImporter;
+  readonly observer?: DatabaseObserver;
 }
 
 export interface PgSchemaProviderOptions {
@@ -229,6 +231,7 @@ export async function createPgDatabase(options: PgOptions): Promise<PostgresData
     fallbackTypeParsers: driver.types,
     ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),
     ...(options.decimal === undefined ? {} : { decimal: options.decimal }),
+    ...(options.observer === undefined ? {} : { observer: options.observer }),
   });
 }
 

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,8 +1,12 @@
+import { createHash } from "node:crypto";
 import {
   assertExecutionCapabilities,
   type Database,
+  type DatabaseObserver,
+  databaseErrorCompletion,
   type ExecutionCapabilities,
   type ExecutionOptions,
+  observeQueryStream,
   type Query,
   type QueryBatch,
   type QueryCancelledError,
@@ -13,6 +17,7 @@ import {
   runControlledExecution,
   type SqlRenderer,
   type StreamOptions,
+  startDatabaseObservation,
 } from "@typed-sql/core";
 import {
   createPostgresPreparedQueryState,
@@ -22,6 +27,7 @@ import {
 } from "./prepared.js";
 import { type PostgresCursorLike, PostgresQueryStream, validatePostgresStreamBatchSize } from "./stream.js";
 import { defaultPostgresTypePolicy } from "./type-policy.js";
+import { POSTGRES_DIALECT_VERSION } from "./version.js";
 
 export type { PostgresPreparedQueryFactory } from "./prepared.js";
 export type { PostgresCursorLike } from "./stream.js";
@@ -91,10 +97,35 @@ export interface PostgresDatabaseOptions {
   readonly decimal?: (value: string) => unknown;
   /** Native driver parsers used for types that typed-sql does not override. */
   readonly fallbackTypeParsers?: PostgresTypeParserSet;
+  readonly observer?: DatabaseObserver;
 }
 
 const defaultPolicy: PostgresCodecPolicy = defaultPostgresTypePolicy;
 const emptyBatchResults = Object.freeze([]);
+
+interface PostgresObservationState {
+  readonly observer: DatabaseObserver | undefined;
+  readonly fingerprints: WeakMap<Query<unknown, readonly unknown[]>, string> | undefined;
+}
+
+function createPostgresObservationState(observer: DatabaseObserver | undefined): PostgresObservationState {
+  return { observer, fingerprints: observer === undefined ? undefined : new WeakMap() };
+}
+
+function postgresQueryFingerprint<Row, Params extends readonly unknown[]>(
+  state: PostgresObservationState,
+  query: Query<Row, Params>,
+): string {
+  const key = query as unknown as Query<unknown, readonly unknown[]>;
+  const cached = state.fingerprints!.get(key);
+  if (cached !== undefined) return cached;
+  const text = renderQuery(query, postgresRenderer).text;
+  const fingerprint = `sha256:${createHash("sha256")
+    .update(`postgres\0${POSTGRES_DIALECT_VERSION}\0${text}`)
+    .digest("hex")}`;
+  state.fingerprints!.set(key, fingerprint);
+  return fingerprint;
+}
 
 const oids = {
   int8: 20,
@@ -211,6 +242,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #parsers: PostgresTypeParserSet;
   readonly #ownsPool: boolean;
   readonly #prepared: PostgresPreparedQueryState;
+  readonly #observation: PostgresObservationState;
   readonly #transactionDepth: number;
   #transactionScopeOpen = true;
   #transactionOperationFailed = false;
@@ -239,6 +271,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     ownsPool: boolean,
     depth: number,
     prepared: PostgresPreparedQueryState,
+    observation: PostgresObservationState,
     transactionState = {
       activeBatch: undefined as Promise<unknown> | undefined,
       activeExecutes: new Set<Promise<unknown>>(),
@@ -259,6 +292,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#ownsPool = ownsPool;
     this.#transactionDepth = depth;
     this.#prepared = prepared;
+    this.#observation = observation;
     this.#transactionState = transactionState;
     this.executionCapabilities = Object.freeze({
       cancellation: pool.executionCapabilities?.cancellation ?? false,
@@ -267,6 +301,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return this.#executeUnobserved(query);
+    return this.#observeQuery(query, "many", () => this.#executeUnobserved(query));
+  }
+
+  async #executeUnobserved<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute another query");
     this.#rejectOperationDuringTransactionBatch("execute another query");
@@ -299,8 +338,16 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return this.#allUnobserved(query, options);
+    return this.#observeQuery(query, "many", () => this.#allUnobserved(query, options));
+  }
+
+  async #allUnobserved<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    options?: ExecutionOptions,
+  ): Promise<readonly Row[]> {
     if (options === undefined || (options.signal === undefined && options.deadline === undefined))
-      return this.execute(query);
+      return this.#executeUnobserved(query);
     assertExecutionCapabilities(this.executionCapabilities, options);
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute another query");
@@ -365,8 +412,16 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<Row> {
-    const rows = await this.all(query, options);
-    if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
+    if (this.#observation.observer === undefined) {
+      const rows = await this.#allUnobserved(query, options);
+      if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
+      return rows[0]!;
+    }
+    const rows = await this.#observeQuery(query, "one", async () => {
+      const result = await this.#allUnobserved(query, options);
+      if (result.length !== 1) throw new QueryCardinalityError("one", result.length);
+      return result;
+    });
     return rows[0]!;
   }
 
@@ -374,12 +429,54 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<Row | undefined> {
-    const rows = await this.all(query, options);
-    if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
+    if (this.#observation.observer === undefined) {
+      const rows = await this.#allUnobserved(query, options);
+      if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
+      return rows[0];
+    }
+    const rows = await this.#observeQuery(query, "maybeOne", async () => {
+      const result = await this.#allUnobserved(query, options);
+      if (result.length > 1) throw new QueryCardinalityError("maybeOne", result.length);
+      return result;
+    });
     return rows[0];
   }
 
+  async #observeQuery<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    cardinality: "many" | "one" | "maybeOne",
+    operation: () => Promise<readonly Row[]>,
+  ): Promise<readonly Row[]> {
+    if (this.#observation.observer === undefined) return operation();
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind: "query",
+      dialect: "postgres",
+      grammarVersion: POSTGRES_DIALECT_VERSION,
+      transactionDepth: this.#transactionDepth,
+      fingerprint: postgresQueryFingerprint(this.#observation, query),
+      cardinality,
+      prepared: this.#prepared.queries.has(query),
+    });
+    if (observation === undefined) return operation();
+    try {
+      const rows = await observation.run(operation);
+      observation.end({ status: "success", rowCount: rows.length });
+      return rows;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
+  }
+
   async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
+    if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
+    if (this.#observation.observer === undefined) return this.#batchUnobserved(queries);
+    return this.#observeGroup("batch", queries, () => this.#batchUnobserved(queries));
+  }
+
+  async #batchUnobserved<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+  ): Promise<QueryResults<Queries>> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute a query batch");
     this.#rejectOperationDuringTransactionBatch("execute another query batch");
@@ -416,6 +513,14 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   }
 
   async pipeline<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+  ): Promise<QueryResults<Queries>> {
+    if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
+    if (this.#observation.observer === undefined) return this.#pipelineUnobserved(queries);
+    return this.#observeGroup("pipeline", queries, () => this.#pipelineUnobserved(queries));
+  }
+
+  async #pipelineUnobserved<const Queries extends readonly unknown[]>(
     queries: QueryBatch<Queries>,
   ): Promise<QueryResults<Queries>> {
     this.#assertTransactionScopeOpen();
@@ -466,6 +571,36 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     }
   }
 
+  async #observeGroup<const Queries extends readonly unknown[]>(
+    kind: "batch" | "pipeline",
+    queries: QueryBatch<Queries>,
+    operation: () => Promise<QueryResults<Queries>>,
+  ): Promise<QueryResults<Queries>> {
+    if (this.#observation.observer === undefined) return operation();
+    const fingerprints = Object.freeze(
+      [...queries].map((query) =>
+        postgresQueryFingerprint(this.#observation, query as unknown as Query<unknown, readonly unknown[]>),
+      ),
+    );
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind,
+      dialect: "postgres",
+      grammarVersion: POSTGRES_DIALECT_VERSION,
+      transactionDepth: this.#transactionDepth,
+      fingerprints,
+      size: queries.length,
+    });
+    if (observation === undefined) return operation();
+    try {
+      const results = await observation.run(operation);
+      observation.end({ status: "success" });
+      return results;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
+  }
+
   stream<Row, Params extends readonly unknown[]>(
     query: Query<Row, Params>,
     options: StreamOptions = {},
@@ -476,8 +611,8 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#rejectOperationDuringTransactionPipeline("start a query stream");
     const batchSize = validatePostgresStreamBatchSize(options.batchSize);
     const config = this.#queryConfig(query);
-    let stream: QueryStream<Row>;
-    stream = new PostgresQueryStream<Row>({
+    let exposedStream: QueryStream<Row>;
+    const stream: QueryStream<Row> = new PostgresQueryStream<Row>({
       batchSize,
       start: async () => {
         await this.#pool.ensureCursor?.();
@@ -520,17 +655,28 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
               this.#rejectOperationDuringTransactionStream("start another query stream");
               this.#rejectOperationDuringTransactionBatch("start a query stream");
               this.#rejectOperationDuringTransactionPipeline("start a query stream");
-              this.#transactionState.activeStreams.add(stream as QueryStream<unknown>);
+              this.#transactionState.activeStreams.add(exposedStream as QueryStream<unknown>);
             },
             onClose: () => {
-              this.#transactionState.activeStreams.delete(stream as QueryStream<unknown>);
-              this.#transactionStreams.delete(stream as QueryStream<unknown>);
+              this.#transactionState.activeStreams.delete(exposedStream as QueryStream<unknown>);
+              this.#transactionStreams.delete(exposedStream as QueryStream<unknown>);
             },
             onError: (error: unknown) => this.#recordTransactionOperationFailure(error),
           }),
     });
-    if (this.#client !== undefined) this.#transactionStreams.add(stream as QueryStream<unknown>);
-    return stream;
+    exposedStream =
+      this.#observation.observer === undefined
+        ? stream
+        : observeQueryStream(stream, this.#observation.observer, {
+            kind: "stream",
+            dialect: "postgres",
+            grammarVersion: POSTGRES_DIALECT_VERSION,
+            transactionDepth: this.#transactionDepth,
+            fingerprint: postgresQueryFingerprint(this.#observation, query),
+            prepared: this.#prepared.queries.has(query),
+          });
+    if (this.#client !== undefined) this.#transactionStreams.add(exposedStream as QueryStream<unknown>);
+    return exposedStream;
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
@@ -542,25 +688,53 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   }
 
   async transaction<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
+    if (this.#observation.observer === undefined) return this.#transactionUnobserved(fn);
+    const observation = startDatabaseObservation(this.#observation.observer, {
+      kind: "transaction",
+      dialect: "postgres",
+      grammarVersion: POSTGRES_DIALECT_VERSION,
+      transactionDepth: this.#transactionDepth + 1,
+    });
+    if (observation === undefined) return this.#transactionUnobserved(fn);
+    try {
+      const result = await observation.run(() => this.#transactionUnobserved(fn));
+      observation.end({ status: "success" });
+      return result;
+    } catch (error) {
+      observation.end(databaseErrorCompletion(error), error);
+      throw error;
+    }
+  }
+
+  async #transactionUnobserved<T>(fn: (db: PostgresTransaction) => Promise<T>): Promise<T> {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("start a nested transaction");
     this.#rejectOperationDuringTransactionBatch("start a nested transaction");
     this.#rejectOperationDuringTransactionPipeline("start a nested transaction");
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
-    const scope = new PostgresDatabaseImplementation(this.#pool, client, this.#parsers, false, 1, this.#prepared, {
-      activeBatch: undefined,
-      activeExecutes: new Set(),
-      activePipeline: undefined,
-      activeStreams: new Set(),
-      discardLease: false,
-      leaseReleased: false,
-      firstDatabaseOperationError: undefined,
-      unsafe: false,
-      unsafeDepth: undefined,
-      unsafeError: undefined,
-      valid: true,
-    });
+    const scope = new PostgresDatabaseImplementation(
+      this.#pool,
+      client,
+      this.#parsers,
+      false,
+      1,
+      this.#prepared,
+      this.#observation,
+      {
+        activeBatch: undefined,
+        activeExecutes: new Set(),
+        activePipeline: undefined,
+        activeStreams: new Set(),
+        discardLease: false,
+        leaseReleased: false,
+        firstDatabaseOperationError: undefined,
+        unsafe: false,
+        unsafeDepth: undefined,
+        unsafeError: undefined,
+        valid: true,
+      },
+    );
     let result: T;
     try {
       try {
@@ -626,6 +800,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       false,
       depth,
       this.#prepared,
+      this.#observation,
       this.#transactionState,
     );
     try {
@@ -908,5 +1083,6 @@ export function createPostgresDatabase(options: PostgresDatabaseOptions): Postgr
     options.ownsPool ?? false,
     0,
     createPostgresPreparedQueryState(),
+    createPostgresObservationState(options.observer),
   );
 }

--- a/packages/postgres/src/version.ts
+++ b/packages/postgres/src/version.ts
@@ -1,0 +1,1 @@
+export const POSTGRES_DIALECT_VERSION = "1.0.0";

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { Pool as PgPool } from "pg";
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
+import { type DatabaseOperationEnd, sql } from "../../core/src/index.js";
 import { adaptPgPool, createPgDatabase, loadPgCursorDriver, loadPgDriver, type PgOptions, pg } from "../src/pg.js";
 import type { PostgresQueryable, PostgresQueryResult } from "../src/provider.js";
 import { createPostgresDatabase, type PostgresQueryConfig } from "../src/runtime.js";
@@ -129,7 +129,11 @@ class HangingPgPool {
 await describe("application-owned pg integration", async () => {
   await it("cancels an in-flight query by discarding its checked-out pg lease", async () => {
     const raw = new HangingPgPool();
-    const database = createPostgresDatabase({ pool: adaptPgPool(raw as unknown as PgPool) });
+    let completion: DatabaseOperationEnd | undefined;
+    const database = createPostgresDatabase({
+      pool: adaptPgPool(raw as unknown as PgPool),
+      observer: { start: () => ({ end: (event) => (completion = event) }) },
+    });
     const controller = new AbortController();
     const running = database.all(sql`SELECT pg_sleep(10)`, { signal: controller.signal });
     while (raw.client.calls.length === 0) await Promise.resolve();
@@ -144,6 +148,9 @@ await describe("application-owned pg integration", async () => {
     strict.strictEqual(raw.connectCount, 1);
     strict.strictEqual(raw.client.releaseCount, 1);
     strict.ok(raw.client.releaseError instanceof Error);
+    strict.strictEqual(completion?.status, "cancelled");
+    strict.strictEqual(completion?.cancellationReason, "signal");
+    strict.ok(!("cause" in completion!));
   });
 
   await it("rejects an already expired deadline without checking out a pg lease", async () => {

--- a/packages/postgres/test/pipeline.test.ts
+++ b/packages/postgres/test/pipeline.test.ts
@@ -1,4 +1,10 @@
-import type { Query, QueryResults } from "@typed-sql/core";
+import type {
+  DatabaseObserver,
+  DatabaseOperationEnd,
+  DatabaseOperationStart,
+  Query,
+  QueryResults,
+} from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import { sql } from "../../core/src/index.js";
 import {
@@ -179,6 +185,30 @@ await describe("PostgreSQL query pipelines", async () => {
     pool.client.resolve("SELECT second", [{ value: "second" }]);
     strict.deepStrictEqual(await result, [[{ value: "first" }], [{ value: "second" }], [{ value: "third" }]]);
     strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("emits one redacted pipeline lifecycle for the whole group", async () => {
+    const starts: DatabaseOperationStart[] = [];
+    const ends: DatabaseOperationEnd[] = [];
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts.push(operation);
+        return { end: (completion) => ends.push(completion) };
+      },
+    };
+    const pool = new PipelinePool();
+    const results = await createPostgresDatabase({ pool, observer }).pipeline([accountQuery, projectQuery]);
+    strict.deepStrictEqual(results, [[], []]);
+    strict.strictEqual(starts.length, 1);
+    const start = starts[0];
+    if (start?.kind !== "pipeline") strict.fail("Expected a pipeline observation");
+    strict.strictEqual(start.size, 2);
+    strict.strictEqual(start.fingerprints.length, 2);
+    strict.ok(start.fingerprints.every((fingerprint) => /^sha256:[a-f0-9]{64}$/u.test(fingerprint)));
+    strict.ok(!("text" in start));
+    strict.ok(!("values" in start));
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "success");
   });
 
   await it("waits for every in-flight query and reports the first input-order rejection", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -1,5 +1,14 @@
+import { createHash } from "node:crypto";
 import { describe, it, strict } from "poku";
-import { type Query, type QueryParameters, type QueryRow, sql } from "../../core/src/index.js";
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  type DatabaseOperationStart,
+  type Query,
+  type QueryParameters,
+  type QueryRow,
+  sql,
+} from "../../core/src/index.js";
 import {
   createPostgresDatabase,
   createPostgresTypeParsers,
@@ -104,6 +113,52 @@ class MockPool implements PostgresPoolLike {
 }
 
 await describe("PostgreSQL runtime adapter", async () => {
+  await it("emits redacted fingerprinted query, batch, and transaction lifecycles", async () => {
+    const starts: DatabaseOperationStart[] = [];
+    const ends: DatabaseOperationEnd[] = [];
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts.push(operation);
+        return { end: (completion) => ends.push(completion) };
+      },
+    };
+    const database = createPostgresDatabase({ pool: new MockPool(), observer });
+    const prepared = database.prepare("observed-account", () => sql<{ id: number }>`SELECT id FROM users`);
+    const query = prepared();
+    strict.deepStrictEqual(await database.one(query), { id: 1 });
+    await database.batch([query]);
+    await database.transaction(async (transaction) => {
+      await transaction.execute(query);
+      await transaction.transaction(async (nested) => nested.execute(query));
+    });
+
+    const expectedFingerprint = `sha256:${createHash("sha256")
+      .update("postgres\u00001.0.0\u0000SELECT id FROM users")
+      .digest("hex")}`;
+    strict.deepStrictEqual(
+      starts.map((operation) => operation.kind),
+      ["query", "batch", "transaction", "query", "transaction", "query"],
+    );
+    const first = starts[0];
+    if (first?.kind !== "query") strict.fail("Expected query observation");
+    strict.strictEqual(first.fingerprint, expectedFingerprint);
+    strict.strictEqual(first.cardinality, "one");
+    strict.strictEqual(first.prepared, true);
+    strict.deepStrictEqual(
+      starts.slice(2).map(({ transactionDepth }) => transactionDepth),
+      [1, 1, 2, 2],
+    );
+    for (const operation of starts) {
+      strict.ok(!("text" in operation));
+      strict.ok(!("values" in operation));
+    }
+    strict.deepStrictEqual(
+      ends.map(({ status }) => status),
+      ["success", "success", "success", "success", "success", "success"],
+    );
+    strict.strictEqual(ends[0]?.rowCount, 1);
+  });
+
   await it("cancels transaction work by discarding the lease without attempting rollback on it", async () => {
     const pool = new MockPool();
     pool.client.blockedText = "SELECT id FROM accounts";

--- a/packages/postgres/test/stream.test.ts
+++ b/packages/postgres/test/stream.test.ts
@@ -1,4 +1,4 @@
-import type { QueryStream } from "@typed-sql/core";
+import type { DatabaseObserver, DatabaseOperationEnd, QueryStream } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import { sql } from "../../core/src/index.js";
 import {
@@ -92,6 +92,28 @@ function commands(client: FakeClient): string[] {
 }
 
 await describe("PostgreSQL query streams", async () => {
+  await it("starts observation lazily and ends it once after an early return", async () => {
+    const pool = new FakePool();
+    const ends: DatabaseOperationEnd[] = [];
+    let starts = 0;
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts += 1;
+        strict.strictEqual(operation.kind, "stream");
+        return { end: (completion) => ends.push(completion) };
+      },
+    };
+    const stream = createPostgresDatabase({ pool, observer }).stream(sql<{ id: number }>`SELECT id FROM account`);
+    strict.strictEqual(starts, 0);
+    strict.deepStrictEqual(await stream.next(), { done: false, value: { id: 1 } });
+    strict.strictEqual(starts, 1);
+    await stream.return?.();
+    await stream.close();
+    strict.strictEqual(ends.length, 1);
+    strict.strictEqual(ends[0]?.status, "success");
+    strict.strictEqual(ends[0]?.rowCount, 1);
+  });
+
   await it("is lazy, retains the row type, fetches bounded pages, and releases once on completion", async () => {
     const pool = new FakePool();
     const database = createPostgresDatabase({ pool });
@@ -453,7 +475,15 @@ await describe("PostgreSQL transaction query streams", async () => {
 
   await it("closes a leaked started stream and rolls back instead of committing", async () => {
     const pool = new FakePool();
-    const database = createPostgresDatabase({ pool });
+    const ends: DatabaseOperationEnd[] = [];
+    const database = createPostgresDatabase({
+      pool,
+      observer: {
+        start() {
+          return { end: (event) => ends.push(event) };
+        },
+      },
+    });
     await strict.rejects(
       () =>
         database.transaction(async (transaction) => {
@@ -465,6 +495,11 @@ await describe("PostgreSQL transaction query streams", async () => {
     strict.strictEqual(pool.client.cursor.closeCount, 1);
     strict.deepStrictEqual(commands(pool.client), ["BEGIN", "ROLLBACK"]);
     strict.strictEqual(pool.client.releaseCount, 1);
+    strict.deepStrictEqual(
+      ends.map(({ status }) => status),
+      ["success", "error"],
+    );
+    strict.strictEqual(ends[0]?.rowCount, 1);
   });
 
   await it("invalidates an escaped unstarted stream and rolls back without opening it", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: 3.0.1
         version: 3.0.1
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       '@pokujs/c8':
         specifier: ^2.0.0
         version: 2.0.0(poku@4.5.0)
@@ -212,6 +215,15 @@ importers:
       '@typed-sql/schema':
         specifier: workspace:*
         version: link:../schema
+
+  packages/opentelemetry:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: '>=1.9.0 <2'
+        version: 1.9.1
+      '@typed-sql/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/postgres:
     dependencies:
@@ -953,6 +965,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@pnpm/deps.graph-sequencer@1100.0.1':
     resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
@@ -3654,6 +3670,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -5,6 +5,7 @@
   "sourceCandidate": "1.0.0-rc.0",
   "packages": [
     "@typed-sql/core",
+    "@typed-sql/opentelemetry",
     "@typed-sql/ast",
     "@typed-sql/schema",
     "@typed-sql/config",
@@ -17,6 +18,7 @@
   "packagePolicy": {
     "stable": [
       "@typed-sql/core",
+      "@typed-sql/opentelemetry",
       "@typed-sql/ast",
       "@typed-sql/schema",
       "@typed-sql/config",

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -134,6 +134,29 @@ export async function deterministicMicrobenchmarks(methodology) {
   );
   assert.deepEqual(postgresConfig.values, [["1", ["2", ["3", "4"]], "done"]]);
 
+  let postgresObservationStarts = 0;
+  let postgresObservationEnds = 0;
+  const observedPostgresDatabase = createPostgresDatabase({
+    pool: postgresPool,
+    observer: {
+      start() {
+        postgresObservationStarts += 1;
+        return {
+          end() {
+            postgresObservationEnds += 1;
+          },
+        };
+      },
+    },
+  });
+  results["micro.postgres.observedDispatch"] = await latency(
+    () => observedPostgresDatabase.execute(postgresEncodingQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.ok(postgresObservationStarts > 0);
+  assert.equal(postgresObservationEnds, postgresObservationStarts);
+
   const postgresStreamRows = Array.from({ length: 100 }, (_, index) => ({ id: BigInt(index + 1) }));
   let postgresStreamReleases = 0;
   const postgresStreamingDatabase = createPostgresDatabase({
@@ -322,6 +345,29 @@ export async function deterministicMicrobenchmarks(methodology) {
   );
   assert.deepEqual(mysqlValues, [["1", ["2", ["3", "4"]], "done"]]);
   assert.equal(mysqlRenderer.placeholder(1), "?");
+
+  let mysqlObservationStarts = 0;
+  let mysqlObservationEnds = 0;
+  const observedMySqlDatabase = createMySqlDatabase({
+    pool: mysqlEncodingPool,
+    observer: {
+      start() {
+        mysqlObservationStarts += 1;
+        return {
+          end() {
+            mysqlObservationEnds += 1;
+          },
+        };
+      },
+    },
+  });
+  results["micro.mysql.observedDispatch"] = await latency(
+    () => observedMySqlDatabase.execute(mysqlEncodingQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.ok(mysqlObservationStarts > 0);
+  assert.equal(mysqlObservationEnds, mysqlObservationStarts);
 
   const mysqlStreamRows = Array.from({ length: 100 }, (_, index) => ({ id: String(index + 1) }));
   let mysqlStreamReleases = 0;

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -18,6 +18,7 @@ const expectedPublicDocs = [
   "docs/guides/composition.md",
   "docs/guides/editors.md",
   "docs/guides/execution.md",
+  "docs/guides/observability.md",
   "docs/guides/schema-snapshots.md",
   "docs/index.md",
   "docs/reference/api.md",

--- a/test/contracts/observation.test.ts
+++ b/test/contracts/observation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, strict } from "poku";
+import { compileSource } from "../../packages/compiler/src/index.js";
+import type { DatabaseObserver, DatabaseOperationStart } from "../../packages/core/src/index.js";
+import { type PostgresSchemaSnapshot, postgres, sql } from "../../packages/postgres/src/index.js";
+import { createPostgresDatabase } from "../../packages/postgres/src/runtime.js";
+import { loadSchemaSnapshot } from "../../packages/schema/src/index.js";
+
+await describe("compiler and runtime observation correlation", async () => {
+  await it("uses a structural variant fingerprint as the runtime query identity", async () => {
+    const schema = (await loadSchemaSnapshot(
+      fileURLToPath(new URL("../fixtures/success/schema.json", import.meta.url)),
+    )) as PostgresSchemaSnapshot;
+    const source = [
+      'import { sql } from "@typed-sql/postgres";',
+      "const query = sql`SELECT id FROM users ${include ? sql.fragment`WHERE id = ${id}` : sql.empty}`;",
+    ].join("\n");
+    const compiled = compileSource({ source, schema, dialect: postgres() });
+    strict.deepStrictEqual(compiled.diagnostics, []);
+    strict.strictEqual(compiled.queries[0]?.variantFingerprints.length, 2);
+
+    const starts: DatabaseOperationStart[] = [];
+    const observer: DatabaseObserver = {
+      start(operation) {
+        starts.push(operation);
+        return undefined;
+      },
+    };
+    const database = createPostgresDatabase({
+      observer,
+      pool: {
+        async query() {
+          return { rows: [] };
+        },
+        async connect() {
+          throw new Error("The correlation test does not lease a connection");
+        },
+        async end() {},
+      },
+    });
+    await database.execute(sql`SELECT id FROM users ${sql.fragment`WHERE id = ${1}`}`);
+
+    const operation = starts[0];
+    if (operation?.kind !== "query") strict.fail("Expected a query observation");
+    strict.ok(compiled.queries[0]?.variantFingerprints.includes(operation.fingerprint));
+  });
+});
+
+import { fileURLToPath } from "node:url";

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -27,6 +27,7 @@ const forbiddenDrivers = new Set(["pg", "mysql2", "better-sqlite3", "sqlite3"]);
 const publicPackages = [
   "ast",
   "core",
+  "opentelemetry",
   "config",
   "schema",
   "postgres",
@@ -39,6 +40,7 @@ const publicPackages = [
 ] as const;
 const stablePackages = [
   "core",
+  "opentelemetry",
   "ast",
   "schema",
   "config",
@@ -52,6 +54,7 @@ const experimentalPackages = ["ts-bridge", "language-server"] as const;
 const expectedEntrypoints: Readonly<Record<(typeof publicPackages)[number], readonly string[]>> = {
   ast: ["."],
   core: ["."],
+  opentelemetry: ["."],
   config: ["."],
   schema: ["."],
   postgres: [".", "./runtime", "./pg"],
@@ -88,6 +91,7 @@ await describe("public package graph", async () => {
   await it("keeps core, compiler, CLI, and dialect roots free of installed drivers", async () => {
     for (const packageName of [
       "core",
+      "opentelemetry",
       "config",
       "compiler",
       "conformance",
@@ -103,6 +107,13 @@ await describe("public package graph", async () => {
         }
       }
     }
+  });
+
+  await it("keeps OpenTelemetry optional and application-owned", async () => {
+    const packageManifest = await manifest("opentelemetry");
+    strict.strictEqual(packageManifest.dependencies?.["@opentelemetry/api"], undefined);
+    strict.strictEqual(packageManifest.peerDependencies?.["@opentelemetry/api"], ">=1.9.0 <2");
+    strict.deepStrictEqual(Object.keys(packageManifest.dependencies ?? {}), ["@typed-sql/core"]);
   });
 
   await it("keeps pg entirely application-owned instead of declaring a peer", async () => {

--- a/test/contracts/packed-consumer.test.ts
+++ b/test/contracts/packed-consumer.test.ts
@@ -13,6 +13,7 @@ const { NODE_PATH: _workspaceNodePath, ...isolatedEnvironment } = process.env;
 const publicPackages = [
   "ast",
   "core",
+  "opentelemetry",
   "config",
   "schema",
   "postgres",
@@ -26,6 +27,7 @@ const publicPackages = [
 const stableModulePackages = new Set([
   "ast",
   "core",
+  "opentelemetry",
   "config",
   "schema",
   "postgres",
@@ -299,6 +301,7 @@ await describe("packed public packages", async () => {
             dependencies: {
               ...dependencies,
               "@acme/typed-sql-synthetic": "file:../grammar",
+              "@opentelemetry/api": `link:${join(workspace, "node_modules", "@opentelemetry", "api")}`,
             },
             pnpm: {
               overrides: {
@@ -335,6 +338,7 @@ await describe("packed public packages", async () => {
         import { loadMySql2Driver } from "@typed-sql/mysql/mysql2";
         import { compileSource } from "@typed-sql/compiler";
         import { assertGrammarConformance, GRAMMAR_CONFORMANCE_VERSION } from "@typed-sql/conformance";
+        import { createOpenTelemetryObserver } from "@typed-sql/opentelemetry";
         import { syntheticConformanceFixture } from "@typed-sql/example-synthetic-grammar/conformance";
         import { parseSchemaSnapshot } from "@typed-sql/schema";
         import "@typed-sql/ast";
@@ -357,6 +361,7 @@ await describe("packed public packages", async () => {
         if (postgresSql\`SELECT \${1}\`.segments.length !== 3 || mysqlSql\`SELECT \${1}\`.segments.length !== 3) throw new Error("dialect sql export failed");
         if (typeof compileSource !== "function") throw new Error("compiler import failed");
         if (GRAMMAR_CONFORMANCE_VERSION !== 1) throw new Error("conformance version import failed");
+        if (typeof createOpenTelemetryObserver !== "function") throw new Error("OpenTelemetry integration import failed");
         const conformance = assertGrammarConformance(syntheticConformanceFixture);
         if (conformance.grammar !== "synthetic" || conformance.structuralVariants !== 2) {
           throw new Error("packed third-party grammar conformance failed");

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -34,8 +34,16 @@ import type {
 } from "../../packages/conformance/src/index.js";
 import * as conformanceApi from "../../packages/conformance/src/index.js";
 import type {
+  ActiveDatabaseObservation,
+  BatchOperationStart,
   ControlledQueryExecutor,
   Database,
+  DatabaseObservation,
+  DatabaseObservationStatus,
+  DatabaseObserver,
+  DatabaseOperationCompletion,
+  DatabaseOperationEnd,
+  DatabaseOperationStart,
   DialectCapabilities,
   DialectPlugin,
   ExecutionCapabilities,
@@ -53,7 +61,9 @@ import type {
   QueryDependencyKind,
   QueryExecutor,
   QueryLocking,
+  QueryObservationCardinality,
   QueryOperation,
+  QueryOperationStart,
   QueryParameters,
   QueryRenderSkeleton,
   QueryResult,
@@ -72,8 +82,10 @@ import type {
   SqlRenderer,
   SqlSegment,
   SqlTag,
+  StreamOperationStart,
   StreamOptions,
   TransactionDatabase,
+  TransactionOperationStart,
   TransactionRunner,
   TypedSqlConfig,
 } from "../../packages/core/src/index.js";
@@ -82,6 +94,8 @@ import * as mysqlApi from "../../packages/mysql/src/index.js";
 import * as mysql2Api from "../../packages/mysql/src/mysql2.js";
 import type { MySqlDatabase, MySqlPreparedQueryFactory, MySqlTransaction } from "../../packages/mysql/src/runtime.js";
 import * as mysqlRuntimeApi from "../../packages/mysql/src/runtime.js";
+import type { OpenTelemetryObserverOptions } from "../../packages/opentelemetry/src/index.js";
+import * as openTelemetryApi from "../../packages/opentelemetry/src/index.js";
 import * as postgresApi from "../../packages/postgres/src/index.js";
 import * as pgApi from "../../packages/postgres/src/pg.js";
 import type {
@@ -301,12 +315,21 @@ type ReferencedStableTypes =
   | RequiredGrammarProbe
   | RuntimeAdapterConformanceFixture<Account, readonly [bigint]>
   | ControlledQueryExecutor
+  | ActiveDatabaseObservation
+  | BatchOperationStart
+  | DatabaseObservation
+  | DatabaseObservationStatus
+  | DatabaseObserver
+  | DatabaseOperationCompletion
+  | DatabaseOperationEnd
+  | DatabaseOperationStart
   | DialectCapabilities
   | DialectPlugin
   | ExecutionCapabilities
   | ExecutionCapability
   | ExecutionOptions
   | OptionalSqlFragment
+  | OpenTelemetryObserverOptions
   | QueryCardinality
   | QueryConnectionAffinity
   | QueryDependency
@@ -314,6 +337,8 @@ type ReferencedStableTypes =
   | QueryDependencyKind
   | QueryLocking
   | QueryOperation
+  | QueryObservationCardinality
+  | QueryOperationStart
   | QuerySemantics
   | QueryVolatility
   | QueryBatch<readonly [ExactQuery]>
@@ -332,10 +357,12 @@ type ReferencedStableTypes =
   | SqlAstVisitor
   | SqlAstContext
   | StreamOptions
+  | StreamOperationStart
   | SemanticEvidence
   | SemanticFact<string>
   | TransactionDatabase
   | TransactionRunner
+  | TransactionOperationStart
   | TypedSqlConfig;
 
 void queryRow;
@@ -406,17 +433,20 @@ const expectedRuntimeExports = {
     "createDatabase",
     "defineConfig",
     "defineQuerySemantics",
+    "databaseErrorCompletion",
     "diagnosticRegistry",
     "executionDeadline",
     "isTypedSqlDiagnosticCode",
     "mapQuerySemanticRanges",
     "mergeQuerySemantics",
+    "observeQueryStream",
     "parameterTypeLiteral",
     "QUERY_SEMANTICS_VERSION",
     "renderQuery",
     "rowTypeLiteral",
     "runControlledExecution",
     "sql",
+    "startDatabaseObservation",
     "unionTypeLiterals",
     "unknownQuerySemantics",
   ],
@@ -435,6 +465,7 @@ const expectedRuntimeExports = {
   ],
   mysql2: ["adaptMySql2Pool", "createMySql2Database", "loadMySql2Driver", "mysql2"],
   mysqlRuntime: ["createMySqlDatabase", "mysqlRenderer"],
+  opentelemetry: ["createOpenTelemetryObserver"],
   postgres: [
     "POSTGRES_DIALECT_VERSION",
     "PostgresSchemaProvider",
@@ -477,6 +508,7 @@ await describe("stable public API", async () => {
       mysql: Object.keys(mysqlApi).sort(),
       mysql2: Object.keys(mysql2Api).sort(),
       mysqlRuntime: Object.keys(mysqlRuntimeApi).sort(),
+      opentelemetry: Object.keys(openTelemetryApi).sort(),
       postgres: Object.keys(postgresApi).sort(),
       pg: Object.keys(pgApi).sort(),
       postgresRuntime: Object.keys(postgresRuntimeApi).sort(),

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../packages/mysql" },
     { "path": "../packages/compiler" },
     { "path": "../packages/conformance" },
+    { "path": "../packages/opentelemetry" },
     { "path": "../packages/cli" },
     { "path": "../packages/ts-bridge" },
     { "path": "../packages/language-server" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "./packages/mysql" },
     { "path": "./packages/compiler" },
     { "path": "./packages/conformance" },
+    { "path": "./packages/opentelemetry" },
     { "path": "./packages/ts-bridge" },
     { "path": "./packages/language-server" },
     { "path": "./packages/cli" },

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Execute queries", link: "/guides/execution" },
+          { text: "Observe database work", link: "/guides/observability" },
           { text: "Compose conditional SQL", link: "/guides/composition" },
           { text: "Manage schema snapshots", link: "/guides/schema-snapshots" },
           { text: "Configure editors", link: "/guides/editors" },


### PR DESCRIPTION
Closes #54

## Summary
- add a redacted, grammar-neutral lifecycle for queries, cardinality, batches, pipelines, streams, cancellation, and nested transactions
- instrument PostgreSQL and MySQL adapters with compiler-correlatable structural fingerprints and a zero-wrapper disabled path
- publish the optional `@typed-sql/opentelemetry` bridge with safe defaults and explicit high-cardinality/error opt-ins
- document tracing and enforce public package, packed-consumer, coverage, E2E, and performance contracts

## Verification
- `pnpm verify`
- PostgreSQL real-driver E2E with Podman
- MySQL real-driver E2E with Podman
- `TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:packed`

## Performance
- PostgreSQL fake-driver dispatch p50: 0.000486 ms disabled baseline, 0.000750 ms observed
- MySQL fake-driver dispatch p50: 0.000610 ms disabled baseline, 0.000868 ms observed
