### PR TITLE
feat: emit deterministic query manifests

### DIFF
--- a/.changeset/bright-queries-manifest.md
+++ b/.changeset/bright-queries-manifest.md
@@ -1,0 +1,10 @@
+---
+"@typed-sql/core": major
+"@typed-sql/compiler": major
+"@typed-sql/cli": major
+---
+
+Add deterministic, secret-free query manifests with bounded structural variants, inferred result
+and parameter descriptions, semantic evidence, runtime-correlatable fingerprints, unresolved
+entries, compatible parsing, canonical serialization, incremental per-file reuse, tsconfig project
+discovery, and a dedicated CLI command.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ codecs. The interpolation is also checked as `bigint` because it is compared wit
   `Query<unknown>`, never `any` or an optimistic type.
 - **Use one grammar contract.** The compiler, CLI, editor tooling, and third-party dialects all
   consume the same public interface.
+- **Carry build evidence into production.** Deterministic query manifests correlate runtime
+  fingerprints with inferred types, dependencies, and capabilities without storing SQL or values.
 
 ## Install
 
@@ -83,6 +85,7 @@ Create `typed-sql.config.ts`, generate a schema snapshot, and check a query:
 pnpm exec typed-sql generate
 pnpm exec typed-sql check --file src/query.ts --project tsconfig.json
 pnpm exec typed-sql drift
+pnpm exec typed-sql manifest
 ```
 
 See [Installation](./docs/getting-started/installation.md),
@@ -124,11 +127,11 @@ the structural-variant bound.
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | Stable |
 | `@typed-sql/schema` | Versioned snapshots, hashes, migrations, and drift | Stable |
 | `@typed-sql/config` | Config discovery and loading | Stable |
-| `@typed-sql/compiler` | Grammar-neutral TypeScript source analysis | Stable |
+| `@typed-sql/compiler` | Grammar-neutral TypeScript source analysis and query manifests | Stable |
 | `@typed-sql/conformance` | Executable compatibility kit for SQL grammar packages | Stable |
 | `@typed-sql/postgres` | PostgreSQL grammar, codecs, introspection, and optional `pg` adapter | Stable |
 | `@typed-sql/mysql` | MySQL grammar, codecs, introspection, and optional `mysql2` adapter | Stable |
-| `@typed-sql/cli` | Snapshot generation, query checking, and drift commands | Stable |
+| `@typed-sql/cli` | Snapshot generation, query checking, drift, and manifest commands | Stable |
 | `@typed-sql/ts-bridge` | Isolated TypeScript preview integration | Experimental |
 | `@typed-sql/language-server` | TypeScript semantic proxy and SQL editor features | Experimental |
 
@@ -138,6 +141,7 @@ the structural-variant bound.
 - [Documentation source](./docs/index.md)
 - [Execution adapters](./docs/guides/execution.md)
 - [Database observability](./docs/guides/observability.md)
+- [Query manifests](./docs/guides/query-manifests.md)
 - [PostgreSQL grammar](./docs/dialects/postgresql.md)
 - [MySQL grammar](./docs/dialects/mysql.md)
 - [Inference and safety](./docs/concepts/type-safety.md)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -16,11 +16,11 @@ typed-sql separates the application query contract, SQL grammar, schema metadata
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | No |
 | `@typed-sql/config` | Dialect-neutral project config discovery and loading | No |
 | `@typed-sql/schema` | Snapshot envelope, deterministic generation, hashes, and drift | No |
-| `@typed-sql/compiler` | Dialect-neutral extraction, transforms, structural expansion, and diagnostics | No |
+| `@typed-sql/compiler` | Dialect-neutral extraction, transforms, structural expansion, diagnostics, and query manifests | No |
 | `@typed-sql/conformance` | Public executable contract for first- and third-party SQL grammars | No |
 | `@typed-sql/postgres` | PostgreSQL grammar, catalog model, resolver, type policy, and codecs | No |
 | `@typed-sql/mysql` | MySQL grammar, catalog model, resolver, type policy, and codecs | No |
-| `@typed-sql/cli` | Generation, checking, drift, and provider discovery | No |
+| `@typed-sql/cli` | Snapshot generation, checking, drift, manifests, and provider discovery | No |
 | `@typed-sql/ts-bridge` | Experimental TypeScript semantic overlay and isolated preview bridge | No |
 | `@typed-sql/language-server` | Experimental TypeScript and LSP semantic proxy | No |
 
@@ -61,11 +61,15 @@ Every successful analysis also returns versioned `QuerySemantics`. A semantic fa
 
 Compiled queries expose a path-independent SHA-256 fingerprint and the fingerprints of their structural variants. These identify compiler artifacts; they do not contain parameter values and are not a security signature.
 
+The optional query manifest serializes the same fingerprints, variants, inferred descriptions, and semantic evidence in canonical order. It contains relative source locations but no SQL text, parameter values, connection configuration, or absolute paths. Runtime observation can therefore correlate a variant fingerprint with build-time evidence without moving driver or telemetry concerns into the compiler.
+
 ## Generated metadata
 
 Generated output contains schema metadata for tooling and review. Application code imports `sql` and `typePolicy` from the dialect package and imports a driver adapter only when it needs introspection or execution.
 
 A custom type policy belongs in an application module shared by config and runtime. Generated output is never an application API entrypoint.
+
+Query manifests are build artifacts rather than generated application APIs. Applications continue importing `sql` from their selected grammar package. See [Query manifests](../guides/query-manifests.md).
 
 ## Composition model
 

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -15,10 +15,11 @@ The production performance suite covers:
 
 - scanning one TypeScript file containing 1,000 static queries;
 - compiling 250 queries with the PostgreSQL grammar and resolver;
+- emitting a 250-query manifest and reusing its unchanged per-file analysis;
 - correlated and independent conditional structure;
 - rejecting structural expansion before grammar work exceeds its bound;
 - core template construction, fragment composition, rendering, and prepared-skeleton binding;
-- adapter render, encode, decode, 100-row stream, 25-query batch, and PostgreSQL pipeline overhead with deterministic fake drivers;
+- adapter render, encode, decode, decoder-plan compilation and cache-hit throughput, 100-row stream, 25-query batch, and PostgreSQL pipeline overhead with deterministic fake drivers;
 - cold, unchanged, incrementally edited, and schema-reloaded language-service analysis;
 - cancellation before expensive analysis;
 - retained heap under cache pressure.
@@ -41,6 +42,8 @@ At runtime, interpolation-free fragment templates may reuse their complete immut
 | --- | ---: | ---: |
 | Scanner, 1,000 queries | 10 ms | 25 ms |
 | Compiler, 250 PostgreSQL queries | 20 ms | 50 ms |
+| Query manifest, 250 queries | 25 ms | 60 ms |
+| Query manifest, unchanged source | 0.5 ms | 1 ms |
 | 20 correlated conditions | 5 ms | 10 ms |
 | Six independent conditions | 10 ms | 25 ms |
 | Structural limit rejection | 5 ms | 10 ms |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -30,6 +30,9 @@ export default defineConfig({
   compiler: {
     maxStructuralVariants: 64,
   },
+  manifest: {
+    outFile: ".typed-sql/queries.json",
+  },
 });
 ```
 
@@ -56,6 +59,9 @@ export default defineConfig({
   compiler: {
     maxStructuralVariants: 64,
   },
+  manifest: {
+    outFile: ".typed-sql/queries.json",
+  },
 });
 ```
 
@@ -65,9 +71,10 @@ export default defineConfig({
 pnpm exec typed-sql generate
 pnpm exec typed-sql check --file src/query.ts --project tsconfig.json
 pnpm exec typed-sql drift
+pnpm exec typed-sql manifest
 ```
 
-`generate` introspects the configured database and writes deterministic schema metadata. `check` analyzes SQL and asks TypeScript to validate the inferred overlay. `drift` compares the committed snapshot and type-policy hash with the live database.
+`generate` introspects the configured database and writes deterministic schema metadata. `check` analyzes SQL and asks TypeScript to validate the inferred overlay. `drift` compares the committed snapshot and type-policy hash with the live database. `manifest` emits deterministic, source-relative compiler evidence for every configured project; see [Query manifests](../guides/query-manifests.md).
 
 Connection strings stay in the config callback or environment. They are not written to generated files. Commit the generated snapshot so schema and type-policy changes are reviewable.
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -94,7 +94,7 @@ Nested transaction events use depth `1` for the first transaction and increase f
 
 A runtime query fingerprint is SHA-256 over the dialect id, grammar version, and rendered structural SQL. Parameter values and checkout paths are not inputs.
 
-For an unconditional query, the runtime fingerprint equals `CompiledQuery.fingerprint`. A conditionally composed query can produce several complete structural statements; its runtime fingerprint equals one member of `CompiledQuery.variantFingerprints`. The compiled query's top-level fingerprint is the deterministic identity of that complete variant set. This lets generated manifests index runtime spans without storing SQL or values.
+For an unconditional query, the runtime fingerprint equals `CompiledQuery.fingerprint`. A conditionally composed query can produce several complete structural statements; its runtime fingerprint equals one member of `CompiledQuery.variantFingerprints`. The compiled query's top-level fingerprint is the deterministic identity of that complete variant set. [Query manifests](./query-manifests.md) index runtime spans without storing SQL or values.
 
 Fingerprints are stable correlation identifiers, not authorization tokens or cryptographic attestations.
 

--- a/docs/guides/query-manifests.md
+++ b/docs/guides/query-manifests.md
@@ -1,0 +1,121 @@
+---
+title: Query manifests
+description: Emit deterministic, secret-free query metadata for CI, deployment checks, and production correlation.
+---
+
+# Query manifests
+
+A query manifest turns compiler analysis into a versioned JSON artifact. It records every statically visible query, its bounded structural variants, inferred parameters and results, semantic dependencies, capabilities, diagnostics, and observation fingerprints.
+
+Application code does not import the manifest or generated query wrappers. It continues importing `sql` from the selected grammar package:
+
+```ts
+import { sql } from "@typed-sql/postgres";
+
+export const account = sql`
+  SELECT users.id, users.email
+  FROM users
+  WHERE users.id = ${42n}
+`;
+```
+
+## Configure the output
+
+List the TypeScript projects that contain queries and optionally select an output path:
+
+```ts
+import { defineConfig } from "@typed-sql/core";
+import { postgres, typePolicy } from "@typed-sql/postgres";
+
+export default defineConfig({
+  dialect: postgres({ typePolicy }),
+  schema: { file: "src/generated/db/schema.json" },
+  outDir: "src/generated/db",
+  projects: ["tsconfig.json", "packages/jobs/tsconfig.json"],
+  manifest: {
+    outFile: ".typed-sql/queries.json",
+  },
+  typePolicy,
+});
+```
+
+Generate the artifact:
+
+```sh
+pnpm exec typed-sql manifest
+```
+
+`--project` analyzes one explicit tsconfig instead of the configured project list. `--out` overrides the configured output path.
+
+The command asks the workspace TypeScript executable for the files selected by each tsconfig. SQL parsing and inference still run through the grammar-neutral typed-sql compiler and the configured dialect; the compiler package does not depend on TypeScript preview APIs.
+
+## Artifact contents
+
+Format version 1 contains:
+
+- the compiler version, dialect id, grammar version, fingerprint algorithm, schema hash, and type-policy hash;
+- checkout-relative project and source paths plus content hashes for incremental reuse;
+- one source-located entry for each static query or explicit `sql.dynamic()` escape hatch;
+- a resolved query's aggregate fingerprint, structural variants, hashed branch choices, row and parameter literals, column and parameter descriptions, and semantic evidence;
+- an unresolved query's diagnostic codes, severities, source ranges, and either `diagnostic` or `dynamic` reason.
+
+Each structural query remains one manifest entry. Its bounded variants are nested under that entry instead of duplicating the source query. Variant fingerprints match the identities emitted by runtime observation, allowing telemetry to correlate with compiler evidence without recording SQL text.
+
+Entries are sorted by relative file and source position. Object keys use canonical order, so unchanged inputs produce byte-identical output even when a checkout moves to another absolute directory.
+
+## Security boundary
+
+The manifest never serializes:
+
+- absolute paths;
+- database URLs or connection configuration;
+- runtime parameter values;
+- environment values;
+- SQL source text.
+
+It does contain relative source paths, database object names, TypeScript type descriptions, diagnostic codes, and semantic classifications with source ranges. Human-readable grammar diagnostic messages, fixes, branch expressions, and evidence descriptions are deliberately excluded because third-party grammars may derive them from source text. Treat the remaining fields as application metadata and apply the same artifact access policy used for source maps or build reports.
+
+Static SQL literals influence fingerprints but are not reversible from their SHA-256 digest. A fingerprint is an identity for correlation, not a security signature.
+
+## Unresolved queries and exit codes
+
+The manifest is written even when it contains unresolved entries. This makes unsupported or intentionally dynamic work visible rather than silently omitting it.
+
+| Exit code | Meaning |
+| ---: | --- |
+| `0` | The manifest was written and every entry resolved. |
+| `2` | The manifest was written and contains one or more unresolved entries. |
+| `1` | Configuration, project discovery, schema loading, or artifact generation failed. |
+
+A CI job can decide whether unresolved entries are permitted while always retaining the produced artifact:
+
+```sh
+set +e
+pnpm exec typed-sql manifest --out artifacts/typed-sql-queries.json
+status=$?
+set -e
+
+if [ "$status" -eq 1 ]; then
+  exit 1
+fi
+```
+
+Projects that commit the manifest can additionally run `git diff --exit-code -- .typed-sql/queries.json`. Projects that do not commit it can upload the file as a build artifact for deployment verification or production correlation.
+
+## Incremental generation
+
+When the output file already contains a compatible manifest, generation reuses entries for source files whose content hash is unchanged. A compiler, format, fingerprint algorithm, dialect, grammar, schema, or type-policy change invalidates reuse conservatively.
+
+The production performance gate measures both a full 250-query build and an unchanged incremental build. See [Performance](../concepts/performance.md) for the current regression budgets.
+
+## Programmatic API
+
+`@typed-sql/compiler` exports:
+
+- `buildQueryManifest(options)` for in-memory source inputs and optional previous-manifest reuse;
+- `serializeQueryManifest(manifest)` for canonical JSON;
+- `parseQueryManifest(value)` for compatible reader validation;
+- `listProjectSourceFiles(options)` for tsconfig file enumeration;
+- `QUERY_MANIFEST_FORMAT_VERSION`, `QUERY_FINGERPRINT_ALGORITHM`, and `QUERY_MANIFEST_JSON_SCHEMA` for consumers.
+
+Format readers accept additive object properties within format version 1. An incompatible required-field or meaning change increments `formatVersion`. A documented fingerprint normalization change uses a new `fingerprintAlgorithm`. Consumers must reject unsupported format or fingerprint versions instead of interpreting them optimistically.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ It is not an ORM or a query builder. SQL remains visible, database drivers remai
 - [Compose conditional SQL](./guides/composition.md) without creating a parallel query-builder API.
 - [Generate snapshots and detect drift](./guides/schema-snapshots.md).
 - [Trace database work safely](./guides/observability.md) through the neutral observer contract.
+- [Emit deterministic query manifests](./guides/query-manifests.md) for CI and production correlation.
 - [Configure Zed, VS Code, or another LSP client](./guides/editors.md).
 - Review the [PostgreSQL](./dialects/postgresql.md) and [MySQL](./dialects/mysql.md) grammar boundaries.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -149,7 +149,7 @@ Set `DatabaseObserver.captureErrorCause` only when an integration explicitly nee
 
 ## Configuration and schema contracts
 
-`defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, and compiler options.
+`defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, compiler options, and optional `manifest.outFile`.
 
 Public schema types include `SchemaSnapshot`, `GeneratedSchemaSnapshot`, table, column, domain, and function metadata, `SchemaProvider`, and source-mapped diagnostics.
 
@@ -159,13 +159,18 @@ Public schema types include `SchemaSnapshot`, `GeneratedSchemaSnapshot`, table, 
 
 - `checkFile` and its option and result types;
 - `compileSource` and its query or fragment results;
-- `extractStaticQueries`, `mapSqlRange`, `ExtractedQuery`, and `ExtractedInterpolation`.
+- `extractStaticQueries`, `extractDynamicQueries`, `mapSqlRange`, and their extracted-source types;
+- `buildQueryManifest`, canonical serialization, compatible parsing, and project file enumeration;
+- the query manifest format, fingerprint algorithm, and JSON Schema constants.
 
 Each `CompiledQuery` includes:
 
 - `fingerprint`, a dialect- and grammar-version-scoped SHA-256 identity;
 - `variantFingerprints`, containing every bounded structural SQL identity;
+- `variants`, containing each fingerprint's ordered parameters, columns, branch choices, and semantics;
 - `semantics`, with source-mapped, conservatively merged query evidence.
+
+Manifest output is a compiler and CI artifact, not an application import surface. See [Query manifests](../guides/query-manifests.md) for the format, redaction boundary, incremental behavior, and CLI exit codes.
 
 Scanner control flow, append extraction, structural parsing, branch expansion, and conditional row rendering remain internal.
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -13,6 +13,7 @@ Automation should depend on diagnostic codes and source ranges, not English mess
 | `TSQ002` | SQL exceeded a parser resource limit. |
 | `TSQ003` | Conditional SQL exceeded the structural variant limit. |
 | `TSQ004` | Structural SQL requires an explicitly trusted fragment. |
+| `TSQ005` | Runtime SQL cannot be analyzed statically. |
 | `TSQ007` | The schema snapshot and dialect do not match. |
 | `TSQ100` | A referenced table does not exist. |
 | `TSQ101` | A referenced column does not exist. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 The stable, config-driven command line interface for
 [typed-sql](https://github.com/Lojhan/typed-sql). It generates deterministic database snapshots,
-checks inferred queries through TypeScript, and detects schema drift.
+checks inferred queries through TypeScript, detects schema drift, and emits deterministic query manifests.
 
 ```sh
 pnpm add -D @typed-sql/cli typescript@7.0.2
@@ -14,6 +14,7 @@ Install a grammar and its application-owned driver, then create `typed-sql.confi
 pnpm exec typed-sql generate
 pnpm exec typed-sql check --file src/query.ts --project tsconfig.json
 pnpm exec typed-sql drift
+pnpm exec typed-sql manifest
 ```
 
 Use `--config path/to/typed-sql.config.ts` to bypass config discovery. Run
@@ -22,6 +23,7 @@ Use `--config path/to/typed-sql.config.ts` to bypass config discovery. Run
 The CLI contains no PostgreSQL, MySQL, `pg`, or `mysql2` dependency. It loads the installed grammar
 and schema provider through the application config. Read
 [Configuration](https://github.com/Lojhan/typed-sql/blob/main/docs/getting-started/configuration.md) and
-[Schema snapshots](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/schema-snapshots.md).
+[Schema snapshots](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/schema-snapshots.md), and
+[Query manifests](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-manifests.md).
 
 MIT © typed-sql contributors

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typed-sql/cli",
   "version": "1.0.0",
-  "description": "Config-driven typed-sql generation, checking, and schema drift CLI.",
+  "description": "Config-driven typed-sql generation, checking, schema drift, and query manifest CLI.",
   "license": "MIT",
   "author": "Lojhan",
   "repository": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { checkFile } from "@typed-sql/compiler";
+import {
+  buildQueryManifest,
+  checkFile,
+  listProjectSourceFiles,
+  parseQueryManifest,
+  serializeQueryManifest,
+} from "@typed-sql/compiler";
 import { fromConfig, loadConfig } from "@typed-sql/config";
 import type { SchemaSnapshot } from "@typed-sql/core";
 import { checkSchemaDrift, generateSchemaPackage, loadGeneratedSchemaSnapshot } from "@typed-sql/schema";
@@ -12,7 +18,7 @@ interface ParsedArguments {
   readonly options: Readonly<Record<string, string>>;
 }
 
-const commands = new Set(["check", "generate", "drift"]);
+const commands = new Set(["check", "generate", "drift", "manifest"]);
 
 async function packageVersion(): Promise<string> {
   let directory = dirname(fileURLToPath(import.meta.url));
@@ -42,6 +48,7 @@ Commands:
   check      Infer SQL result types and verify them with TypeScript 7
   generate   Introspect or load a schema snapshot and generate the typed contract
   drift      Compare the generated contract with the live database catalog
+  manifest   Emit a deterministic manifest for every project query
 
 Global options:
   -h, --help       Show this help
@@ -51,6 +58,7 @@ Examples:
   typed-sql check --config typed-sql.config.ts --file src/query.ts --project tsconfig.json
   typed-sql generate --config typed-sql.config.ts --out generated/db
   typed-sql drift --config typed-sql.config.ts
+  typed-sql manifest --config typed-sql.config.ts --project tsconfig.json --out .typed-sql/queries.json
 `;
 }
 
@@ -80,6 +88,15 @@ function required(options: Readonly<Record<string, string>>, name: string): stri
 
 async function readSnapshot(path: string, validate: (value: unknown) => SchemaSnapshot): Promise<SchemaSnapshot> {
   return validate(JSON.parse(await readFile(path, "utf8")) as unknown);
+}
+
+async function readPreviousManifest(path: string) {
+  try {
+    return parseQueryManifest(JSON.parse(await readFile(path, "utf8")) as unknown);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return undefined;
+    throw error;
+  }
 }
 
 async function main(): Promise<void> {
@@ -140,6 +157,50 @@ async function main(): Promise<void> {
       dialectVersion: dialect.grammarVersion,
     });
     process.stdout.write(`Generated schema ${metadata.schemaHash}\n`);
+    return;
+  }
+
+  if (parsed.command === "manifest") {
+    const schema = await readSnapshot(schemaFile, (value) => dialect.validateSnapshot(value));
+    const projects =
+      parsed.options.project === undefined
+        ? (config.projects ?? ["tsconfig.json"]).map((project) => fromConfig(loaded.directory, project))
+        : [resolve(parsed.options.project)];
+    if (projects.length === 0) throw new Error("typed-sql manifest requires at least one TypeScript project");
+    const sourceFiles = [
+      ...new Set(
+        (
+          await Promise.all(projects.map((project) => listProjectSourceFiles({ project, cwd: loaded.directory })))
+        ).flat(),
+      ),
+    ].sort();
+    const sources = await Promise.all(
+      sourceFiles.map(async (file) => ({ file, source: await readFile(file, "utf8") })),
+    );
+    const outFile = fromConfig(
+      loaded.directory,
+      parsed.options.out ?? config.manifest?.outFile ?? ".typed-sql/queries.json",
+    );
+    const previous = await readPreviousManifest(outFile);
+    const result = buildQueryManifest({
+      rootDir: loaded.directory,
+      sources,
+      projects,
+      dialect,
+      schema,
+      typePolicy: policy,
+      compilerVersion: version,
+      ...(previous === undefined ? {} : { previous }),
+      ...(config.compiler?.maxStructuralVariants === undefined
+        ? {}
+        : { maxStructuralVariants: config.compiler.maxStructuralVariants }),
+    });
+    await mkdir(dirname(outFile), { recursive: true });
+    await writeFile(outFile, serializeQueryManifest(result.manifest), "utf8");
+    process.stdout.write(
+      `Generated ${result.manifest.queries.length} queries (${result.stats.unresolvedQueries} unresolved, ${result.stats.reusedFiles} files reused) at ${outFile}\n`,
+    );
+    if (result.stats.unresolvedQueries > 0) process.exitCode = 2;
     return;
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,7 @@ import { describe, it, strict } from "poku";
 
 const execFile = promisify(execFileCallback);
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workspace = resolve(packageDirectory, "../..");
 const cli = join(packageDirectory, "src", "cli.ts");
 const tsx = fileURLToPath(import.meta.resolve("tsx"));
 const version = (
@@ -56,6 +57,111 @@ await describe("typed-sql CLI discovery-free commands", async () => {
         if (!(error instanceof Error && "stderr" in error)) return false;
         strict.match(String(error.stderr), /Unknown command unknown/u);
         strict.ok(!String(error.stderr).includes("typed-sql.config.ts"));
+        return true;
+      });
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+});
+
+await describe("typed-sql manifest command", async () => {
+  await it("writes deterministic project manifests and reuses unchanged analysis", async () => {
+    const temporary = await mkdtemp(join(workspace, ".typed-sql-cli-manifest-"));
+    try {
+      await mkdir(join(temporary, "src"));
+      await writeFile(
+        join(temporary, "typed-sql.config.ts"),
+        [
+          'import { defineConfig } from "@typed-sql/core";',
+          'import { postgres, typePolicy } from "@typed-sql/postgres";',
+          "export default defineConfig({",
+          "  dialect: postgres(),",
+          '  schema: { file: "schema.json" },',
+          '  outDir: "generated",',
+          '  projects: ["tsconfig.json"],',
+          '  manifest: { outFile: ".typed-sql/queries.json" },',
+          "  typePolicy,",
+          "});",
+        ].join("\n"),
+      );
+      await writeFile(
+        join(temporary, "schema.json"),
+        `${JSON.stringify({
+          formatVersion: 1,
+          dialect: "postgres",
+          tables: {
+            users: {
+              name: "users",
+              columns: {
+                id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+              },
+            },
+          },
+        })}\n`,
+      );
+      await writeFile(
+        join(temporary, "tsconfig.json"),
+        `${JSON.stringify({
+          extends: "../tsconfig.base.json",
+          compilerOptions: { composite: false },
+          include: ["src/**/*.ts"],
+        })}\n`,
+      );
+      await writeFile(
+        join(temporary, "src", "query.ts"),
+        'import { sql } from "@typed-sql/postgres"; export const query = sql`SELECT users.id FROM users`;\n',
+      );
+
+      const first = await execute(["manifest"], temporary);
+      strict.match(first.stdout, /Generated 1 queries \(0 unresolved, 0 files reused\)/u);
+      const outFile = join(temporary, ".typed-sql", "queries.json");
+      const initial = await readFile(outFile, "utf8");
+      const second = await execute(["manifest"], temporary);
+      strict.match(second.stdout, /Generated 1 queries \(0 unresolved, 1 files reused\)/u);
+      strict.strictEqual(await readFile(outFile, "utf8"), initial);
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+
+  await it("writes unresolved entries with exit code 2, distinct from build failures", async () => {
+    const temporary = await mkdtemp(join(workspace, ".typed-sql-cli-manifest-"));
+    try {
+      await mkdir(join(temporary, "src"));
+      await writeFile(
+        join(temporary, "typed-sql.config.ts"),
+        [
+          'import { defineConfig } from "@typed-sql/core";',
+          'import { postgres } from "@typed-sql/postgres";',
+          'export default defineConfig({ dialect: postgres(), schema: { file: "schema.json" }, outDir: "generated", projects: ["tsconfig.json"] });',
+        ].join("\n"),
+      );
+      await writeFile(
+        join(temporary, "schema.json"),
+        `${JSON.stringify({ formatVersion: 1, dialect: "postgres", tables: {} })}\n`,
+      );
+      await writeFile(
+        join(temporary, "tsconfig.json"),
+        `${JSON.stringify({ extends: "../tsconfig.base.json", include: ["src/**/*.ts"] })}\n`,
+      );
+      await writeFile(
+        join(temporary, "src", "query.ts"),
+        'import { sql } from "@typed-sql/postgres"; export const query = sql`SELECT missing FROM absent`;\n',
+      );
+      await strict.rejects(execute(["manifest"], temporary), (error: unknown) => {
+        if (!(error instanceof Error && "code" in error && "stdout" in error)) return false;
+        strict.strictEqual(error.code, 2);
+        strict.match(String(error.stdout), /1 unresolved/u);
+        return true;
+      });
+      const manifest = JSON.parse(await readFile(join(temporary, ".typed-sql", "queries.json"), "utf8")) as {
+        readonly queries: readonly { readonly status: string }[];
+      };
+      strict.strictEqual(manifest.queries[0]?.status, "unresolved");
+      await strict.rejects(execute(["manifest", "--project", "missing.json"], temporary), (error: unknown) => {
+        if (!(error instanceof Error && "code" in error)) return false;
+        strict.strictEqual(error.code, 1);
         return true;
       });
     } finally {

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -2,8 +2,8 @@
 
 The stable, grammar-neutral TypeScript source compiler behind
 [typed-sql](https://github.com/Lojhan/typed-sql). It finds static SQL templates, asks the configured
-grammar for row and parameter shapes, creates an in-memory TypeScript overlay, and preserves source
-mappings for diagnostics and editor tooling.
+grammar for row and parameter shapes, creates an in-memory TypeScript overlay, preserves source
+mappings, and emits deterministic query manifests for CI and production correlation.
 
 ```sh
 pnpm add @typed-sql/compiler
@@ -22,11 +22,15 @@ const result = compileSource({
 
 `compileSource` consumes only `DialectPlugin`; it does not branch on a database, grammar package,
 or driver. Compiled queries expose path-independent SHA-256 fingerprints, variant fingerprints,
-and source-mapped semantics merged conservatively across conditional structure. Its public options include the structural-variant bound used for conditional fragments.
-Application projects normally use the compiler through `typed-sql check` or the language server.
+variant descriptions, and source-mapped semantics merged conservatively across conditional
+structure. `buildQueryManifest` turns the same evidence into canonical, secret-free JSON without
+generating an application API. Its public options include the structural-variant bound used for
+conditional fragments. Application projects normally use the compiler through `typed-sql check`
+or the language server.
 
 Read [Architecture](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/architecture.md),
-[Compose conditional SQL](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/composition.md), and
+[Compose conditional SQL](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/composition.md),
+[Query manifests](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-manifests.md), and
 [Inference and safety](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/type-safety.md).
 
 MIT © typed-sql contributors

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -41,6 +41,7 @@
     ".": "./dist/packages/compiler/src/index.js"
   },
   "dependencies": {
-    "@typed-sql/core": "workspace:*"
+    "@typed-sql/core": "workspace:*",
+    "@typed-sql/schema": "workspace:*"
   }
 }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -5,6 +5,7 @@ import {
   mergeQuerySemantics,
   parameterTypeLiteral,
   type QuerySemantics,
+  type ResolvedColumn,
   type ResolvedParameter,
   rowTypeLiteral,
   type SchemaSnapshot,
@@ -28,6 +29,17 @@ export interface CompiledQuery {
   readonly structural?: true;
   readonly fingerprint: string;
   readonly variantFingerprints: readonly string[];
+  readonly variants: readonly CompiledQueryVariant[];
+  readonly semantics: QuerySemantics;
+}
+
+export interface CompiledQueryVariant {
+  readonly fingerprint: string;
+  readonly rowType: string;
+  readonly parameterType: string;
+  readonly choices: Readonly<Record<string, boolean>>;
+  readonly columns: readonly ResolvedColumn[];
+  readonly parameters: readonly ResolvedParameter[];
   readonly semantics: QuerySemantics;
 }
 
@@ -158,6 +170,26 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
           resolved.diagnostics.some((diagnostic) => diagnostic.severity === "error"),
         )
       ) {
+        const variants: readonly CompiledQueryVariant[] = resolvedVariants.map(
+          ({ variant, resolved, fingerprint }) => ({
+            fingerprint,
+            rowType: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
+            parameterType: parameterTypeLiteral(variant.query.parameterCount, resolved.parameters),
+            choices: Object.freeze(
+              Object.fromEntries(
+                [...variant.choices].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+              ),
+            ),
+            columns: Object.freeze(
+              resolved.columns.map((column) => ({
+                ...column,
+                range: mapSqlRange(source, variant.query, column.range),
+              })),
+            ),
+            parameters: Object.freeze(resolved.parameters.map((parameter) => Object.freeze({ ...parameter }))),
+            semantics: sourceSemantics(source, variant.query, resolved.semantics),
+          }),
+        );
         const rows = resolvedVariants.map(({ variant, resolved }) => ({
           row: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
           choices: variant.choices,
@@ -219,9 +251,8 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
             [...new Set(resolvedVariants.map((variant) => variant.fingerprint))].sort(),
           ),
           fingerprint: identify([...new Set(resolvedVariants.map((variant) => variant.fingerprint))].sort().join("\0")),
-          semantics: mergeQuerySemantics(
-            resolvedVariants.map(({ variant, resolved }) => sourceSemantics(source, variant.query, resolved.semantics)),
-          ),
+          variants,
+          semantics: mergeQuerySemantics(variants.map((variant) => variant.semantics)),
         });
         compiledFragments.push(
           ...[...byPosition.values()].map((item) => ({
@@ -236,13 +267,30 @@ export function compileSource<Snapshot extends SchemaSnapshot, Policy>(
     diagnostics.push(...resolved.diagnostics.map((diagnostic) => mapDiagnostic(source, query, diagnostic)));
     if (!resolved.diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
       const queryFingerprint = identify(query.sql);
+      const semantics = sourceSemantics(source, query, resolved.semantics);
       compiled.push({
         query,
         rowType: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
         parameterType: parameterTypeLiteral(query.parameterCount, resolved.parameters),
         fingerprint: queryFingerprint,
         variantFingerprints: Object.freeze([queryFingerprint]),
-        semantics: sourceSemantics(source, query, resolved.semantics),
+        variants: Object.freeze([
+          {
+            fingerprint: queryFingerprint,
+            rowType: resolved.resultKind === "command" ? "never" : rowTypeLiteral(resolved.columns),
+            parameterType: parameterTypeLiteral(query.parameterCount, resolved.parameters),
+            choices: Object.freeze({}),
+            columns: Object.freeze(
+              resolved.columns.map((column) => ({
+                ...column,
+                range: mapSqlRange(source, query, column.range),
+              })),
+            ),
+            parameters: Object.freeze(resolved.parameters.map((parameter) => Object.freeze({ ...parameter }))),
+            semantics,
+          },
+        ]),
+        semantics,
       });
     }
   }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,6 +1,41 @@
 export type { CheckFileOptions, CheckFileResult, TypeScriptCheckResult } from "./check.js";
 export { checkFile } from "./check.js";
-export type { CompiledFragment, CompiledQuery, CompileSourceOptions, CompileSourceResult } from "./compiler.js";
+export type {
+  CompiledFragment,
+  CompiledQuery,
+  CompiledQueryVariant,
+  CompileSourceOptions,
+  CompileSourceResult,
+} from "./compiler.js";
 export { compileSource } from "./compiler.js";
-export type { ExtractedInterpolation, ExtractedQuery } from "./scanner.js";
-export { extractStaticQueries, mapSqlRange } from "./scanner.js";
+export type {
+  BuildQueryManifestOptions,
+  BuildQueryManifestResult,
+  QueryManifest,
+  QueryManifestBuildStats,
+  QueryManifestColumn,
+  QueryManifestDiagnostic,
+  QueryManifestEntry,
+  QueryManifestLocation,
+  QueryManifestParameter,
+  QueryManifestSemanticEvidence,
+  QueryManifestSemanticFact,
+  QueryManifestSemantics,
+  QueryManifestSource,
+  QueryManifestSourceInput,
+  QueryManifestVariant,
+  ResolvedQueryManifestEntry,
+  UnresolvedQueryManifestEntry,
+} from "./manifest.js";
+export {
+  buildQueryManifest,
+  parseQueryManifest,
+  QUERY_FINGERPRINT_ALGORITHM,
+  QUERY_MANIFEST_FORMAT_VERSION,
+  QUERY_MANIFEST_JSON_SCHEMA,
+  serializeQueryManifest,
+} from "./manifest.js";
+export type { ListProjectSourceFilesOptions } from "./project.js";
+export { listProjectSourceFiles } from "./project.js";
+export type { ExtractedDynamicQuery, ExtractedInterpolation, ExtractedQuery } from "./scanner.js";
+export { extractDynamicQueries, extractStaticQueries, mapSqlRange } from "./scanner.js";

--- a/packages/compiler/src/manifest.ts
+++ b/packages/compiler/src/manifest.ts
@@ -1,0 +1,827 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import type {
+  DialectPlugin,
+  QuerySemantics,
+  ResolvedColumn,
+  ResolvedParameter,
+  SchemaSnapshot,
+  SourceRange,
+  SqlDiagnostic,
+} from "@typed-sql/core";
+import { calculateSchemaHash, calculateTypePolicyHash } from "@typed-sql/schema";
+import { compileSource } from "./compiler.js";
+import { extractDynamicQueries, extractStaticQueries } from "./scanner.js";
+
+export const QUERY_MANIFEST_FORMAT_VERSION = 1 as const;
+export const QUERY_FINGERPRINT_ALGORITHM = "typed-sql-v1" as const;
+
+export interface QueryManifestSourceInput {
+  readonly file: string;
+  readonly source: string;
+}
+
+export interface QueryManifestSource {
+  readonly file: string;
+  readonly hash: string;
+}
+
+export interface QueryManifestLocation {
+  readonly file: string;
+  readonly range: SourceRange;
+}
+
+export interface QueryManifestDiagnostic {
+  readonly code: string;
+  readonly severity: SqlDiagnostic["severity"];
+  readonly range: SourceRange;
+}
+
+export interface QueryManifestSemanticEvidence {
+  readonly kind: QuerySemantics["operation"]["evidence"][number]["kind"];
+  readonly range: SourceRange;
+}
+
+export interface QueryManifestSemanticFact<Value extends string = string> {
+  readonly value: Value;
+  readonly evidence: readonly QueryManifestSemanticEvidence[];
+}
+
+export interface QueryManifestSemantics {
+  readonly version: QuerySemantics["version"];
+  readonly operation: QueryManifestSemanticFact<QuerySemantics["operation"]["value"]>;
+  readonly dependencies: QuerySemantics["dependencies"];
+  readonly cardinality: {
+    readonly minimum: QuerySemantics["cardinality"]["minimum"];
+    readonly maximum: QuerySemantics["cardinality"]["maximum"];
+    readonly evidence: readonly QueryManifestSemanticEvidence[];
+  };
+  readonly volatility: QueryManifestSemanticFact<QuerySemantics["volatility"]["value"]>;
+  readonly locking: QueryManifestSemanticFact<QuerySemantics["locking"]["value"]>;
+  readonly connectionAffinity: QueryManifestSemanticFact<QuerySemantics["connectionAffinity"]["value"]>;
+  readonly capabilities: readonly string[];
+}
+
+export interface QueryManifestColumn {
+  readonly name: string;
+  readonly tsType: string;
+  readonly nullable: boolean;
+  readonly databaseType?: string;
+}
+
+export interface QueryManifestParameter {
+  readonly index: number;
+  readonly tsType: string;
+  readonly nullable: boolean;
+  readonly databaseType?: string;
+}
+
+export interface QueryManifestVariant {
+  readonly fingerprint: string;
+  readonly choices: Readonly<Record<string, boolean>>;
+  readonly rowType: string;
+  readonly parameterType: string;
+  readonly columns: readonly QueryManifestColumn[];
+  readonly parameters: readonly QueryManifestParameter[];
+  readonly semantics: QueryManifestSemantics;
+}
+
+interface QueryManifestEntryBase {
+  readonly id: string;
+  readonly source: QueryManifestLocation;
+}
+
+export interface ResolvedQueryManifestEntry extends QueryManifestEntryBase {
+  readonly status: "resolved";
+  readonly structural: boolean;
+  readonly fingerprint: string;
+  readonly rowType: string;
+  readonly parameterType: string;
+  readonly diagnostics: readonly QueryManifestDiagnostic[];
+  readonly variants: readonly QueryManifestVariant[];
+  readonly semantics: QueryManifestSemantics;
+}
+
+export interface UnresolvedQueryManifestEntry extends QueryManifestEntryBase {
+  readonly status: "unresolved";
+  readonly reason: "diagnostic" | "dynamic";
+  readonly diagnostics: readonly QueryManifestDiagnostic[];
+}
+
+export type QueryManifestEntry = ResolvedQueryManifestEntry | UnresolvedQueryManifestEntry;
+
+export interface QueryManifest {
+  readonly formatVersion: typeof QUERY_MANIFEST_FORMAT_VERSION;
+  readonly compilerVersion: string;
+  readonly fingerprintAlgorithm: typeof QUERY_FINGERPRINT_ALGORITHM;
+  readonly dialect: {
+    readonly id: string;
+    readonly grammarVersion: string;
+  };
+  readonly schemaHash: string;
+  readonly typePolicyHash: string;
+  readonly projects: readonly string[];
+  readonly sources: readonly QueryManifestSource[];
+  readonly queries: readonly QueryManifestEntry[];
+}
+
+export interface BuildQueryManifestOptions<Snapshot extends SchemaSnapshot, Policy> {
+  readonly rootDir: string;
+  readonly sources: readonly QueryManifestSourceInput[];
+  readonly projects?: readonly string[];
+  readonly dialect: DialectPlugin<Snapshot, Policy>;
+  readonly schema: Snapshot;
+  readonly typePolicy?: Policy;
+  readonly compilerVersion: string;
+  readonly maxStructuralVariants?: number;
+  readonly previous?: QueryManifest;
+}
+
+export interface QueryManifestBuildStats {
+  readonly analyzedFiles: number;
+  readonly reusedFiles: number;
+  readonly resolvedQueries: number;
+  readonly unresolvedQueries: number;
+}
+
+export interface BuildQueryManifestResult {
+  readonly manifest: QueryManifest;
+  readonly stats: QueryManifestBuildStats;
+}
+
+const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
+const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
+
+function portableRelative(rootDir: string, file: string): string {
+  const root = resolve(rootDir);
+  const path = relative(root, isAbsolute(file) ? resolve(file) : resolve(root, file))
+    .split(sep)
+    .join("/");
+  if (path.length === 0 || isAbsolute(path)) throw new TypeError(`Cannot make ${file} relative to ${rootDir}`);
+  return path;
+}
+
+function isPortableRelativePath(path: string): boolean {
+  return (
+    path.length > 0 &&
+    !path.startsWith("/") &&
+    !path.startsWith("\\") &&
+    !/^[A-Za-z]:[\\/]/u.test(path) &&
+    !path.includes("\0")
+  );
+}
+
+function columnDescription(column: ResolvedColumn): QueryManifestColumn {
+  return {
+    name: column.name,
+    tsType: column.tsType,
+    nullable: column.nullable,
+    ...(column.databaseType === undefined ? {} : { databaseType: column.databaseType }),
+  };
+}
+
+function parameterDescription(parameter: ResolvedParameter): QueryManifestParameter {
+  return {
+    index: parameter.index,
+    tsType: parameter.tsType,
+    nullable: parameter.nullable,
+    ...(parameter.databaseType === undefined ? {} : { databaseType: parameter.databaseType }),
+  };
+}
+
+function choiceDescriptions(choices: Readonly<Record<string, boolean>>): Readonly<Record<string, boolean>> {
+  return Object.fromEntries(
+    Object.entries(choices)
+      .map(([condition, enabled]) => [`sha256:${sha256(condition)}`, enabled] as const)
+      .sort(([left], [right]) => compareText(left, right)),
+  );
+}
+
+function manifestDiagnostic(diagnostic: SqlDiagnostic): QueryManifestDiagnostic {
+  return { code: diagnostic.code, severity: diagnostic.severity, range: diagnostic.range };
+}
+
+function manifestSemantics(semantics: QuerySemantics): QueryManifestSemantics {
+  const evidence = (items: QuerySemantics["operation"]["evidence"]): readonly QueryManifestSemanticEvidence[] =>
+    items.map((item) => ({ kind: item.kind, range: item.range }));
+  const fact = <Value extends string>(value: {
+    readonly value: Value;
+    readonly evidence: QuerySemantics["operation"]["evidence"];
+  }) => ({
+    value: value.value,
+    evidence: evidence(value.evidence),
+  });
+  return {
+    version: semantics.version,
+    operation: fact(semantics.operation),
+    dependencies: semantics.dependencies,
+    cardinality: { ...semantics.cardinality, evidence: evidence(semantics.cardinality.evidence) },
+    volatility: fact(semantics.volatility),
+    locking: fact(semantics.locking),
+    connectionAffinity: fact(semantics.connectionAffinity),
+    capabilities: semantics.capabilities,
+  };
+}
+
+function entryId(dialect: string, location: QueryManifestLocation, identity: string): string {
+  return `sha256:${sha256(`${dialect}\0${location.file}\0${location.range.start}\0${identity}`)}`;
+}
+
+function inRange(diagnostic: SqlDiagnostic, range: SourceRange): boolean {
+  return diagnostic.range.start >= range.start && diagnostic.range.start < range.end;
+}
+
+function sourceEntries<Snapshot extends SchemaSnapshot, Policy>(
+  file: string,
+  source: string,
+  options: BuildQueryManifestOptions<Snapshot, Policy>,
+): readonly QueryManifestEntry[] {
+  const compilation = compileSource({
+    source,
+    dialect: options.dialect,
+    schema: options.schema,
+    ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),
+    ...(options.maxStructuralVariants === undefined ? {} : { maxStructuralVariants: options.maxStructuralVariants }),
+  });
+  const extracted = extractStaticQueries(source, (index) => options.dialect.placeholder(index), [
+    options.dialect.sqlModule,
+  ]);
+  const compiledByStart = new Map(compilation.queries.map((query) => [query.query.range.start, query]));
+  const entries: QueryManifestEntry[] = extracted.map((query) => {
+    const location = { file, range: query.range };
+    const compiled = compiledByStart.get(query.range.start);
+    if (compiled === undefined) {
+      const diagnostics = compilation.diagnostics.filter((diagnostic) => inRange(diagnostic, query.range));
+      return {
+        id: entryId(options.dialect.id, location, `unresolved\0${query.sql}`),
+        source: location,
+        status: "unresolved",
+        reason: "diagnostic",
+        diagnostics: diagnostics.map(manifestDiagnostic),
+      };
+    }
+    return {
+      id: entryId(options.dialect.id, location, compiled.fingerprint),
+      source: location,
+      status: "resolved",
+      structural: compiled.structural === true,
+      fingerprint: compiled.fingerprint,
+      rowType: compiled.rowType,
+      parameterType: compiled.parameterType,
+      diagnostics: compilation.diagnostics
+        .filter((diagnostic) => inRange(diagnostic, query.range))
+        .map(manifestDiagnostic),
+      variants: compiled.variants.map((variant) => ({
+        fingerprint: variant.fingerprint,
+        choices: choiceDescriptions(variant.choices),
+        rowType: variant.rowType,
+        parameterType: variant.parameterType,
+        columns: variant.columns.map(columnDescription),
+        parameters: variant.parameters.map(parameterDescription),
+        semantics: manifestSemantics(variant.semantics),
+      })),
+      semantics: manifestSemantics(compiled.semantics),
+    };
+  });
+  for (const dynamic of extractDynamicQueries(source, [options.dialect.sqlModule])) {
+    const location = { file, range: dynamic.range };
+    entries.push({
+      id: entryId(options.dialect.id, location, "dynamic"),
+      source: location,
+      status: "unresolved",
+      reason: "dynamic",
+      diagnostics: [
+        {
+          code: "TSQ005",
+          severity: "info",
+          range: dynamic.range,
+        },
+      ],
+    });
+  }
+  return entries.sort((left, right) => left.source.range.start - right.source.range.start);
+}
+
+function compatiblePrevious(
+  previous: QueryManifest | undefined,
+  compilerVersion: string,
+  dialect: DialectPlugin,
+  schemaHash: string,
+  typePolicyHash: string,
+): previous is QueryManifest {
+  return (
+    previous?.formatVersion === QUERY_MANIFEST_FORMAT_VERSION &&
+    previous.compilerVersion === compilerVersion &&
+    previous.fingerprintAlgorithm === QUERY_FINGERPRINT_ALGORITHM &&
+    previous.dialect.id === dialect.id &&
+    previous.dialect.grammarVersion === dialect.grammarVersion &&
+    previous.schemaHash === schemaHash &&
+    previous.typePolicyHash === typePolicyHash
+  );
+}
+
+export function buildQueryManifest<Snapshot extends SchemaSnapshot, Policy>(
+  options: BuildQueryManifestOptions<Snapshot, Policy>,
+): BuildQueryManifestResult {
+  if (options.compilerVersion.length === 0) throw new TypeError("compilerVersion must be a non-empty string");
+  if (options.schema.dialect !== options.dialect.id) {
+    throw new TypeError(`Dialect ${options.dialect.id} cannot build a manifest for ${options.schema.dialect}`);
+  }
+  const schemaHash = calculateSchemaHash(options.schema);
+  const typePolicyHash = calculateTypePolicyHash(options.typePolicy ?? {});
+  const inputs = options.sources
+    .map((input) => ({ input, file: portableRelative(options.rootDir, input.file), hash: sha256(input.source) }))
+    .sort((left, right) => compareText(left.file, right.file));
+  const duplicate = inputs.find((input, index) => input.file === inputs[index - 1]?.file);
+  if (duplicate !== undefined) throw new TypeError(`Duplicate manifest source ${duplicate.file}`);
+
+  const mayReuse = compatiblePrevious(
+    options.previous,
+    options.compilerVersion,
+    options.dialect,
+    schemaHash,
+    typePolicyHash,
+  );
+  const previousSources = new Map(options.previous?.sources.map((source) => [source.file, source.hash]) ?? []);
+  const previousEntries = new Map<string, readonly QueryManifestEntry[]>();
+  for (const entry of options.previous?.queries ?? []) {
+    const entries = previousEntries.get(entry.source.file);
+    previousEntries.set(entry.source.file, entries === undefined ? [entry] : [...entries, entry]);
+  }
+
+  let analyzedFiles = 0;
+  let reusedFiles = 0;
+  const queries = inputs.flatMap(({ input, file, hash }) => {
+    if (mayReuse && previousSources.get(file) === hash) {
+      reusedFiles += 1;
+      return previousEntries.get(file) ?? [];
+    }
+    analyzedFiles += 1;
+    return sourceEntries(file, input.source, options);
+  });
+  queries.sort(
+    (left, right) =>
+      compareText(left.source.file, right.source.file) || left.source.range.start - right.source.range.start,
+  );
+  const projects = [
+    ...new Set((options.projects ?? []).map((project) => portableRelative(options.rootDir, project))),
+  ].sort();
+  const manifest: QueryManifest = {
+    formatVersion: QUERY_MANIFEST_FORMAT_VERSION,
+    compilerVersion: options.compilerVersion,
+    fingerprintAlgorithm: QUERY_FINGERPRINT_ALGORITHM,
+    dialect: { id: options.dialect.id, grammarVersion: options.dialect.grammarVersion },
+    schemaHash,
+    typePolicyHash,
+    projects,
+    sources: inputs.map(({ file, hash }) => ({ file, hash })),
+    queries,
+  };
+  return {
+    manifest,
+    stats: {
+      analyzedFiles,
+      reusedFiles,
+      resolvedQueries: queries.filter((query) => query.status === "resolved").length,
+      unresolvedQueries: queries.filter((query) => query.status === "unresolved").length,
+    },
+  };
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => compareText(left, right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+}
+
+export function serializeQueryManifest(manifest: QueryManifest): string {
+  return `${JSON.stringify(canonicalize(manifest), null, 2)}\n`;
+}
+
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertString(value: unknown, description: string): asserts value is string {
+  if (typeof value !== "string") throw new TypeError(`${description} must be a string`);
+}
+
+function assertRange(value: unknown, description: string): asserts value is SourceRange {
+  if (!record(value)) throw new TypeError(`${description} must be a source range`);
+  for (const property of ["start", "end", "line", "column"] as const) {
+    const minimum = property === "line" || property === "column" ? 1 : 0;
+    if (!Number.isSafeInteger(value[property]) || (value[property] as number) < minimum) {
+      throw new TypeError(`${description}.${property} must be a safe integer greater than or equal to ${minimum}`);
+    }
+  }
+  if ((value.end as number) < (value.start as number)) throw new TypeError(`${description}.end must not precede start`);
+}
+
+function assertDiagnostics(value: unknown, description: string): asserts value is readonly QueryManifestDiagnostic[] {
+  if (!Array.isArray(value)) throw new TypeError(`${description} must be an array`);
+  for (const diagnostic of value) {
+    if (!record(diagnostic)) throw new TypeError(`${description} entries must be objects`);
+    assertString(diagnostic.code, `${description} code`);
+    if (!(["error", "warning", "info"] as const).includes(diagnostic.severity as never)) {
+      throw new TypeError(`${description} severity is unsupported`);
+    }
+    assertRange(diagnostic.range, `${description} range`);
+  }
+}
+
+function assertEvidence(value: unknown, description: string): void {
+  if (!Array.isArray(value)) throw new TypeError(`${description} must be an array`);
+  for (const evidence of value) {
+    if (!record(evidence) || !(["syntax", "schema", "conservative"] as const).includes(evidence.kind as never)) {
+      throw new TypeError(`${description} contains unsupported evidence`);
+    }
+    assertRange(evidence.range, `${description} range`);
+  }
+}
+
+function assertFact(value: unknown, allowed: readonly string[], description: string): void {
+  if (!record(value) || typeof value.value !== "string" || !allowed.includes(value.value)) {
+    throw new TypeError(`${description} contains an unsupported value`);
+  }
+  assertEvidence(value.evidence, `${description} evidence`);
+}
+
+function assertSemantics(value: unknown, description: string): asserts value is QueryManifestSemantics {
+  if (!record(value) || value.version !== 1) throw new TypeError(`${description} must use semantics version 1`);
+  assertFact(value.operation, ["read", "write", "ddl", "transaction-control", "unknown"], `${description} operation`);
+  assertFact(value.volatility, ["immutable", "stable", "volatile", "unknown"], `${description} volatility`);
+  assertFact(value.locking, ["none", "row", "table", "unknown"], `${description} locking`);
+  assertFact(value.connectionAffinity, ["none", "transaction", "session", "unknown"], `${description} affinity`);
+  if (!record(value.cardinality) || (value.cardinality.minimum !== 0 && value.cardinality.minimum !== 1)) {
+    throw new TypeError(`${description} cardinality is invalid`);
+  }
+  if (![0, 1, "many", "unknown"].includes(value.cardinality.maximum as never)) {
+    throw new TypeError(`${description} cardinality maximum is invalid`);
+  }
+  assertEvidence(value.cardinality.evidence, `${description} cardinality evidence`);
+  if (!Array.isArray(value.dependencies)) throw new TypeError(`${description} dependencies must be an array`);
+  for (const dependency of value.dependencies) {
+    if (!record(dependency)) throw new TypeError(`${description} dependencies must contain objects`);
+    for (const property of ["kind", "access", "name", "certainty"] as const) {
+      assertString(dependency[property], `${description} dependency ${property}`);
+    }
+    if (
+      !["relation", "column", "function", "type", "sequence", "unknown"].includes(dependency.kind as never) ||
+      !["read", "write", "execute", "reference", "unknown"].includes(dependency.access as never) ||
+      !["resolved", "syntactic"].includes(dependency.certainty as never)
+    ) {
+      throw new TypeError(`${description} dependency classification is unsupported`);
+    }
+    if (dependency.schema !== undefined) assertString(dependency.schema, `${description} dependency schema`);
+    if (dependency.parent !== undefined) assertString(dependency.parent, `${description} dependency parent`);
+    assertRange(dependency.range, `${description} dependency range`);
+  }
+  if (!Array.isArray(value.capabilities) || value.capabilities.some((capability) => typeof capability !== "string")) {
+    throw new TypeError(`${description} capabilities must contain strings`);
+  }
+}
+
+function assertVariant(value: unknown, description: string): asserts value is QueryManifestVariant {
+  if (!record(value)) throw new TypeError(`${description} must be an object`);
+  assertString(value.fingerprint, `${description}.fingerprint`);
+  assertString(value.rowType, `${description}.rowType`);
+  assertString(value.parameterType, `${description}.parameterType`);
+  if (!/^sha256:[a-f\d]{64}$/u.test(value.fingerprint)) {
+    throw new TypeError(`${description}.fingerprint must use SHA-256`);
+  }
+  if (
+    !record(value.choices) ||
+    Object.entries(value.choices).some(
+      ([choice, enabled]) => !/^sha256:[a-f\d]{64}$/u.test(choice) || typeof enabled !== "boolean",
+    )
+  ) {
+    throw new TypeError(`${description}.choices must contain booleans`);
+  }
+  if (!Array.isArray(value.columns) || !Array.isArray(value.parameters)) {
+    throw new TypeError(`${description} columns and parameters must be arrays`);
+  }
+  for (const column of value.columns) {
+    if (!record(column) || typeof column.nullable !== "boolean") {
+      throw new TypeError(`${description} columns are invalid`);
+    }
+    assertString(column.name, `${description} column name`);
+    assertString(column.tsType, `${description} column tsType`);
+    if (column.databaseType !== undefined) assertString(column.databaseType, `${description} column databaseType`);
+  }
+  for (const parameter of value.parameters) {
+    if (
+      !record(parameter) ||
+      !Number.isSafeInteger(parameter.index) ||
+      (parameter.index as number) < 1 ||
+      typeof parameter.nullable !== "boolean"
+    ) {
+      throw new TypeError(`${description} parameters are invalid`);
+    }
+    assertString(parameter.tsType, `${description} parameter tsType`);
+    if (parameter.databaseType !== undefined) {
+      assertString(parameter.databaseType, `${description} parameter databaseType`);
+    }
+  }
+  assertSemantics(value.semantics, `${description} semantics`);
+}
+
+export function parseQueryManifest(value: unknown): QueryManifest {
+  if (!record(value)) throw new TypeError("Query manifest must be an object");
+  if (value.formatVersion !== QUERY_MANIFEST_FORMAT_VERSION) {
+    throw new TypeError(
+      `Unsupported query manifest format ${String(value.formatVersion)}; this release supports format ${QUERY_MANIFEST_FORMAT_VERSION}`,
+    );
+  }
+  if (typeof value.compilerVersion !== "string" || value.compilerVersion.length === 0) {
+    throw new TypeError("Query manifest compilerVersion must be a non-empty string");
+  }
+  if (value.fingerprintAlgorithm !== QUERY_FINGERPRINT_ALGORITHM) {
+    throw new TypeError(`Unsupported query fingerprint algorithm ${String(value.fingerprintAlgorithm)}`);
+  }
+  if (
+    !record(value.dialect) ||
+    typeof value.dialect.id !== "string" ||
+    value.dialect.id.length === 0 ||
+    typeof value.dialect.grammarVersion !== "string" ||
+    value.dialect.grammarVersion.length === 0
+  ) {
+    throw new TypeError("Query manifest dialect must contain id and grammarVersion");
+  }
+  if (
+    typeof value.schemaHash !== "string" ||
+    !/^[a-f\d]{64}$/u.test(value.schemaHash) ||
+    typeof value.typePolicyHash !== "string" ||
+    !/^[a-f\d]{64}$/u.test(value.typePolicyHash)
+  ) {
+    throw new TypeError("Query manifest schemaHash and typePolicyHash must be strings");
+  }
+  if (!Array.isArray(value.projects) || !Array.isArray(value.sources) || !Array.isArray(value.queries)) {
+    throw new TypeError("Query manifest projects, sources, and queries must be arrays");
+  }
+  if (value.projects.some((project) => typeof project !== "string" || !isPortableRelativePath(project))) {
+    throw new TypeError("Query manifest projects must contain relative paths");
+  }
+  for (const source of value.sources) {
+    if (
+      !record(source) ||
+      typeof source.file !== "string" ||
+      !isPortableRelativePath(source.file) ||
+      typeof source.hash !== "string" ||
+      !/^[a-f\d]{64}$/u.test(source.hash)
+    ) {
+      throw new TypeError("Query manifest sources must contain relative file paths and hashes");
+    }
+  }
+  for (const query of value.queries) {
+    if (
+      !record(query) ||
+      typeof query.id !== "string" ||
+      !/^sha256:[a-f\d]{64}$/u.test(query.id) ||
+      !record(query.source)
+    ) {
+      throw new TypeError("Query manifest entries must contain id and source");
+    }
+    const location = query.source;
+    if (typeof location.file !== "string" || !isPortableRelativePath(location.file) || !record(location.range)) {
+      throw new TypeError("Query manifest entry sources must contain a relative file and range");
+    }
+    assertRange(location.range, "Query manifest source range");
+    if (query.status === "resolved") {
+      if (
+        typeof query.fingerprint !== "string" ||
+        !/^sha256:[a-f\d]{64}$/u.test(query.fingerprint) ||
+        typeof query.rowType !== "string" ||
+        typeof query.parameterType !== "string" ||
+        typeof query.structural !== "boolean" ||
+        !Array.isArray(query.variants) ||
+        query.variants.length === 0
+      ) {
+        throw new TypeError("Resolved query manifest entries are incomplete");
+      }
+      assertDiagnostics(query.diagnostics, "Resolved query diagnostics");
+      for (const [index, variant] of query.variants.entries()) {
+        assertVariant(variant, `Query manifest variant ${index}`);
+      }
+      assertSemantics(query.semantics, "Resolved query semantics");
+    } else if (query.status === "unresolved") {
+      if (query.reason !== "diagnostic" && query.reason !== "dynamic") {
+        throw new TypeError("Unresolved query manifest entries are incomplete");
+      }
+      assertDiagnostics(query.diagnostics, "Unresolved query diagnostics");
+      if (query.diagnostics.length === 0) throw new TypeError("Unresolved query diagnostics cannot be empty");
+    } else throw new TypeError(`Unsupported query manifest entry status ${String(query.status)}`);
+  }
+  return value as unknown as QueryManifest;
+}
+
+/** Machine-readable public contract. Readers accept unknown object properties within format v1. */
+export const QUERY_MANIFEST_JSON_SCHEMA = Object.freeze({
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "urn:typed-sql:query-manifest:1",
+  title: "typed-sql query manifest",
+  type: "object",
+  $defs: {
+    relativePath: { type: "string", minLength: 1, pattern: "^(?!/|\\\\|[A-Za-z]:[\\\\/])(?!.*\\u0000).+$" },
+    hash: { type: "string", pattern: "^[a-f0-9]{64}$" },
+    fingerprint: { type: "string", pattern: "^sha256:[a-f0-9]{64}$" },
+    range: {
+      type: "object",
+      required: ["start", "end", "line", "column"],
+      properties: {
+        start: { type: "integer", minimum: 0 },
+        end: { type: "integer", minimum: 0 },
+        line: { type: "integer", minimum: 1 },
+        column: { type: "integer", minimum: 1 },
+      },
+    },
+    diagnostic: {
+      type: "object",
+      required: ["code", "range", "severity"],
+      properties: {
+        code: { type: "string" },
+        range: { $ref: "#/$defs/range" },
+        severity: { enum: ["error", "warning", "info"] },
+      },
+    },
+    evidence: {
+      type: "object",
+      required: ["kind", "range"],
+      properties: {
+        kind: { enum: ["syntax", "schema", "conservative"] },
+        range: { $ref: "#/$defs/range" },
+      },
+    },
+    fact: {
+      type: "object",
+      required: ["value", "evidence"],
+      properties: {
+        value: { type: "string" },
+        evidence: { type: "array", items: { $ref: "#/$defs/evidence" } },
+      },
+    },
+    dependency: {
+      type: "object",
+      required: ["kind", "access", "name", "certainty", "range"],
+      properties: {
+        kind: { enum: ["relation", "column", "function", "type", "sequence", "unknown"] },
+        access: { enum: ["read", "write", "execute", "reference", "unknown"] },
+        name: { type: "string" },
+        schema: { type: "string" },
+        parent: { type: "string" },
+        certainty: { enum: ["resolved", "syntactic"] },
+        range: { $ref: "#/$defs/range" },
+      },
+    },
+    semantics: {
+      type: "object",
+      required: [
+        "version",
+        "operation",
+        "dependencies",
+        "cardinality",
+        "volatility",
+        "locking",
+        "connectionAffinity",
+        "capabilities",
+      ],
+      properties: {
+        version: { const: 1 },
+        operation: { $ref: "#/$defs/fact" },
+        dependencies: { type: "array", items: { $ref: "#/$defs/dependency" } },
+        cardinality: {
+          type: "object",
+          required: ["minimum", "maximum", "evidence"],
+          properties: {
+            minimum: { enum: [0, 1] },
+            maximum: { enum: [0, 1, "many", "unknown"] },
+            evidence: { type: "array", items: { $ref: "#/$defs/evidence" } },
+          },
+        },
+        volatility: { $ref: "#/$defs/fact" },
+        locking: { $ref: "#/$defs/fact" },
+        connectionAffinity: { $ref: "#/$defs/fact" },
+        capabilities: { type: "array", items: { type: "string" } },
+      },
+    },
+    column: {
+      type: "object",
+      required: ["name", "tsType", "nullable"],
+      properties: {
+        name: { type: "string" },
+        tsType: { type: "string" },
+        nullable: { type: "boolean" },
+        databaseType: { type: "string" },
+      },
+    },
+    parameter: {
+      type: "object",
+      required: ["index", "tsType", "nullable"],
+      properties: {
+        index: { type: "integer", minimum: 1 },
+        tsType: { type: "string" },
+        nullable: { type: "boolean" },
+        databaseType: { type: "string" },
+      },
+    },
+    variant: {
+      type: "object",
+      required: ["fingerprint", "choices", "rowType", "parameterType", "columns", "parameters", "semantics"],
+      properties: {
+        fingerprint: { $ref: "#/$defs/fingerprint" },
+        choices: {
+          type: "object",
+          propertyNames: { $ref: "#/$defs/fingerprint" },
+          additionalProperties: { type: "boolean" },
+        },
+        rowType: { type: "string" },
+        parameterType: { type: "string" },
+        columns: { type: "array", items: { $ref: "#/$defs/column" } },
+        parameters: { type: "array", items: { $ref: "#/$defs/parameter" } },
+        semantics: { $ref: "#/$defs/semantics" },
+      },
+    },
+    location: {
+      type: "object",
+      required: ["file", "range"],
+      properties: { file: { $ref: "#/$defs/relativePath" }, range: { $ref: "#/$defs/range" } },
+    },
+    resolvedQuery: {
+      type: "object",
+      required: [
+        "id",
+        "source",
+        "status",
+        "structural",
+        "fingerprint",
+        "rowType",
+        "parameterType",
+        "diagnostics",
+        "variants",
+        "semantics",
+      ],
+      properties: {
+        id: { $ref: "#/$defs/fingerprint" },
+        source: { $ref: "#/$defs/location" },
+        status: { const: "resolved" },
+        structural: { type: "boolean" },
+        fingerprint: { $ref: "#/$defs/fingerprint" },
+        rowType: { type: "string" },
+        parameterType: { type: "string" },
+        diagnostics: { type: "array", items: { $ref: "#/$defs/diagnostic" } },
+        variants: { type: "array", minItems: 1, items: { $ref: "#/$defs/variant" } },
+        semantics: { $ref: "#/$defs/semantics" },
+      },
+    },
+    unresolvedQuery: {
+      type: "object",
+      required: ["id", "source", "status", "reason", "diagnostics"],
+      properties: {
+        id: { $ref: "#/$defs/fingerprint" },
+        source: { $ref: "#/$defs/location" },
+        status: { const: "unresolved" },
+        reason: { enum: ["diagnostic", "dynamic"] },
+        diagnostics: { type: "array", minItems: 1, items: { $ref: "#/$defs/diagnostic" } },
+      },
+    },
+  },
+  required: [
+    "formatVersion",
+    "compilerVersion",
+    "fingerprintAlgorithm",
+    "dialect",
+    "schemaHash",
+    "typePolicyHash",
+    "projects",
+    "sources",
+    "queries",
+  ],
+  properties: {
+    formatVersion: { const: QUERY_MANIFEST_FORMAT_VERSION },
+    compilerVersion: { type: "string", minLength: 1 },
+    fingerprintAlgorithm: { const: QUERY_FINGERPRINT_ALGORITHM },
+    dialect: {
+      type: "object",
+      required: ["id", "grammarVersion"],
+      properties: { id: { type: "string" }, grammarVersion: { type: "string" } },
+    },
+    schemaHash: { type: "string" },
+    typePolicyHash: { type: "string" },
+    projects: { type: "array", items: { $ref: "#/$defs/relativePath" } },
+    sources: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["file", "hash"],
+        properties: { file: { $ref: "#/$defs/relativePath" }, hash: { $ref: "#/$defs/hash" } },
+      },
+    },
+    queries: {
+      type: "array",
+      items: { oneOf: [{ $ref: "#/$defs/resolvedQuery" }, { $ref: "#/$defs/unresolvedQuery" }] },
+    },
+  },
+} as const);

--- a/packages/compiler/src/project.ts
+++ b/packages/compiler/src/project.ts
@@ -1,0 +1,74 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export interface ListProjectSourceFilesOptions {
+  readonly project: string;
+  readonly cwd?: string;
+  readonly typeScriptTimeoutMs?: number;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tscBinary(start: string): Promise<string> {
+  const name = process.platform === "win32" ? "tsc.cmd" : "tsc";
+  let directory = resolve(start);
+  while (true) {
+    const candidate = join(directory, "node_modules", ".bin", name);
+    if (await exists(candidate)) return candidate;
+    const parent = dirname(directory);
+    if (parent === directory) return name;
+    directory = parent;
+  }
+}
+
+function isApplicationSource(file: string): boolean {
+  return (
+    !file.split(sep).includes("node_modules") && !/\.d\.(?:c|m)?ts$/u.test(file) && /\.(?:c|m)?(?:j|t)sx?$/u.test(file)
+  );
+}
+
+/** Uses the workspace TypeScript executable only for tsconfig file discovery, never compiler analysis. */
+export async function listProjectSourceFiles(options: ListProjectSourceFilesOptions): Promise<readonly string[]> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const project = resolve(cwd, options.project);
+  const timeout = options.typeScriptTimeoutMs ?? 60_000;
+  if (!Number.isSafeInteger(timeout) || timeout < 1) {
+    throw new TypeError("typeScriptTimeoutMs must be a positive safe integer");
+  }
+  const binary = await tscBinary(cwd);
+  try {
+    const result = await execFile(binary, ["--project", project, "--listFilesOnly", "--pretty", "false"], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout,
+    });
+    return [
+      ...new Set(
+        result.stdout
+          .split(/\r?\n/u)
+          .filter(Boolean)
+          .map((file) => (isAbsolute(file) ? file : resolve(cwd, file))),
+      ),
+    ]
+      .filter(isApplicationSource)
+      .sort();
+  } catch (error) {
+    const candidate = error as { readonly stdout?: string; readonly stderr?: string; readonly message?: string };
+    throw new Error(
+      `Could not enumerate TypeScript project ${project}: ${`${candidate.stdout ?? ""}${candidate.stderr ?? ""}${candidate.message ?? ""}`.trim()}`,
+    );
+  }
+}

--- a/packages/compiler/src/scanner.ts
+++ b/packages/compiler/src/scanner.ts
@@ -27,6 +27,11 @@ export interface ExtractedAppendFragment {
   readonly parameterOffset: number;
 }
 
+export interface ExtractedDynamicQuery {
+  readonly tagName: string;
+  readonly range: SourceRange;
+}
+
 export interface StructuralOperand {
   readonly kind: "empty" | "fragment";
   readonly start: number;
@@ -595,6 +600,51 @@ export function extractStaticQueries(
       continue;
     }
     index += 1;
+  }
+  return queries;
+}
+
+/** Locates explicit `sql.dynamic(...)` escape hatches without reading their runtime value. */
+export function extractDynamicQueries(
+  source: string,
+  sqlModules: readonly string[] = ["@typed-sql/core"],
+): readonly ExtractedDynamicQuery[] {
+  const names = importedSqlNames(source, new Set(sqlModules));
+  if (names.size === 0) return [];
+  const queries: ExtractedDynamicQuery[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipQuoted(source, index, char);
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "/") {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "*") {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const tag = identifierAt(source, index);
+    if (tag === undefined) {
+      index += 1;
+      continue;
+    }
+    index = tag.end;
+    if (!names.has(tag.value)) continue;
+    let cursor = skipTrivia(source, tag.end);
+    if (source[cursor] !== ".") continue;
+    cursor = skipTrivia(source, cursor + 1);
+    const member = identifierAt(source, cursor);
+    if (member?.value !== "dynamic") continue;
+    cursor = skipTrivia(source, member.end);
+    if (source[cursor] !== "(") continue;
+    const close = closingParenthesis(source, cursor);
+    const end = close === undefined ? member.end : close + 1;
+    queries.push({ tagName: tag.value, range: positionRange(source, tag.end - tag.value.length, end) });
+    index = end;
   }
   return queries;
 }

--- a/packages/compiler/test/manifest.test.ts
+++ b/packages/compiler/test/manifest.test.ts
@@ -1,0 +1,305 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, strict } from "poku";
+import { type MySqlSchemaSnapshot, mysql, typePolicy as mysqlTypePolicy } from "../../mysql/src/index.js";
+import { type PostgresSchemaSnapshot, postgres, typePolicy as postgresTypePolicy } from "../../postgres/src/index.js";
+import type { SchemaSnapshot } from "../../schema/src/index.js";
+import {
+  buildQueryManifest,
+  listProjectSourceFiles,
+  parseQueryManifest,
+  QUERY_MANIFEST_JSON_SCHEMA,
+  serializeQueryManifest,
+} from "../src/index.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function snapshot(dialect: "mysql" | "postgres"): SchemaSnapshot {
+  return {
+    formatVersion: 1,
+    dialect,
+    tables: {
+      users: {
+        name: "users",
+        columns: {
+          id: {
+            name: "id",
+            databaseType: dialect === "postgres" ? "bigint" : "bigint",
+            tsType: "bigint",
+            nullable: false,
+          },
+          email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
+          status: { name: "status", databaseType: "text", tsType: '"active" | "suspended"', nullable: false },
+        },
+      },
+    },
+  };
+}
+
+const source = [
+  'import { sql } from "@typed-sql/postgres";',
+  "declare const minimum: bigint;",
+  'const query = sql`SELECT users.id, users.email ${process.env["recognizable-secret"] ? sql.fragment`, users.status` : sql.empty} FROM users WHERE users.id >= ${minimum}`;',
+  "const invalid = sql`SELECT missing FROM absent`;",
+  'const runtime = sql.dynamic(process.env.RUNTIME_SQL ?? "SELECT 1");',
+  "void [query, invalid, runtime];",
+].join("\n");
+
+await describe("deterministic query manifests", async () => {
+  await it("emits resolved structural variants and explicit unresolved entries without source values", () => {
+    const root = "/checkout/typed-sql-app";
+    const policy = {
+      ...postgresTypePolicy,
+      connectionString: "postgresql://user:recognizable-secret@localhost/db",
+    };
+    const result = buildQueryManifest({
+      rootDir: root,
+      sources: [{ file: join(root, "src", "accounts.ts"), source }],
+      projects: [join(root, "tsconfig.json")],
+      dialect: postgres(),
+      schema: snapshot("postgres") as PostgresSchemaSnapshot,
+      typePolicy: policy,
+      compilerVersion: "2.0.0-test",
+    });
+    strict.strictEqual(result.stats.resolvedQueries, 1);
+    strict.strictEqual(result.stats.unresolvedQueries, 2);
+    const resolved = result.manifest.queries.find((query) => query.status === "resolved");
+    strict.strictEqual(resolved?.structural, true);
+    strict.strictEqual(resolved?.variants.length, 2);
+    strict.deepStrictEqual(
+      resolved?.variants.map((variant) => variant.parameters.length),
+      [1, 1],
+    );
+    strict.ok(resolved?.variants.some((variant) => variant.columns.some((column) => column.name === "status")));
+    strict.ok(
+      resolved?.variants.every((variant) =>
+        Object.keys(variant.choices).every((choice) => choice.startsWith("sha256:")),
+      ),
+    );
+    strict.ok(resolved?.semantics.dependencies.some((dependency) => dependency.name === "users"));
+    strict.deepStrictEqual(
+      result.manifest.queries.filter((query) => query.status === "unresolved").map((query) => query.reason),
+      ["diagnostic", "dynamic"],
+    );
+    const serialized = serializeQueryManifest(result.manifest);
+    strict.ok(!serialized.includes("recognizable-secret"));
+    strict.ok(!serialized.includes(root));
+    strict.ok(!serialized.includes("RUNTIME_SQL"));
+    strict.deepStrictEqual(parseQueryManifest(JSON.parse(serialized)), JSON.parse(serialized));
+    strict.strictEqual(QUERY_MANIFEST_JSON_SCHEMA.properties.formatVersion.const, 1);
+  });
+
+  await it("is byte-identical across source order and absolute checkout roots", () => {
+    const files = [
+      { relative: "src/z.ts", source: 'import { sql } from "@typed-sql/postgres"; sql`SELECT id FROM users`;' },
+      { relative: "src/a.ts", source: 'import { sql } from "@typed-sql/postgres"; sql`SELECT email FROM users`;' },
+    ];
+    const generate = (root: string, reversed: boolean) =>
+      serializeQueryManifest(
+        buildQueryManifest({
+          rootDir: root,
+          sources: (reversed ? [...files].reverse() : files).map((file) => ({
+            file: join(root, file.relative),
+            source: file.source,
+          })),
+          projects: [join(root, "tsconfig.json")],
+          dialect: postgres(),
+          schema: snapshot("postgres") as PostgresSchemaSnapshot,
+          typePolicy: postgresTypePolicy,
+          compilerVersion: "2.0.0-test",
+        }).manifest,
+      );
+    strict.strictEqual(generate("/first/checkout", false), generate("/different/checkout", true));
+  });
+
+  await it("reuses unchanged source analysis and invalidates changed sources", () => {
+    const root = "/checkout/app";
+    const options = {
+      rootDir: root,
+      sources: [
+        {
+          file: join(root, "query.ts"),
+          source: 'import { sql } from "@typed-sql/postgres"; sql`SELECT id FROM users`;',
+        },
+      ],
+      dialect: postgres(),
+      schema: snapshot("postgres") as PostgresSchemaSnapshot,
+      typePolicy: postgresTypePolicy,
+      compilerVersion: "2.0.0-test",
+    } as const;
+    const initial = buildQueryManifest(options);
+    const reused = buildQueryManifest({ ...options, previous: initial.manifest });
+    strict.deepStrictEqual(reused.stats, {
+      analyzedFiles: 0,
+      reusedFiles: 1,
+      resolvedQueries: 1,
+      unresolvedQueries: 0,
+    });
+    strict.strictEqual(serializeQueryManifest(reused.manifest), serializeQueryManifest(initial.manifest));
+    const changed = buildQueryManifest({
+      ...options,
+      sources: [{ ...options.sources[0], source: `${options.sources[0].source}\n// changed` }],
+      previous: reused.manifest,
+    });
+    strict.strictEqual(changed.stats.analyzedFiles, 1);
+    strict.strictEqual(changed.stats.reusedFiles, 0);
+  });
+
+  await it("uses the same grammar-neutral manifest contract for MySQL", () => {
+    const root = "/checkout/mysql-app";
+    const result = buildQueryManifest({
+      rootDir: root,
+      sources: [
+        {
+          file: join(root, "query.ts"),
+          source:
+            'import { sql } from "@typed-sql/mysql"; declare const id: bigint; sql`SELECT email FROM users WHERE id = ${id}`;',
+        },
+      ],
+      dialect: mysql(),
+      schema: snapshot("mysql") as MySqlSchemaSnapshot,
+      typePolicy: mysqlTypePolicy,
+      compilerVersion: "2.0.0-test",
+    });
+    const query = result.manifest.queries[0];
+    strict.strictEqual(query?.status, "resolved");
+    if (query?.status !== "resolved") throw new Error("Expected a resolved MySQL query");
+    strict.strictEqual(query.variants[0]?.parameters[0]?.tsType, "bigint");
+    strict.strictEqual(query.variants[0]?.columns[0]?.name, "email");
+    strict.ok(query.semantics.dependencies.some((dependency) => dependency.name === "users"));
+    strict.strictEqual(result.manifest.dialect.id, "mysql");
+  });
+
+  await it("rejects incompatible manifest format versions", () => {
+    strict.throws(() => parseQueryManifest({ formatVersion: 2 }), /Unsupported query manifest format 2/u);
+    const root = "/checkout/validation";
+    const valid = JSON.parse(
+      serializeQueryManifest(
+        buildQueryManifest({
+          rootDir: root,
+          sources: [
+            {
+              file: join(root, "query.ts"),
+              source: 'import { sql } from "@typed-sql/postgres"; sql`SELECT id FROM users`;',
+            },
+          ],
+          dialect: postgres(),
+          schema: snapshot("postgres") as PostgresSchemaSnapshot,
+          compilerVersion: "validation",
+        }).manifest,
+      ),
+    ) as Record<string, unknown>;
+    const resolved = (valid.queries as Record<string, unknown>[])[0]!;
+    const variant = (resolved.variants as Record<string, unknown>[])[0]!;
+    const semantics = resolved.semantics as Record<string, unknown>;
+    const sourceLocation = resolved.source as Record<string, unknown>;
+    const sourceRange = sourceLocation.range as Record<string, unknown>;
+    const columns = variant.columns as Record<string, unknown>[];
+    const parameters = variant.parameters as Record<string, unknown>[];
+    for (const invalid of [
+      null,
+      { ...valid, compilerVersion: 1 },
+      { ...valid, compilerVersion: "" },
+      { ...valid, fingerprintAlgorithm: "future" },
+      { ...valid, dialect: null },
+      { ...valid, dialect: { id: "", grammarVersion: "1" } },
+      { ...valid, schemaHash: 1 },
+      { ...valid, typePolicyHash: "invalid" },
+      { ...valid, queries: null },
+      { ...valid, projects: ["/absolute/tsconfig.json"] },
+      { ...valid, sources: [{ file: "/absolute/query.ts", hash: "x" }] },
+      { ...valid, queries: [{ id: 1, source: null }] },
+      {
+        ...valid,
+        queries: [{ ...resolved, source: { ...sourceLocation, range: { ...sourceRange, start: "zero" } } }],
+      },
+      { ...valid, queries: [{ ...resolved, source: { ...sourceLocation, range: { ...sourceRange, end: -1 } } }] },
+      { ...valid, queries: [{ ...resolved, fingerprint: "invalid" }] },
+      { ...valid, queries: [{ ...resolved, structural: "yes" }] },
+      { ...valid, queries: [{ ...resolved, variants: [] }] },
+      { ...valid, queries: [{ ...resolved, diagnostics: [{}] }] },
+      { ...valid, queries: [{ ...resolved, variants: [{ ...variant, fingerprint: "invalid" }] }] },
+      { ...valid, queries: [{ ...resolved, variants: [{ ...variant, choices: { rawCondition: true } }] }] },
+      { ...valid, queries: [{ ...resolved, variants: [{ ...variant, columns: "invalid" }] }] },
+      {
+        ...valid,
+        queries: [{ ...resolved, variants: [{ ...variant, columns: [{ ...columns[0], nullable: "yes" }] }] }],
+      },
+      {
+        ...valid,
+        queries: [{ ...resolved, variants: [{ ...variant, parameters: [{ ...parameters[0], index: 0 }] }] }],
+      },
+      {
+        ...valid,
+        queries: [{ ...resolved, variants: [{ ...variant, semantics: { ...semantics, version: 2 } }] }],
+      },
+      {
+        ...valid,
+        queries: [{ ...resolved, semantics: { ...semantics, capabilities: [1] } }],
+      },
+      {
+        ...valid,
+        queries: [
+          {
+            ...resolved,
+            status: "resolved",
+            diagnostics: undefined,
+          },
+        ],
+      },
+      {
+        ...valid,
+        queries: [{ ...resolved, status: "unresolved", reason: "dynamic", diagnostics: [] }],
+      },
+      {
+        ...valid,
+        queries: [
+          {
+            ...resolved,
+            status: "unresolved",
+            reason: "other",
+            diagnostics: [],
+          },
+        ],
+      },
+      {
+        ...valid,
+        queries: [
+          {
+            ...resolved,
+            status: "future",
+          },
+        ],
+      },
+    ]) {
+      strict.throws(() => parseQueryManifest(invalid));
+    }
+  });
+
+  await it("enumerates application sources through the workspace TypeScript project", async () => {
+    const directory = await mkdtemp(join(workspace, ".typed-sql-project-files-"));
+    try {
+      await mkdir(join(directory, "src"));
+      await writeFile(join(directory, "src", "query.ts"), "export const value = 1;\n");
+      await writeFile(join(directory, "src", "types.d.ts"), "export declare const ignored: true;\n");
+      await writeFile(
+        join(directory, "tsconfig.json"),
+        `${JSON.stringify({ compilerOptions: { module: "NodeNext", moduleResolution: "NodeNext" }, include: ["src"] })}\n`,
+      );
+      strict.deepStrictEqual(await listProjectSourceFiles({ project: "tsconfig.json", cwd: directory }), [
+        join(directory, "src", "query.ts"),
+      ]);
+      await strict.rejects(
+        () => listProjectSourceFiles({ project: "missing.json", cwd: directory }),
+        /Could not enumerate TypeScript project/u,
+      );
+      await strict.rejects(
+        () => listProjectSourceFiles({ project: "tsconfig.json", cwd: directory, typeScriptTimeoutMs: 0 }),
+        /positive safe integer/u,
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -2,5 +2,5 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist" },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../schema" }]
 }

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -3,6 +3,7 @@ export const diagnosticRegistry = Object.freeze({
   TSQ002: { category: "resource", summary: "SQL exceeded a parser resource limit." },
   TSQ003: { category: "resource", summary: "Conditional SQL exceeded the structural variant limit." },
   TSQ004: { category: "contract", summary: "Structural SQL requires an explicitly trusted fragment." },
+  TSQ005: { category: "support", summary: "Runtime SQL cannot be analyzed statically." },
   TSQ007: { category: "contract", summary: "The schema snapshot and dialect do not match." },
   TSQ100: { category: "schema", summary: "A referenced table does not exist." },
   TSQ101: { category: "schema", summary: "A referenced column does not exist." },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -142,6 +142,10 @@ export interface TypedSqlConfig<Snapshot extends SchemaSnapshot = SchemaSnapshot
   readonly compiler?: {
     readonly maxStructuralVariants?: number;
   };
+  readonly manifest?: {
+    /** Output path relative to the typed-sql config file. */
+    readonly outFile?: string;
+  };
 }
 
 function record(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -177,6 +181,9 @@ export function defineConfig<Snapshot extends SchemaSnapshot, Policy>(
   const maximum = config.compiler?.maxStructuralVariants;
   if (maximum !== undefined && (!Number.isSafeInteger(maximum) || maximum < 1)) {
     throw new TypeError("compiler.maxStructuralVariants must be a positive safe integer");
+  }
+  if (config.manifest?.outFile !== undefined && config.manifest.outFile.length === 0) {
+    throw new TypeError("manifest.outFile must be a non-empty string");
   }
   return Object.freeze(config);
 }

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -446,9 +446,11 @@ await describe("core contracts", async () => {
       schema: { file: "schema.json" },
       outDir: "generated",
       compiler: { maxStructuralVariants: 32 },
+      manifest: { outFile: ".typed-sql/queries.json" },
     });
     strict.strictEqual(config.dialect, dialect);
     strict.strictEqual(config.compiler?.maxStructuralVariants, 32);
+    strict.strictEqual(config.manifest?.outFile, ".typed-sql/queries.json");
     strict.ok(Object.isFrozen(config));
     strict.throws(
       () =>
@@ -471,6 +473,16 @@ await describe("core contracts", async () => {
         /positive safe integer/,
       );
     }
+    strict.throws(
+      () =>
+        defineConfig({
+          dialect,
+          schema: { file: "schema.json" },
+          outDir: "generated",
+          manifest: { outFile: "" },
+        }),
+      /manifest\.outFile must be a non-empty string/u,
+    );
   });
 
   await it("validates every public dialect contract boundary", () => {

--- a/packages/mysql/test/decoder-cache.test.ts
+++ b/packages/mysql/test/decoder-cache.test.ts
@@ -1,8 +1,6 @@
-import { performance } from "node:perf_hooks";
 import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import {
-  compileMySqlRowDecoders,
   decodeMySqlRow,
   MySqlDecoderPlanCache,
   type MySqlFieldLike,
@@ -205,41 +203,5 @@ await describe("MySQL decoder plan cache", async () => {
     });
     await changedMetadata.close();
     strict.strictEqual(pool.connection.releaseCount, 2);
-  });
-
-  await it("keeps repeated decoder lookup faster than recompiling stable metadata", () => {
-    const fields = Array.from(
-      { length: 24 },
-      (_, index): MySqlFieldLike => ({
-        name: `column_${index}`,
-        columnType: index % 2 === 0 ? 8 : 246,
-      }),
-    );
-    const cache = new MySqlDecoderPlanCache(defaultPolicy);
-    cache.get(fields);
-    const iterations = 10_000;
-    for (let index = 0; index < 2_000; index += 1) {
-      compileMySqlRowDecoders(fields, defaultPolicy);
-      cache.get(fields);
-    }
-    const uncachedSamples: number[] = [];
-    const cachedSamples: number[] = [];
-    for (let sample = 0; sample < 5; sample += 1) {
-      let start = performance.now();
-      for (let index = 0; index < iterations; index += 1) compileMySqlRowDecoders(fields, defaultPolicy);
-      uncachedSamples.push(performance.now() - start);
-      start = performance.now();
-      for (let index = 0; index < iterations; index += 1) cache.get(fields);
-      cachedSamples.push(performance.now() - start);
-    }
-    uncachedSamples.sort((left, right) => left - right);
-    cachedSamples.sort((left, right) => left - right);
-    const uncachedDuration = uncachedSamples[2]!;
-    const cachedDuration = cachedSamples[2]!;
-
-    strict.ok(
-      cachedDuration < uncachedDuration * 0.8,
-      `Expected cached decoder lookup (${cachedDuration.toFixed(2)}ms) to stay at least 20% below recompilation (${uncachedDuration.toFixed(2)}ms)`,
-    );
   });
 });

--- a/performance-budgets.json
+++ b/performance-budgets.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "methodology": {
     "warmups": 3,
     "samples": 20,
@@ -10,6 +10,8 @@
   "latencyMs": {
     "scanner.largeFile": { "p50": 10, "p95": 25 },
     "compiler.manyQueries": { "p50": 20, "p95": 50 },
+    "compiler.queryManifest": { "p50": 25, "p95": 60 },
+    "compiler.queryManifestIncremental": { "p50": 0.5, "p95": 1 },
     "compiler.semanticMetadata": { "p50": 10, "p95": 25 },
     "compiler.correlatedConditions": { "p50": 5, "p95": 10 },
     "compiler.independentConditions": { "p50": 10, "p95": 25 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@typed-sql/core':
         specifier: workspace:*
         version: link:../core
+      '@typed-sql/schema':
+        specifier: workspace:*
+        version: link:../schema
 
   packages/config:
     dependencies:

--- a/scripts/performance-gate.mjs
+++ b/scripts/performance-gate.mjs
@@ -3,7 +3,11 @@ import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { compileSource, extractStaticQueries } from "../packages/compiler/dist/packages/compiler/src/index.js";
+import {
+  buildQueryManifest,
+  compileSource,
+  extractStaticQueries,
+} from "../packages/compiler/dist/packages/compiler/src/index.js";
 import { renderQuery, sql } from "../packages/core/dist/packages/core/src/index.js";
 import { TypedSqlLanguageService } from "../packages/language-server/dist/packages/language-server/src/index.js";
 import { postgres } from "../packages/postgres/dist/packages/postgres/src/index.js";
@@ -108,6 +112,30 @@ await latency("compiler.manyQueries", () => {
   assert.equal(compiled.queries.length, 250);
   assert.deepEqual(compiled.diagnostics, []);
 });
+
+const manifestOptions = {
+  rootDir: "/benchmark/project",
+  sources: [{ file: "/benchmark/project/src/queries.ts", source: compilerSource }],
+  projects: ["/benchmark/project/tsconfig.json"],
+  schema: snapshot,
+  dialect,
+  compilerVersion: "performance",
+};
+await latency("compiler.queryManifest", () => {
+  const result = buildQueryManifest(manifestOptions);
+  assert.equal(result.manifest.queries.length, 250);
+  assert.equal(result.stats.analyzedFiles, 1);
+});
+const previousManifest = buildQueryManifest(manifestOptions).manifest;
+await latency(
+  "compiler.queryManifestIncremental",
+  () => {
+    const result = buildQueryManifest({ ...manifestOptions, previous: previousManifest });
+    assert.equal(result.manifest.queries.length, 250);
+    assert.equal(result.stats.reusedFiles, 1);
+  },
+  { iterations: methodology.subMillisecondIterations },
+);
 
 const semanticQueries = Array.from(
   { length: 250 },

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -5,6 +5,10 @@ import {
   renderQuery,
   sql,
 } from "../../packages/core/dist/packages/core/src/index.js";
+import {
+  compileMySqlRowDecoders,
+  MySqlDecoderPlanCache,
+} from "../../packages/mysql/dist/packages/mysql/src/decoding.js";
 import { createMySqlDatabase, mysqlRenderer } from "../../packages/mysql/dist/packages/mysql/src/runtime.js";
 import {
   createPostgresDatabase,
@@ -324,6 +328,41 @@ export async function deterministicMicrobenchmarks(methodology) {
     assert.equal(Object.keys(decoded[0]).length, columnCount);
     assert.equal(decoded[0].value_0, 1n);
   }
+
+  const decoderFields = Array.from({ length: 24 }, (_, index) => ({
+    name: `column_${index}`,
+    columnType: index % 2 === 0 ? 8 : 246,
+  }));
+  const decoderPolicy = {
+    bigint: "bigint",
+    decimal: "string",
+    date: "Date",
+    json: "json",
+    tinyint1: "boolean",
+  };
+  const decoderCache = new MySqlDecoderPlanCache(decoderPolicy);
+  const cachedDecoderPlan = decoderCache.get(decoderFields);
+  let decoderPlan;
+  results["micro.mysql.decoderPlanCacheHit"] = throughput(
+    () => {
+      decoderPlan = decoderCache.get(decoderFields);
+    },
+    methodology,
+    renderIterations,
+  );
+  assert.equal(decoderPlan, cachedDecoderPlan);
+  results["micro.mysql.decoderPlanCompile"] = throughput(
+    () => {
+      decoderPlan = compileMySqlRowDecoders(decoderFields, decoderPolicy);
+    },
+    methodology,
+    renderIterations,
+  );
+  assert.equal(decoderPlan.length, decoderFields.length);
+  assert.ok(
+    results["micro.mysql.decoderPlanCacheHit"].p50 > results["micro.mysql.decoderPlanCompile"].p50,
+    "MySQL decoder plan cache hits must remain faster than recompilation",
+  );
 
   let mysqlValues;
   const mysqlEncodingPool = {

--- a/test/contracts/diagnostic-registry.test.ts
+++ b/test/contracts/diagnostic-registry.test.ts
@@ -9,6 +9,7 @@ const sources = [
   "packages/ast/src/parser.ts",
   "packages/ast/src/tokenizer.ts",
   "packages/compiler/src/compiler.ts",
+  "packages/compiler/src/manifest.ts",
   "packages/postgres/src/resolver.ts",
   "packages/mysql/src/resolver.ts",
   "packages/cli/src/cli.ts",

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -19,6 +19,7 @@ const expectedPublicDocs = [
   "docs/guides/editors.md",
   "docs/guides/execution.md",
   "docs/guides/observability.md",
+  "docs/guides/query-manifests.md",
   "docs/guides/schema-snapshots.md",
   "docs/index.md",
   "docs/reference/api.md",

--- a/test/contracts/observation.test.ts
+++ b/test/contracts/observation.test.ts
@@ -1,5 +1,6 @@
+import { fileURLToPath } from "node:url";
 import { describe, it, strict } from "poku";
-import { compileSource } from "../../packages/compiler/src/index.js";
+import { buildQueryManifest, compileSource } from "../../packages/compiler/src/index.js";
 import type { DatabaseObserver, DatabaseOperationStart } from "../../packages/core/src/index.js";
 import { type PostgresSchemaSnapshot, postgres, sql } from "../../packages/postgres/src/index.js";
 import { createPostgresDatabase } from "../../packages/postgres/src/runtime.js";
@@ -15,6 +16,13 @@ await describe("compiler and runtime observation correlation", async () => {
       "const query = sql`SELECT id FROM users ${include ? sql.fragment`WHERE id = ${id}` : sql.empty}`;",
     ].join("\n");
     const compiled = compileSource({ source, schema, dialect: postgres() });
+    const manifest = buildQueryManifest({
+      rootDir: "/project",
+      sources: [{ file: "/project/query.ts", source }],
+      schema,
+      dialect: postgres(),
+      compilerVersion: "contract-test",
+    }).manifest;
     strict.deepStrictEqual(compiled.diagnostics, []);
     strict.strictEqual(compiled.queries[0]?.variantFingerprints.length, 2);
 
@@ -42,7 +50,8 @@ await describe("compiler and runtime observation correlation", async () => {
     const operation = starts[0];
     if (operation?.kind !== "query") strict.fail("Expected a query observation");
     strict.ok(compiled.queries[0]?.variantFingerprints.includes(operation.fingerprint));
+    const manifestQuery = manifest.queries[0];
+    if (manifestQuery?.status !== "resolved") strict.fail("Expected a resolved manifest query");
+    strict.ok(manifestQuery.variants.some((variant) => variant.fingerprint === operation.fingerprint));
   });
 });
-
-import { fileURLToPath } from "node:url";

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -153,7 +153,10 @@ await describe("public package graph", async () => {
     const compiler = await source("compiler");
     strict.ok(!compiler.includes("@typed-sql/postgres"));
     strict.ok(!compiler.includes('=== "postgres"'));
-    strict.deepStrictEqual(Object.keys((await manifest("compiler")).dependencies ?? {}), ["@typed-sql/core"]);
+    strict.deepStrictEqual(Object.keys((await manifest("compiler")).dependencies ?? {}).sort(), [
+      "@typed-sql/core",
+      "@typed-sql/schema",
+    ]);
   });
 
   await it("keeps the public conformance kit and example grammar implementation-neutral", async () => {

--- a/test/contracts/packed-consumer.test.ts
+++ b/test/contracts/packed-consumer.test.ts
@@ -302,6 +302,7 @@ await describe("packed public packages", async () => {
               ...dependencies,
               "@acme/typed-sql-synthetic": "file:../grammar",
               "@opentelemetry/api": `link:${join(workspace, "node_modules", "@opentelemetry", "api")}`,
+              typescript: `link:${join(workspace, "node_modules", "typescript")}`,
             },
             pnpm: {
               overrides: {
@@ -336,7 +337,7 @@ await describe("packed public packages", async () => {
         import { mysql, sql as mysqlSql, typePolicy as mysqlTypePolicy } from "@typed-sql/mysql";
         import { mysqlRenderer } from "@typed-sql/mysql/runtime";
         import { loadMySql2Driver } from "@typed-sql/mysql/mysql2";
-        import { compileSource } from "@typed-sql/compiler";
+        import { buildQueryManifest, compileSource, parseQueryManifest, serializeQueryManifest } from "@typed-sql/compiler";
         import { assertGrammarConformance, GRAMMAR_CONFORMANCE_VERSION } from "@typed-sql/conformance";
         import { createOpenTelemetryObserver } from "@typed-sql/opentelemetry";
         import { syntheticConformanceFixture } from "@typed-sql/example-synthetic-grammar/conformance";
@@ -398,6 +399,24 @@ await describe("packed public packages", async () => {
         if (externalCompiled.diagnostics.length !== 0 || externalCompiled.queries.length !== 1) {
           throw new Error("external grammar could not compile from packed public packages");
         }
+        const externalManifest = buildQueryManifest({
+          rootDir: "/portable/checkout",
+          sources: [{
+            file: "/portable/checkout/query.ts",
+            source: 'import { sql } from "@acme/typed-sql-synthetic"; const query = sql\`SELECT value FROM widgets WHERE value = \${1}\`;'
+          }],
+          dialect: externalDialect,
+          schema: externalSnapshot,
+          typePolicy: syntheticTypePolicy,
+          compilerVersion: "packed-test",
+        });
+        const serializedManifest = serializeQueryManifest(externalManifest.manifest);
+        if (externalManifest.manifest.queries.length !== 1 || serializedManifest.includes("/portable/checkout")) {
+          throw new Error("packed query manifest contract failed");
+        }
+        if (parseQueryManifest(JSON.parse(serializedManifest)).queries[0]?.status !== "resolved") {
+          throw new Error("packed query manifest reader failed");
+        }
         if (!externalCompiled.transformedSource.includes('sql<{ "value": number; }, readonly [number]>')) {
           throw new Error("external grammar inference contract failed");
         }
@@ -422,8 +441,17 @@ await describe("packed public packages", async () => {
       await execFile(process.execPath, [join(consumer, "verify.mjs")], { cwd: consumer, env: isolatedEnvironment });
 
       const languageServer = join(consumer, "node_modules", ".bin", "typed-sql-language-server");
+      const typedSql = join(consumer, "node_modules", ".bin", "typed-sql");
       for (const dialect of ["postgres", "mysql"] as const) {
         const project = await writeEditorProject(consumer, dialect);
+        const manifestRun = await execFile(typedSql, ["manifest"], {
+          cwd: project.directory,
+          env: isolatedEnvironment,
+        });
+        strict.match(manifestRun.stdout, /Generated 4 queries \(0 unresolved/u);
+        const manifestSource = await readFile(join(project.directory, ".typed-sql", "queries.json"), "utf8");
+        strict.ok(!manifestSource.includes(project.directory));
+        strict.strictEqual((JSON.parse(manifestSource) as { readonly queries: readonly unknown[] }).queries.length, 4);
         const uri = pathToFileURL(project.queryFile).href;
         const client = new ProtocolClient(languageServer, ["--stdio"], project.directory, isolatedEnvironment);
         try {

--- a/test/contracts/performance-policy.test.ts
+++ b/test/contracts/performance-policy.test.ts
@@ -33,6 +33,8 @@ await describe("performance regression policy", async () => {
       "compiler.correlatedConditions",
       "compiler.independentConditions",
       "compiler.manyQueries",
+      "compiler.queryManifest",
+      "compiler.queryManifestIncremental",
       "compiler.semanticMetadata",
       "compiler.structuralLimit",
       "editor.cancelledRequest",
@@ -74,10 +76,14 @@ await describe("performance regression policy", async () => {
     ]) {
       strict.ok(gate.includes(evidence), `performance gate does not record ${evidence}`);
     }
+    const microbenchmarks = await readFile(join(workspace, "scripts", "performance", "microbenchmarks.mjs"), "utf8");
+    for (const metric of ["micro.mysql.decoderPlanCacheHit", "micro.mysql.decoderPlanCompile"]) {
+      strict.ok(microbenchmarks.includes(metric), `microbenchmark suite does not record ${metric}`);
+    }
     strict.strictEqual(
       gate.match(/iterations: methodology\.subMillisecondIterations/gu)?.length,
-      2,
-      "cache-hit and cancellation fast paths must batch samples",
+      3,
+      "manifest, cache-hit, and cancellation fast paths must batch samples",
     );
   });
 

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -3,15 +3,35 @@ import { describe, it, strict } from "poku";
 import type { SqlAstContext, SqlAstVisitor } from "../../packages/ast/src/index.js";
 import * as astApi from "../../packages/ast/src/index.js";
 import type {
+  BuildQueryManifestOptions,
+  BuildQueryManifestResult,
   CheckFileOptions,
   CheckFileResult,
   CompiledFragment,
   CompiledQuery,
+  CompiledQueryVariant,
   CompileSourceOptions,
   CompileSourceResult,
+  ExtractedDynamicQuery,
   ExtractedInterpolation,
   ExtractedQuery,
+  ListProjectSourceFilesOptions,
+  QueryManifest,
+  QueryManifestBuildStats,
+  QueryManifestColumn,
+  QueryManifestDiagnostic,
+  QueryManifestEntry,
+  QueryManifestLocation,
+  QueryManifestParameter,
+  QueryManifestSemanticEvidence,
+  QueryManifestSemanticFact,
+  QueryManifestSemantics,
+  QueryManifestSource,
+  QueryManifestSourceInput,
+  QueryManifestVariant,
+  ResolvedQueryManifestEntry,
   TypeScriptCheckResult,
+  UnresolvedQueryManifestEntry,
 } from "../../packages/compiler/src/index.js";
 import * as compilerApi from "../../packages/compiler/src/index.js";
 import * as configApi from "../../packages/config/src/index.js";
@@ -292,12 +312,32 @@ async function transactionBatchContract(
 type ReferencedStableTypes =
   | CheckFileOptions
   | CheckFileResult
+  | BuildQueryManifestOptions<SchemaSnapshot, unknown>
+  | BuildQueryManifestResult
   | CompiledFragment
   | CompiledQuery
+  | CompiledQueryVariant
   | CompileSourceOptions<SchemaSnapshot, unknown>
   | CompileSourceResult
+  | ExtractedDynamicQuery
   | ExtractedInterpolation
   | ExtractedQuery
+  | ListProjectSourceFilesOptions
+  | QueryManifest
+  | QueryManifestBuildStats
+  | QueryManifestColumn
+  | QueryManifestDiagnostic
+  | QueryManifestEntry
+  | QueryManifestLocation
+  | QueryManifestParameter
+  | QueryManifestSemanticEvidence
+  | QueryManifestSemanticFact
+  | QueryManifestSemantics
+  | QueryManifestSource
+  | QueryManifestSourceInput
+  | QueryManifestVariant
+  | ResolvedQueryManifestEntry
+  | UnresolvedQueryManifestEntry
   | TypeScriptCheckResult
   | CodecConformanceCase<unknown, unknown>
   | CodecConformanceFixture<unknown, unknown>
@@ -406,7 +446,20 @@ const expectedRuntimeExports = {
     "tokenize",
     "walkStatement",
   ],
-  compiler: ["checkFile", "compileSource", "extractStaticQueries", "mapSqlRange"],
+  compiler: [
+    "QUERY_FINGERPRINT_ALGORITHM",
+    "QUERY_MANIFEST_FORMAT_VERSION",
+    "QUERY_MANIFEST_JSON_SCHEMA",
+    "buildQueryManifest",
+    "checkFile",
+    "compileSource",
+    "extractDynamicQueries",
+    "extractStaticQueries",
+    "listProjectSourceFiles",
+    "mapSqlRange",
+    "parseQueryManifest",
+    "serializeQueryManifest",
+  ],
   conformance: [
     "GRAMMAR_CONFORMANCE_VERSION",
     "REQUIRED_GRAMMAR_PROBES",

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -46,6 +46,7 @@ export default defineConfig({
         items: [
           { text: "Execute queries", link: "/guides/execution" },
           { text: "Observe database work", link: "/guides/observability" },
+          { text: "Emit query manifests", link: "/guides/query-manifests" },
           { text: "Compose conditional SQL", link: "/guides/composition" },
           { text: "Manage schema snapshots", link: "/guides/schema-snapshots" },
           { text: "Configure editors", link: "/guides/editors" },


### PR DESCRIPTION
## Summary

- emit a canonical, versioned, grammar-neutral query manifest with resolved and unresolved entries
- preserve bounded structural variants, inferred rows/parameters, dependencies, capabilities, and runtime-correlatable fingerprints
- add project discovery, compatible incremental reuse, strict parsing, a published JSON Schema, and `typed-sql manifest`
- enforce the privacy boundary: no SQL text, runtime values, credentials, database URLs, absolute paths, or branch expressions
- document CI usage, compatibility, exit codes, and the grammar-package application import contract
- move the MySQL decoder-cache speed assertion into the production performance harness to avoid wall-clock unit-test flakes

## Acceptance coverage

- byte-identical canonical output and checkout-root independence
- PostgreSQL, MySQL, conditional variants, diagnostics, and explicit dynamic-query coverage
- seeded secret/value/path redaction checks
- unchanged-file reuse plus conservative invalidation
- packed external consumers generate and parse manifests through public packages
- dedicated full and incremental performance budgets

## Verification

- `pnpm verify`
- `git diff --check`

Closes #52