### PR TITLE
feat: analyze migration compatibility

### DIFF
--- a/.changeset/swift-schemas-compare.md
+++ b/.changeset/swift-schemas-compare.md
@@ -1,0 +1,10 @@
+---
+"@typed-sql/core": major
+"@typed-sql/compiler": major
+"@typed-sql/cli": major
+---
+
+Add deterministic migration compatibility analysis across before/after schema snapshots and query
+manifests. Reports classify both rolling-deployment directions, retain exact source and dependency
+evidence, fail closed for unknown semantics, redact defaults and paths, and support configurable CI
+severity through `typed-sql compat`.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bundle/
 target/
 *.tsbuildinfo
 .typed-sql-*
+.typed-sql/
 e2e/*/generated/
 e2e/*/.typed-sql/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ codecs. The interpolation is also checked as `bigint` because it is compared wit
   fingerprints with inferred types, dependencies, and capabilities without storing SQL or values.
 - **Prove inference against the database.** Optional native prepare metadata verifies safe variants
   and produces a deterministic, secret-free proof that CI can later validate offline.
+- **Check migrations against deployed queries.** Offline compatibility reports analyze both rolling-
+  deployment directions and link breaks to exact query variants.
 
 ## Install
 
@@ -90,6 +92,7 @@ pnpm exec typed-sql drift
 pnpm exec typed-sql manifest
 pnpm exec typed-sql verify --live
 pnpm exec typed-sql verify
+pnpm exec typed-sql compat --before before.schema.json --after after.schema.json --before-manifest before.queries.json --after-manifest after.queries.json
 ```
 
 See [Installation](./docs/getting-started/installation.md),
@@ -131,11 +134,11 @@ the structural-variant bound.
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | Stable |
 | `@typed-sql/schema` | Versioned snapshots, hashes, migrations, and drift | Stable |
 | `@typed-sql/config` | Config discovery and loading | Stable |
-| `@typed-sql/compiler` | Grammar-neutral source analysis, manifests, and verification proofs | Stable |
+| `@typed-sql/compiler` | Grammar-neutral source analysis, manifests, verification proofs, and migration reports | Stable |
 | `@typed-sql/conformance` | Executable compatibility kit for SQL grammar packages | Stable |
 | `@typed-sql/postgres` | PostgreSQL grammar, codecs, introspection, and optional `pg` adapter | Stable |
 | `@typed-sql/mysql` | MySQL grammar, codecs, introspection, and optional `mysql2` adapter | Stable |
-| `@typed-sql/cli` | Snapshot, checking, drift, manifest, and verification commands | Stable |
+| `@typed-sql/cli` | Snapshot, checking, drift, manifest, verification, and compatibility commands | Stable |
 | `@typed-sql/ts-bridge` | Isolated TypeScript preview integration | Experimental |
 | `@typed-sql/language-server` | TypeScript semantic proxy and SQL editor features | Experimental |
 
@@ -147,6 +150,7 @@ the structural-variant bound.
 - [Database observability](./docs/guides/observability.md)
 - [Query manifests](./docs/guides/query-manifests.md)
 - [Live database verification](./docs/guides/live-verification.md)
+- [Migration compatibility](./docs/guides/migration-compatibility.md)
 - [PostgreSQL grammar](./docs/dialects/postgresql.md)
 - [MySQL grammar](./docs/dialects/mysql.md)
 - [Inference and safety](./docs/concepts/type-safety.md)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -16,11 +16,11 @@ typed-sql separates the application query contract, SQL grammar, schema metadata
 | `@typed-sql/ast` | Bounded tokenizer, parser, AST, and source ranges | No |
 | `@typed-sql/config` | Dialect-neutral project config discovery and loading | No |
 | `@typed-sql/schema` | Snapshot envelope, deterministic generation, hashes, and drift | No |
-| `@typed-sql/compiler` | Dialect-neutral extraction, transforms, structural expansion, diagnostics, and query manifests | No |
+| `@typed-sql/compiler` | Dialect-neutral extraction, transforms, diagnostics, manifests, verification, and migration analysis | No |
 | `@typed-sql/conformance` | Public executable contract for first- and third-party SQL grammars | No |
 | `@typed-sql/postgres` | PostgreSQL grammar, catalog model, resolver, type policy, and codecs | No |
 | `@typed-sql/mysql` | MySQL grammar, catalog model, resolver, type policy, and codecs | No |
-| `@typed-sql/cli` | Snapshot generation, checking, drift, manifests, live verification, and provider discovery | No |
+| `@typed-sql/cli` | Snapshot generation, checking, drift, manifests, verification, compatibility, and provider discovery | No |
 | `@typed-sql/ts-bridge` | Experimental TypeScript semantic overlay and isolated preview bridge | No |
 | `@typed-sql/language-server` | Experimental TypeScript and LSP semantic proxy | No |
 
@@ -65,6 +65,8 @@ The optional query manifest serializes the same fingerprints, variants, inferred
 
 Live verification follows the same dependency direction. Core defines a native metadata adapter contract, grammar driver subpaths implement it, and the compiler compares evidence and emits a deterministic proof. The CLI reconstructs SQL transiently only after the source still matches the manifest. Neither the manifest nor proof stores SQL, values, connection configuration, absolute paths, or driver errors.
 
+Migration compatibility remains on the artifact side of that boundary. The compiler compares public snapshots and manifests without knowing how a migration was authored or applied. It maps catalog changes through grammar-owned dependencies, analyzes both mixed-version deployment directions, and emits a deterministic report. Existing migration runners remain responsible for execution and can provide an after-snapshot through any configured `SchemaProvider`.
+
 ## Generated metadata
 
 Generated output contains schema metadata for tooling and review. Application code imports `sql` and `typePolicy` from the dialect package and imports a driver adapter only when it needs introspection or execution.
@@ -74,6 +76,8 @@ A custom type policy belongs in an application module shared by config and runti
 Query manifests are build artifacts rather than generated application APIs. Applications continue importing `sql` from their selected grammar package. See [Query manifests](../guides/query-manifests.md).
 
 Verification proofs are CI artifacts rather than runtime dependencies. See [Live verification](../guides/live-verification.md).
+
+Compatibility reports are review and CI artifacts rather than migration instructions. See [Migration compatibility](../guides/migration-compatibility.md).
 
 ## Composition model
 

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -17,6 +17,7 @@ The production performance suite covers:
 - compiling 250 queries with the PostgreSQL grammar and resolver;
 - emitting a 250-query manifest and reusing its unchanged per-file analysis;
 - scheduling and comparing native evidence for a 250-query verification manifest with bounded concurrency;
+- comparing 250-query before/after manifests across 50 changed database contracts;
 - correlated and independent conditional structure;
 - rejecting structural expansion before grammar work exceeds its bound;
 - core template construction, fragment composition, rendering, and prepared-skeleton binding;
@@ -46,6 +47,7 @@ At runtime, interpolation-free fragment templates may reuse their complete immut
 | Query manifest, 250 queries | 25 ms | 60 ms |
 | Query manifest, unchanged source | 0.5 ms | 1 ms |
 | Query verification, 250 cached native responses plus canonical proof hashing | 40 ms | 60 ms |
+| Schema compatibility, 250 queries and 50 changed contracts | 70 ms | 120 ms |
 | 20 correlated conditions | 5 ms | 10 ms |
 | Six independent conditions | 10 ms | 25 ms |
 | Structural limit rejection | 5 ms | 10 ms |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -40,6 +40,10 @@ export default defineConfig({
     proofFile: ".typed-sql/verification.json",
     concurrency: 4,
   },
+  compatibility: {
+    reportFile: ".typed-sql/compatibility.json",
+    failOn: "error",
+  },
 });
 ```
 
@@ -76,6 +80,10 @@ export default defineConfig({
     proofFile: ".typed-sql/verification.json",
     concurrency: 4,
   },
+  compatibility: {
+    reportFile: ".typed-sql/compatibility.json",
+    failOn: "error",
+  },
 });
 ```
 
@@ -88,9 +96,10 @@ pnpm exec typed-sql drift
 pnpm exec typed-sql manifest
 pnpm exec typed-sql verify --live
 pnpm exec typed-sql verify
+pnpm exec typed-sql compat --before before.schema.json --after after.schema.json --before-manifest before.queries.json --after-manifest after.queries.json
 ```
 
-`generate` introspects the configured database and writes deterministic schema metadata. `check` analyzes SQL and asks TypeScript to validate the inferred overlay. `drift` compares the committed snapshot and type-policy hash with the live database. `manifest` emits deterministic, source-relative compiler evidence for every configured project; see [Query manifests](../guides/query-manifests.md). `verify --live` compares that evidence with native prepare metadata, while `verify` validates the cached proof offline; see [Live verification](../guides/live-verification.md).
+`generate` introspects the configured database and writes deterministic schema metadata. `check` analyzes SQL and asks TypeScript to validate the inferred overlay. `drift` compares the committed snapshot and type-policy hash with the live database. `manifest` emits deterministic, source-relative compiler evidence for every configured project; see [Query manifests](../guides/query-manifests.md). `verify --live` compares that evidence with native prepare metadata, while `verify` validates the cached proof offline; see [Live verification](../guides/live-verification.md). `compat` compares before/after snapshots and manifests without contacting the database; see [Migration compatibility](../guides/migration-compatibility.md).
 
 Connection strings stay in the config callback or environment. They are not written to generated files. Commit the generated snapshot so schema and type-policy changes are reviewable.
 

--- a/docs/guides/migration-compatibility.md
+++ b/docs/guides/migration-compatibility.md
@@ -1,0 +1,133 @@
+---
+title: Migration compatibility
+description: Compare schema and query artifacts to find source, runtime, and rolling-deployment breaks before a migration ships.
+---
+
+# Migration compatibility
+
+`typed-sql compat` compares two schema snapshots and their compiled query manifests. It answers two questions that a schema diff alone cannot:
+
+- Can the older application run against the newer database?
+- Can the newer application run against the older database?
+
+The analyzer is offline and grammar-neutral. It does not apply migrations, contact a database, or require a particular migration framework. Existing tools continue to own migration ordering, locks, rollback, and production execution.
+
+## Produce the four inputs
+
+Keep one snapshot and manifest from each application revision:
+
+| Artifact | Meaning |
+| --- | --- |
+| `before.schema.json` | Catalog before the proposed migration |
+| `before.queries.json` | Queries compiled from the older application against that catalog |
+| `after.schema.json` | Catalog after the proposed migration |
+| `after.queries.json` | Queries compiled from the newer application against that catalog |
+
+Run snapshot generation and manifest generation at each revision:
+
+```sh
+pnpm exec typed-sql generate
+pnpm exec typed-sql manifest
+
+cp generated/db/schema.json artifacts/after.schema.json
+cp .typed-sql/queries.json artifacts/after.queries.json
+```
+
+The exact generated directory comes from `outDir`; the manifest path comes from `manifest.outFile`. Preserve the corresponding `before` artifacts from the merge base, a build artifact, or a checked-in baseline.
+
+## Analyze both deployment directions
+
+```sh
+pnpm exec typed-sql compat \
+  --before artifacts/before.schema.json \
+  --after artifacts/after.schema.json \
+  --before-manifest artifacts/before.queries.json \
+  --after-manifest artifacts/after.queries.json
+```
+
+Paths are resolved relative to `typed-sql.config.ts`. The command writes canonical JSON to `.typed-sql/compatibility.json` and prints every assessment, including informational findings. Each affected query includes its relative file, source range, variant fingerprint, and dependency range when the grammar supplied one.
+
+Every database change is assessed in both directions:
+
+| Direction | What it models |
+| --- | --- |
+| `before-app-after-database` | Old application instances remain while the migrated database is live |
+| `after-app-before-database` | New application instances start before every database instance has migrated |
+
+The report classifies findings as `compatible`, `deployment-order-sensitive`, `source-breaking`, `runtime-breaking`, or `unknown`. `unknown` is deliberate: unresolved queries, ambiguous dependencies, server-version changes, and unsupported semantics remain visible instead of being treated as safe.
+
+## Configure CI policy
+
+```ts
+export default defineConfig({
+  // dialect, schema, and outDir omitted
+  compatibility: {
+    reportFile: ".typed-sql/compatibility.json",
+    failOn: "error",
+  },
+});
+```
+
+`--fail-on` overrides the config for one run:
+
+```sh
+pnpm exec typed-sql compat ... --fail-on warning
+```
+
+| Policy | Exit with code `1` when the report contains |
+| --- | --- |
+| `none` | Never; useful while adopting the check |
+| `warning` | A warning or error |
+| `error` | An error |
+
+The JSON report is always written and lower-severity findings are always printed. A failing policy therefore changes the exit code without hiding evidence.
+
+## Use plain SQL migrations
+
+Apply plain SQL to a disposable database with the same runner used by the application, then regenerate the after-snapshot:
+
+```sh
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f migrations/20260828_accounts.sql
+pnpm exec typed-sql generate
+pnpm exec typed-sql manifest
+pnpm exec typed-sql compat \
+  --before artifacts/before.schema.json \
+  --after generated/db/schema.json \
+  --before-manifest artifacts/before.queries.json \
+  --after-manifest .typed-sql/queries.json
+```
+
+For MySQL, replace the migration command and grammar adapter; the compatibility command and report contract stay the same.
+
+## Use an external migration workflow
+
+For example, a project that already uses Prisma Migrate can keep Prisma as the migration runner:
+
+```sh
+pnpm exec prisma migrate deploy
+pnpm exec typed-sql generate
+pnpm exec typed-sql manifest
+pnpm exec typed-sql compat \
+  --before artifacts/before.schema.json \
+  --after generated/db/schema.json \
+  --before-manifest artifacts/before.queries.json \
+  --after-manifest .typed-sql/queries.json
+```
+
+The same boundary works with Flyway, Liquibase, Drizzle Kit, Atlas, or an internal migration service: run the existing migration against a disposable database, let the configured `SchemaProvider` introspect it, then pass the resulting artifacts to `compat`. typed-sql consumes the outcome rather than the migration language.
+
+## Interpret schema changes
+
+The report carries before/after evidence for table, column, enum, domain, function, database-type, TypeScript-type, nullability, array, default, grammar-version, and server-version changes. Default expressions are represented by fingerprints, so secrets or operational expressions are not copied into reports.
+
+Changes to inferred rows or ordered parameters produce a `query-contract` change. This captures type-policy and codec-facing changes even when the SQL text itself is unchanged.
+
+Renames are intentionally conservative. Without explicit evidence, removing `display_name` and adding `full_name` is reported as a removal plus an addition. The analyzer does not guess that data, semantics, or every deployed query moved safely.
+
+Adding a required column without a default and changing defaults can affect writes that do not name the changed column. Function overload additions and removals can change resolution. These are reported as deployment-order-sensitive even when a direct read dependency would miss the hazard.
+
+## Artifact guarantees
+
+Compatibility reports are deterministic, versioned, and validated at their public parser boundary. They contain hashes and relative source locations, but no SQL text, parameter values, connection configuration, default expressions, credentials, absolute paths, or driver errors.
+
+The compiler API exposes `analyzeSchemaCompatibility()`, `serializeSchemaCompatibilityReport()`, and `parseSchemaCompatibilityReport()` for CI systems that need an in-memory workflow. Snapshot producers only need to emit the public `SchemaSnapshot` contract; migration-framework integration does not belong in the analyzer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ It is not an ORM or a query builder. SQL remains visible, database drivers remai
 - [Trace database work safely](./guides/observability.md) through the neutral observer contract.
 - [Emit deterministic query manifests](./guides/query-manifests.md) for CI and production correlation.
 - [Verify compiler evidence against a live database](./guides/live-verification.md) and cache the proof.
+- [Check migrations against compiled queries](./guides/migration-compatibility.md) in both rolling-deployment directions.
 - [Configure Zed, VS Code, or another LSP client](./guides/editors.md).
 - Review the [PostgreSQL](./dialects/postgresql.md) and [MySQL](./dialects/mysql.md) grammar boundaries.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -149,7 +149,7 @@ Set `DatabaseObserver.captureErrorCause` only when an integration explicitly nee
 
 ## Configuration and schema contracts
 
-`defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, compiler options, optional `manifest.outFile`, and optional live-verification adapter, proof path, and concurrency.
+`defineConfig()` accepts a `DialectPlugin`, schema file and provider, output directory, TypeScript projects, type policy, compiler options, optional `manifest.outFile`, optional live-verification adapter, proof path and concurrency, and optional compatibility report path and failure severity.
 
 Public schema types include `SchemaSnapshot`, `GeneratedSchemaSnapshot`, table, column, domain, and function metadata, `SchemaProvider`, and source-mapped diagnostics.
 
@@ -163,6 +163,7 @@ Public schema types include `SchemaSnapshot`, `GeneratedSchemaSnapshot`, table, 
 - `buildQueryManifest`, canonical serialization, compatible parsing, and project file enumeration;
 - the query manifest format, fingerprint algorithm, and JSON Schema constants.
 - live-verification candidate collection, native comparison, proof parsing and serialization, cache validation, and artifact-version constants.
+- migration compatibility analysis, report parsing and serialization, before/after evidence types, classifications, deployment directions, and artifact-version constants.
 
 Each `CompiledQuery` includes:
 
@@ -174,6 +175,8 @@ Each `CompiledQuery` includes:
 Manifest output is a compiler and CI artifact, not an application import surface. See [Query manifests](../guides/query-manifests.md) for the format, redaction boundary, incremental behavior, and CLI exit codes.
 
 `LiveQueryVerifier` is the grammar-neutral adapter contract. PostgreSQL exposes `createPgLiveVerifier()` from `@typed-sql/postgres/pg`; MySQL exposes `createMySql2LiveVerifier()` from `@typed-sql/mysql/mysql2`. These adapters are lazy and driver-optional. See [Live verification](../guides/live-verification.md).
+
+`analyzeSchemaCompatibility()` consumes two public `SchemaSnapshot` values and their matching query manifests. `serializeSchemaCompatibilityReport()` writes canonical JSON and `parseSchemaCompatibilityReport()` validates the versioned public artifact. See [Migration compatibility](../guides/migration-compatibility.md).
 
 Scanner control flow, append extraction, structural parsing, branch expansion, and conditional row rendering remain internal.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,8 @@
 The stable, config-driven command line interface for
 [typed-sql](https://github.com/Lojhan/typed-sql). It generates deterministic database snapshots,
 checks inferred queries through TypeScript, detects schema drift, emits deterministic query manifests,
-and verifies compiler evidence through optional native database metadata.
+verifies compiler evidence through optional native database metadata, and analyzes migrations against
+compiled query contracts.
 
 ```sh
 pnpm add -D @typed-sql/cli typescript@7.0.2
@@ -18,6 +19,7 @@ pnpm exec typed-sql drift
 pnpm exec typed-sql manifest
 pnpm exec typed-sql verify --live
 pnpm exec typed-sql verify
+pnpm exec typed-sql compat --before before.schema.json --after after.schema.json --before-manifest before.queries.json --after-manifest after.queries.json
 ```
 
 Use `--config path/to/typed-sql.config.ts` to bypass config discovery. Run
@@ -30,5 +32,7 @@ and schema provider through the application config. Read
 [Query manifests](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-manifests.md).
 [Live verification](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/live-verification.md) documents
 native safety, cached proofs, and CI behavior.
+[Migration compatibility](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/migration-compatibility.md)
+documents deterministic reports, rolling deployments, and migration-runner integration.
 
 MIT © typed-sql contributors

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typed-sql/cli",
   "version": "1.0.0",
-  "description": "Config-driven typed-sql generation, checking, schema drift, and query manifest CLI.",
+  "description": "Config-driven typed-sql generation, checking, verification, and migration compatibility CLI.",
   "license": "MIT",
   "author": "Lojhan",
   "repository": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, parse, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  analyzeSchemaCompatibility,
   assertQueryVerificationProofCurrent,
   buildQueryManifest,
   checkFile,
@@ -12,18 +13,24 @@ import {
   parseQueryVerificationProof,
   serializeQueryManifest,
   serializeQueryVerificationProof,
+  serializeSchemaCompatibilityReport,
   verifyQueryManifest,
 } from "@typed-sql/compiler";
 import { fromConfig, loadConfig } from "@typed-sql/config";
 import type { SchemaSnapshot } from "@typed-sql/core";
-import { checkSchemaDrift, generateSchemaPackage, loadGeneratedSchemaSnapshot } from "@typed-sql/schema";
+import {
+  checkSchemaDrift,
+  generateSchemaPackage,
+  loadGeneratedSchemaSnapshot,
+  parseSchemaSnapshot,
+} from "@typed-sql/schema";
 
 interface ParsedArguments {
   readonly command?: string;
   readonly options: Readonly<Record<string, string>>;
 }
 
-const commands = new Set(["check", "generate", "drift", "manifest", "verify"]);
+const commands = new Set(["check", "compat", "generate", "drift", "manifest", "verify"]);
 
 async function packageVersion(): Promise<string> {
   let directory = dirname(fileURLToPath(import.meta.url));
@@ -51,6 +58,7 @@ Usage:
 
 Commands:
   check      Infer SQL result types and verify them with TypeScript 7
+  compat     Analyze rolling-deployment compatibility from two snapshots and manifests
   generate   Introspect or load a schema snapshot and generate the typed contract
   drift      Compare the generated contract with the live database catalog
   manifest   Emit a deterministic manifest for every project query
@@ -62,6 +70,7 @@ Global options:
 
 Examples:
   typed-sql check --config typed-sql.config.ts --file src/query.ts --project tsconfig.json
+  typed-sql compat --before schema.before.json --after schema.after.json --before-manifest old.json --after-manifest new.json
   typed-sql generate --config typed-sql.config.ts --out generated/db
   typed-sql drift --config typed-sql.config.ts
   typed-sql manifest --config typed-sql.config.ts --project tsconfig.json --out .typed-sql/queries.json
@@ -157,6 +166,30 @@ function reportVerification(
   }
 }
 
+function reportCompatibility(
+  assessments: readonly {
+    readonly direction: string;
+    readonly classification: string;
+    readonly severity: string;
+    readonly reason: string;
+    readonly queries: readonly {
+      readonly source: { readonly file: string; readonly range: { readonly line: number; readonly column: number } };
+    }[];
+  }[],
+): void {
+  for (const assessment of assessments) {
+    const locations =
+      assessment.queries.length === 0
+        ? "schema-wide"
+        : assessment.queries
+            .map((query) => `${query.source.file}:${query.source.range.line}:${query.source.range.column}`)
+            .join(", ");
+    process.stderr.write(
+      `${assessment.severity} ${assessment.direction} ${assessment.classification} (${locations}): ${assessment.reason}\n`,
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const version = await packageVersion();
@@ -178,6 +211,44 @@ async function main(): Promise<void> {
   const dialect = config.dialect;
   const policy = config.typePolicy ?? dialect.defaultTypePolicy;
   const schemaFile = fromConfig(loaded.directory, parsed.options.schema ?? config.schema.file);
+
+  if (parsed.command === "compat") {
+    const beforeFile = fromConfig(loaded.directory, required(parsed.options, "before"));
+    const afterFile = fromConfig(loaded.directory, required(parsed.options, "after"));
+    const beforeManifestFile = fromConfig(loaded.directory, required(parsed.options, "before-manifest"));
+    const afterManifestFile = fromConfig(loaded.directory, required(parsed.options, "after-manifest"));
+    const outFile = fromConfig(
+      loaded.directory,
+      parsed.options.out ?? config.compatibility?.reportFile ?? ".typed-sql/compatibility.json",
+    );
+    const failOn = parsed.options["fail-on"] ?? config.compatibility?.failOn ?? "error";
+    if (!(failOn === "none" || failOn === "warning" || failOn === "error")) {
+      throw new Error("--fail-on must be none, warning, or error");
+    }
+    const [before, after, beforeManifest, afterManifest] = await Promise.all([
+      readSnapshot(beforeFile, parseSchemaSnapshot),
+      readSnapshot(afterFile, parseSchemaSnapshot),
+      readFile(beforeManifestFile, "utf8").then((source) => parseQueryManifest(JSON.parse(source) as unknown)),
+      readFile(afterManifestFile, "utf8").then((source) => parseQueryManifest(JSON.parse(source) as unknown)),
+    ]);
+    if (before.dialect !== dialect.id || after.dialect !== dialect.id) {
+      throw new TypeError(`Compatibility snapshots must use configured dialect ${dialect.id}`);
+    }
+    const report = analyzeSchemaCompatibility({ before, after, beforeManifest, afterManifest });
+    await mkdir(dirname(outFile), { recursive: true });
+    await writeFile(outFile, serializeSchemaCompatibilityReport(report), "utf8");
+    reportCompatibility(report.assessments);
+    process.stdout.write(
+      `Compatibility: ${report.summary.error} errors, ${report.summary.warning} warnings, ${report.summary.info} informational assessments at ${outFile}\n`,
+    );
+    if (
+      (failOn === "error" && report.summary.error > 0) ||
+      (failOn === "warning" && (report.summary.error > 0 || report.summary.warning > 0))
+    ) {
+      process.exitCode = 1;
+    }
+    return;
+  }
 
   if (parsed.command === "check") {
     const file = resolve(required(parsed.options, "file"));

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { describe, it, strict } from "poku";
+import { buildQueryManifest, serializeQueryManifest } from "../../compiler/src/index.js";
+import { postgres } from "../../postgres/src/index.js";
 
 const execFile = promisify(execFileCallback);
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -164,6 +166,101 @@ await describe("typed-sql manifest command", async () => {
         strict.strictEqual(error.code, 1);
         return true;
       });
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  });
+});
+
+await describe("typed-sql compat command", async () => {
+  await it("writes a secret-free rolling-deployment report and enforces configured severity", async () => {
+    const temporary = await mkdtemp(join(workspace, ".typed-sql-cli-compat-"));
+    try {
+      await writeFile(
+        join(temporary, "typed-sql.config.ts"),
+        [
+          'import { defineConfig } from "@typed-sql/core";',
+          'import { postgres } from "@typed-sql/postgres";',
+          'export default defineConfig({ dialect: postgres(), schema: { file: "after.json" }, outDir: "generated", compatibility: { reportFile: ".typed-sql/compatibility.json" } });',
+        ].join("\n"),
+      );
+      const before = {
+        formatVersion: 1 as const,
+        dialect: "postgres" as const,
+        tables: {
+          users: {
+            name: "users",
+            columns: {
+              id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+              email: {
+                name: "email",
+                databaseType: "text",
+                tsType: "string",
+                nullable: false,
+                defaultExpression: "'recognizable-secret'",
+              },
+            },
+          },
+        },
+      };
+      const after = {
+        formatVersion: 1 as const,
+        dialect: "postgres" as const,
+        tables: {
+          users: {
+            name: "users",
+            columns: {
+              id: { name: "id", databaseType: "numeric", tsType: "string", nullable: false },
+            },
+          },
+        },
+      };
+      const dialect = postgres();
+      const source =
+        'import { sql } from "@typed-sql/postgres"; declare const id: bigint; export const query = sql`SELECT users.id, users.email FROM users WHERE users.id = ${id}`;';
+      const nextSource =
+        'import { sql } from "@typed-sql/postgres"; declare const id: string; export const query = sql`SELECT users.id FROM users WHERE users.id = ${id}`;';
+      const createManifest = (schema: typeof before | typeof after, value: string) =>
+        buildQueryManifest({
+          rootDir: temporary,
+          sources: [{ file: join(temporary, "query.ts"), source: value }],
+          dialect,
+          schema,
+          compilerVersion: "test",
+        }).manifest;
+      await writeFile(join(temporary, "before.json"), `${JSON.stringify(before)}\n`);
+      await writeFile(join(temporary, "after.json"), `${JSON.stringify(after)}\n`);
+      await writeFile(join(temporary, "before-manifest.json"), serializeQueryManifest(createManifest(before, source)));
+      await writeFile(
+        join(temporary, "after-manifest.json"),
+        serializeQueryManifest(createManifest(after, nextSource)),
+      );
+
+      const args = [
+        "compat",
+        "--before",
+        "before.json",
+        "--after",
+        "after.json",
+        "--before-manifest",
+        "before-manifest.json",
+        "--after-manifest",
+        "after-manifest.json",
+      ] as const;
+      const working = join(temporary, "nested");
+      await mkdir(working);
+      const allowed = await execute([...args, "--fail-on", "none"], working);
+      strict.match(allowed.stdout, /Compatibility: \d+ errors/u);
+      strict.match(allowed.stderr, /before-app-after-database/u);
+      const report = await readFile(join(temporary, ".typed-sql", "compatibility.json"), "utf8");
+      strict.ok(!report.includes("recognizable-secret"));
+      strict.ok(!report.includes(temporary));
+      await strict.rejects(execute(args, working), (error: unknown) => {
+        if (!(error instanceof Error && "code" in error)) return false;
+        strict.strictEqual(error.code, 1);
+        return true;
+      });
+      await strict.rejects(execute([...args, "--fail-on", "all"], working), /none, warning, or error/u);
     } finally {
       await rm(temporary, { recursive: true, force: true });
     }

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -4,7 +4,8 @@ The stable, grammar-neutral TypeScript source compiler behind
 [typed-sql](https://github.com/Lojhan/typed-sql). It finds static SQL templates, asks the configured
 grammar for row and parameter shapes, creates an in-memory TypeScript overlay, preserves source
 mappings, emits deterministic query manifests, and compares them with grammar-owned native database
-evidence for CI and production correlation.
+evidence for CI and production correlation. It also compares before/after snapshots and manifests to
+find query-level migration breaks in both rolling-deployment directions.
 
 ```sh
 pnpm add @typed-sql/compiler
@@ -33,10 +34,15 @@ Live verification APIs collect transient SQL only after sources still match the 
 grammar-owned adapters with bounded concurrency, compare native field evidence, and emit canonical
 proofs that contain no SQL, values, URLs, absolute paths, or driver errors.
 
+Migration compatibility APIs consume deterministic artifacts only. They classify source, runtime,
+deployment-order, compatible, and unknown outcomes; link affected variants to source and dependency
+ranges; and emit canonical reports without SQL, default expressions, credentials, or absolute paths.
+
 Read [Architecture](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/architecture.md),
 [Compose conditional SQL](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/composition.md),
 [Query manifests](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-manifests.md), and
-[Live verification](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/live-verification.md), and
+[Live verification](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/live-verification.md),
+[Migration compatibility](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/migration-compatibility.md), and
 [Inference and safety](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/type-safety.md).
 
 MIT © typed-sql contributors

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typed-sql/compiler",
   "version": "1.0.0",
-  "description": "Dialect-neutral TypeScript source extraction and typed SQL compilation.",
+  "description": "Dialect-neutral TypeScript source compilation, query evidence, and migration compatibility.",
   "license": "MIT",
   "author": "Lojhan",
   "repository": {

--- a/packages/compiler/src/compatibility.ts
+++ b/packages/compiler/src/compatibility.ts
@@ -1,0 +1,999 @@
+import { createHash } from "node:crypto";
+import type { QueryDependency, SchemaSnapshot, SourceRange } from "@typed-sql/core";
+import { calculateSchemaHash } from "@typed-sql/schema";
+import type { QueryManifest, QueryManifestLocation, QueryManifestVariant } from "./manifest.js";
+import { parseQueryManifest, serializeQueryManifest } from "./manifest.js";
+
+export const SCHEMA_COMPATIBILITY_FORMAT_VERSION = 1 as const;
+export const SCHEMA_COMPATIBILITY_ANALYZER_VERSION = "typed-sql-v1" as const;
+
+export type DeploymentDirection = "before-app-after-database" | "after-app-before-database";
+export type CompatibilityClassification =
+  | "compatible"
+  | "deployment-order-sensitive"
+  | "source-breaking"
+  | "runtime-breaking"
+  | "unknown";
+export type CompatibilitySeverity = "info" | "warning" | "error";
+export type SchemaCompatibilityChangeKind =
+  | "relation-added"
+  | "relation-removed"
+  | "column-added"
+  | "column-removed"
+  | "column-database-type"
+  | "column-typescript-type"
+  | "column-nullability"
+  | "column-array"
+  | "column-default"
+  | "enum-added"
+  | "enum-removed"
+  | "enum-values"
+  | "domain-added"
+  | "domain-removed"
+  | "domain-database-type"
+  | "domain-typescript-type"
+  | "domain-nullability"
+  | "function-added"
+  | "function-removed"
+  | "function-return-type"
+  | "function-nullability"
+  | "function-set-returning"
+  | "function-volatility"
+  | "dialect-version"
+  | "server-version"
+  | "query-contract";
+
+export interface SchemaCompatibilityTarget {
+  readonly kind: "schema" | "relation" | "column" | "enum" | "domain" | "function" | "query";
+  readonly key: string;
+  readonly name: string;
+  readonly schema?: string;
+  readonly parent?: string;
+}
+
+export type CompatibilityEvidenceValue = string | boolean | null | readonly string[];
+export type CompatibilityEvidence = Readonly<Record<string, CompatibilityEvidenceValue>>;
+
+export interface SchemaCompatibilityChange {
+  readonly id: string;
+  readonly kind: SchemaCompatibilityChangeKind;
+  readonly target: SchemaCompatibilityTarget;
+  readonly before?: CompatibilityEvidence;
+  readonly after?: CompatibilityEvidence;
+}
+
+export interface CompatibilityQueryReference {
+  readonly queryId: string;
+  readonly variantFingerprint: string;
+  readonly source: QueryManifestLocation;
+  readonly dependencyRange?: SourceRange;
+}
+
+export interface SchemaCompatibilityAssessment {
+  readonly direction: DeploymentDirection;
+  readonly changeId?: string;
+  readonly classification: CompatibilityClassification;
+  readonly severity: CompatibilitySeverity;
+  readonly reason: string;
+  readonly queries: readonly CompatibilityQueryReference[];
+}
+
+export interface SchemaCompatibilityReport {
+  readonly formatVersion: typeof SCHEMA_COMPATIBILITY_FORMAT_VERSION;
+  readonly analyzerVersion: typeof SCHEMA_COMPATIBILITY_ANALYZER_VERSION;
+  readonly dialect: string;
+  readonly before: { readonly schemaHash: string; readonly manifestHash: string; readonly version?: string };
+  readonly after: { readonly schemaHash: string; readonly manifestHash: string; readonly version?: string };
+  readonly changes: readonly SchemaCompatibilityChange[];
+  readonly assessments: readonly SchemaCompatibilityAssessment[];
+  readonly summary: Readonly<Record<CompatibilitySeverity, number>>;
+}
+
+export interface AnalyzeSchemaCompatibilityOptions {
+  readonly before: SchemaSnapshot;
+  readonly after: SchemaSnapshot;
+  readonly beforeManifest: QueryManifest;
+  readonly afterManifest: QueryManifest;
+}
+
+interface InternalChange {
+  readonly change: SchemaCompatibilityChange;
+  readonly keys: readonly string[];
+  readonly relationWriteKey?: string;
+  readonly addedMandatoryColumn?: boolean;
+  readonly removedMandatoryColumn?: boolean;
+  readonly queryReferences?: Readonly<Record<DeploymentDirection, CompatibilityQueryReference>>;
+}
+
+interface ManifestReferences {
+  readonly byKey: ReadonlyMap<string, readonly CompatibilityQueryReference[]>;
+  readonly unknown: readonly CompatibilityQueryReference[];
+}
+
+const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
+const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
+const relationKey = (key: string) => `relation:${key}`;
+const relationWriteKey = (key: string) => `relation-write:${key}`;
+const columnKey = (table: string, column: string) => `column:${table}.${column}`;
+const functionKey = (key: string) => `function:${key}`;
+const functionNameKey = (schema: string | undefined, name: string) => `function-name:${schema ?? ""}.${name}`;
+const typeKey = (kind: "enum" | "domain", key: string) => `type:${kind}:${key}`;
+const changeKinds = new Set<SchemaCompatibilityChangeKind>([
+  "relation-added",
+  "relation-removed",
+  "column-added",
+  "column-removed",
+  "column-database-type",
+  "column-typescript-type",
+  "column-nullability",
+  "column-array",
+  "column-default",
+  "enum-added",
+  "enum-removed",
+  "enum-values",
+  "domain-added",
+  "domain-removed",
+  "domain-database-type",
+  "domain-typescript-type",
+  "domain-nullability",
+  "function-added",
+  "function-removed",
+  "function-return-type",
+  "function-nullability",
+  "function-set-returning",
+  "function-volatility",
+  "dialect-version",
+  "server-version",
+  "query-contract",
+]);
+const targetKinds = new Set<SchemaCompatibilityTarget["kind"]>([
+  "schema",
+  "relation",
+  "column",
+  "enum",
+  "domain",
+  "function",
+  "query",
+]);
+const directions = new Set<DeploymentDirection>(["before-app-after-database", "after-app-before-database"]);
+const classifications = new Set<CompatibilityClassification>([
+  "compatible",
+  "deployment-order-sensitive",
+  "source-breaking",
+  "runtime-breaking",
+  "unknown",
+]);
+const severities = new Set<CompatibilitySeverity>(["info", "warning", "error"]);
+
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNonEmptyString(value: unknown, description: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${description} must be a non-empty string`);
+}
+
+function assertOptionalString(value: unknown, description: string): void {
+  if (value !== undefined) assertNonEmptyString(value, description);
+}
+
+function assertHash(value: unknown, description: string): asserts value is string {
+  if (typeof value !== "string" || !/^sha256:[a-f\d]{64}$/u.test(value)) {
+    throw new TypeError(`${description} must be a sha256 fingerprint`);
+  }
+}
+
+function assertDigest(value: unknown, description: string): asserts value is string {
+  if (typeof value !== "string" || !/^[a-f\d]{64}$/u.test(value)) {
+    throw new TypeError(`${description} must be a sha256 digest`);
+  }
+}
+
+function assertRange(value: unknown, description: string): asserts value is SourceRange {
+  if (
+    !record(value) ||
+    !Number.isSafeInteger(value.start) ||
+    (value.start as number) < 0 ||
+    !Number.isSafeInteger(value.end) ||
+    (value.end as number) < (value.start as number) ||
+    !Number.isSafeInteger(value.line) ||
+    (value.line as number) < 1 ||
+    !Number.isSafeInteger(value.column) ||
+    (value.column as number) < 1
+  ) {
+    throw new TypeError(`${description} must contain a valid source range`);
+  }
+}
+
+function assertLocation(value: unknown, description: string): asserts value is QueryManifestLocation {
+  if (!record(value)) throw new TypeError(`${description} must be an object`);
+  assertNonEmptyString(value.file, `${description}.file`);
+  if (/^(?:\/|\\|[A-Za-z]:[\\/])/u.test(value.file) || value.file.includes("\0")) {
+    throw new TypeError(`${description}.file must be a portable relative path`);
+  }
+  assertRange(value.range, `${description}.range`);
+}
+
+function assertEvidence(value: unknown, description: string): asserts value is CompatibilityEvidence {
+  if (!record(value)) throw new TypeError(`${description} must be an object`);
+  for (const item of Object.values(value)) {
+    if (
+      item !== null &&
+      typeof item !== "string" &&
+      typeof item !== "boolean" &&
+      !(Array.isArray(item) && item.every((entry) => typeof entry === "string"))
+    ) {
+      throw new TypeError(`${description} contains an unsupported evidence value`);
+    }
+  }
+}
+
+function assertQueryReference(value: unknown, description: string): asserts value is CompatibilityQueryReference {
+  if (!record(value)) throw new TypeError(`${description} must be an object`);
+  assertHash(value.queryId, `${description}.queryId`);
+  assertHash(value.variantFingerprint, `${description}.variantFingerprint`);
+  assertLocation(value.source, `${description}.source`);
+  if (value.dependencyRange !== undefined) assertRange(value.dependencyRange, `${description}.dependencyRange`);
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => compareText(left, right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+}
+
+function targetIdentity(target: SchemaCompatibilityTarget): string {
+  return `${target.kind}\0${target.key}\0${target.schema ?? ""}\0${target.parent ?? ""}\0${target.name}`;
+}
+
+function change(
+  kind: SchemaCompatibilityChangeKind,
+  target: SchemaCompatibilityTarget,
+  before: CompatibilityEvidence | undefined,
+  after: CompatibilityEvidence | undefined,
+): SchemaCompatibilityChange {
+  const identity = JSON.stringify(canonicalize({ kind, target, before, after }));
+  return {
+    id: `sha256:${sha256(identity)}`,
+    kind,
+    target,
+    ...(before === undefined ? {} : { before }),
+    ...(after === undefined ? {} : { after }),
+  };
+}
+
+function relationTarget(key: string, table: SchemaSnapshot["tables"][string]): SchemaCompatibilityTarget {
+  return {
+    kind: "relation",
+    key,
+    name: table.name,
+    ...(table.schema === undefined ? {} : { schema: table.schema }),
+  };
+}
+
+function columnTarget(
+  tableKey: string,
+  table: SchemaSnapshot["tables"][string],
+  name: string,
+): SchemaCompatibilityTarget {
+  return {
+    kind: "column",
+    key: `${tableKey}.${name}`,
+    name,
+    parent: tableKey,
+    ...(table.schema === undefined ? {} : { schema: table.schema }),
+  };
+}
+
+function typeTarget(
+  kind: "enum" | "domain",
+  key: string,
+  name = key.split(".").at(-1) ?? key,
+): SchemaCompatibilityTarget {
+  const dot = key.lastIndexOf(".");
+  return {
+    kind,
+    key,
+    name,
+    ...(dot === -1 ? {} : { schema: key.slice(0, dot) }),
+  };
+}
+
+function functionTarget(
+  key: string,
+  value: NonNullable<SchemaSnapshot["functions"]>[string],
+): SchemaCompatibilityTarget {
+  return {
+    kind: "function",
+    key,
+    name: value.name,
+    ...(value.schema === undefined ? {} : { schema: value.schema }),
+  };
+}
+
+function defaultEvidence(value: string | undefined): CompatibilityEvidence {
+  return value === undefined ? { present: false, fingerprint: null } : { present: true, fingerprint: sha256(value) };
+}
+
+function enumChanges(before: SchemaSnapshot, after: SchemaSnapshot): InternalChange[] {
+  const output: InternalChange[] = [];
+  const keys = [...new Set([...Object.keys(before.enums ?? {}), ...Object.keys(after.enums ?? {})])].sort(compareText);
+  for (const key of keys) {
+    const left = before.enums?.[key];
+    const right = after.enums?.[key];
+    const target = typeTarget("enum", key);
+    if (left === undefined && right !== undefined) {
+      const item = change("enum-added", target, undefined, { values: right });
+      output.push({ change: item, keys: [typeKey("enum", key)] });
+    } else if (left !== undefined && right === undefined) {
+      const item = change("enum-removed", target, { values: left }, undefined);
+      output.push({ change: item, keys: [typeKey("enum", key)] });
+    } else if (left !== undefined && right !== undefined && JSON.stringify(left) !== JSON.stringify(right)) {
+      const item = change("enum-values", target, { values: left }, { values: right });
+      output.push({ change: item, keys: [typeKey("enum", key)] });
+    }
+  }
+  return output;
+}
+
+function domainChanges(before: SchemaSnapshot, after: SchemaSnapshot): InternalChange[] {
+  const output: InternalChange[] = [];
+  const keys = [...new Set([...Object.keys(before.domains ?? {}), ...Object.keys(after.domains ?? {})])].sort(
+    compareText,
+  );
+  for (const key of keys) {
+    const left = before.domains?.[key];
+    const right = after.domains?.[key];
+    const target = typeTarget("domain", key, left?.name ?? right?.name);
+    if (left === undefined && right !== undefined) {
+      const item = change("domain-added", target, undefined, {
+        databaseType: right.databaseType,
+        tsType: right.tsType,
+        nullable: right.nullable,
+      });
+      output.push({ change: item, keys: [typeKey("domain", key)] });
+      continue;
+    }
+    if (left !== undefined && right === undefined) {
+      const item = change(
+        "domain-removed",
+        target,
+        { databaseType: left.databaseType, tsType: left.tsType, nullable: left.nullable },
+        undefined,
+      );
+      output.push({ change: item, keys: [typeKey("domain", key)] });
+      continue;
+    }
+    if (left === undefined || right === undefined) continue;
+    for (const [kind, property] of [
+      ["domain-database-type", "databaseType"],
+      ["domain-typescript-type", "tsType"],
+      ["domain-nullability", "nullable"],
+    ] as const) {
+      if (left[property] === right[property]) continue;
+      const item = change(kind, target, { [property]: left[property] }, { [property]: right[property] });
+      output.push({ change: item, keys: [typeKey("domain", key)] });
+    }
+  }
+  return output;
+}
+
+function functionEvidence(value: NonNullable<SchemaSnapshot["functions"]>[string]): CompatibilityEvidence {
+  return {
+    arguments: value.argumentTypes,
+    databaseReturnType: value.databaseReturnType ?? null,
+    returnType: value.returnType,
+    nullable: value.nullable,
+    setReturning: value.setReturning ?? false,
+    volatility: value.volatility ?? null,
+  };
+}
+
+function functionChanges(before: SchemaSnapshot, after: SchemaSnapshot): InternalChange[] {
+  const output: InternalChange[] = [];
+  const keys = [...new Set([...Object.keys(before.functions ?? {}), ...Object.keys(after.functions ?? {})])].sort(
+    compareText,
+  );
+  for (const key of keys) {
+    const left = before.functions?.[key];
+    const right = after.functions?.[key];
+    const value = left ?? right;
+    if (value === undefined) continue;
+    const target = functionTarget(key, value);
+    const impactKeys = [functionKey(key), functionNameKey(value.schema, value.name)];
+    if (left === undefined && right !== undefined) {
+      output.push({ change: change("function-added", target, undefined, functionEvidence(right)), keys: impactKeys });
+      continue;
+    }
+    if (left !== undefined && right === undefined) {
+      output.push({ change: change("function-removed", target, functionEvidence(left), undefined), keys: impactKeys });
+      continue;
+    }
+    if (left === undefined || right === undefined) continue;
+    for (const [kind, property, evidenceName] of [
+      ["function-return-type", "databaseReturnType", "databaseReturnType"],
+      ["function-return-type", "returnType", "returnType"],
+      ["function-nullability", "nullable", "nullable"],
+      ["function-set-returning", "setReturning", "setReturning"],
+      ["function-volatility", "volatility", "volatility"],
+    ] as const) {
+      const leftValue = left[property] ?? (property === "setReturning" ? false : null);
+      const rightValue = right[property] ?? (property === "setReturning" ? false : null);
+      if (leftValue === rightValue) continue;
+      const item = change(kind, target, { [evidenceName]: leftValue }, { [evidenceName]: rightValue });
+      output.push({ change: item, keys: impactKeys });
+    }
+  }
+  return output;
+}
+
+function schemaChanges(before: SchemaSnapshot, after: SchemaSnapshot): InternalChange[] {
+  const output: InternalChange[] = [
+    ...enumChanges(before, after),
+    ...domainChanges(before, after),
+    ...functionChanges(before, after),
+  ];
+  const tableKeys = [...new Set([...Object.keys(before.tables), ...Object.keys(after.tables)])].sort(compareText);
+  for (const tableKey of tableKeys) {
+    const leftTable = before.tables[tableKey];
+    const rightTable = after.tables[tableKey];
+    const table = leftTable ?? rightTable;
+    if (table === undefined) continue;
+    if (leftTable === undefined && rightTable !== undefined) {
+      output.push({
+        change: change("relation-added", relationTarget(tableKey, rightTable), undefined, {}),
+        keys: [relationKey(tableKey)],
+      });
+      continue;
+    }
+    if (leftTable !== undefined && rightTable === undefined) {
+      output.push({
+        change: change("relation-removed", relationTarget(tableKey, leftTable), {}, undefined),
+        keys: [relationKey(tableKey)],
+      });
+      continue;
+    }
+    if (leftTable === undefined || rightTable === undefined) continue;
+    const columnNames = [...new Set([...Object.keys(leftTable.columns), ...Object.keys(rightTable.columns)])].sort(
+      compareText,
+    );
+    for (const name of columnNames) {
+      const left = leftTable.columns[name];
+      const right = rightTable.columns[name];
+      const target = columnTarget(tableKey, table, name);
+      if (left === undefined && right !== undefined) {
+        output.push({
+          change: change("column-added", target, undefined, {
+            databaseType: right.databaseType,
+            tsType: right.tsType,
+            nullable: right.nullable,
+            ...defaultEvidence(right.defaultExpression),
+          }),
+          keys: [columnKey(tableKey, name)],
+          relationWriteKey: relationWriteKey(tableKey),
+          addedMandatoryColumn: !right.nullable && right.defaultExpression === undefined,
+        });
+        continue;
+      }
+      if (left !== undefined && right === undefined) {
+        output.push({
+          change: change(
+            "column-removed",
+            target,
+            {
+              databaseType: left.databaseType,
+              tsType: left.tsType,
+              nullable: left.nullable,
+              ...defaultEvidence(left.defaultExpression),
+            },
+            undefined,
+          ),
+          keys: [columnKey(tableKey, name)],
+          relationWriteKey: relationWriteKey(tableKey),
+          removedMandatoryColumn: !left.nullable && left.defaultExpression === undefined,
+        });
+        continue;
+      }
+      if (left === undefined || right === undefined) continue;
+      for (const [kind, property] of [
+        ["column-database-type", "databaseType"],
+        ["column-typescript-type", "tsType"],
+        ["column-nullability", "nullable"],
+      ] as const) {
+        if (left[property] === right[property]) continue;
+        output.push({
+          change: change(kind, target, { [property]: left[property] }, { [property]: right[property] }),
+          keys: [columnKey(tableKey, name)],
+          relationWriteKey: relationWriteKey(tableKey),
+        });
+      }
+      if ((left.array ?? false) !== (right.array ?? false)) {
+        output.push({
+          change: change("column-array", target, { array: left.array ?? false }, { array: right.array ?? false }),
+          keys: [columnKey(tableKey, name)],
+        });
+      }
+      if (left.defaultExpression !== right.defaultExpression) {
+        output.push({
+          change: change(
+            "column-default",
+            target,
+            defaultEvidence(left.defaultExpression),
+            defaultEvidence(right.defaultExpression),
+          ),
+          keys: [columnKey(tableKey, name)],
+          relationWriteKey: relationWriteKey(tableKey),
+        });
+      }
+    }
+  }
+  if (before.version !== after.version) {
+    output.push({
+      change: change(
+        "server-version",
+        { kind: "schema", key: before.dialect, name: before.dialect },
+        { version: before.version ?? null },
+        { version: after.version ?? null },
+      ),
+      keys: ["all-queries"],
+    });
+  }
+  if (before.dialectVersion !== after.dialectVersion) {
+    output.push({
+      change: change(
+        "dialect-version",
+        { kind: "schema", key: before.dialect, name: before.dialect },
+        { version: before.dialectVersion ?? null },
+        { version: after.dialectVersion ?? null },
+      ),
+      keys: ["all-queries"],
+    });
+  }
+  return output.sort(
+    (left, right) =>
+      compareText(targetIdentity(left.change.target), targetIdentity(right.change.target)) ||
+      compareText(left.change.kind, right.change.kind),
+  );
+}
+
+function matchingTables(snapshot: SchemaSnapshot, name: string, schema?: string) {
+  return Object.entries(snapshot.tables).filter(
+    ([key, table]) =>
+      (key === name || table.name === name || key.endsWith(`.${name}`)) &&
+      (schema === undefined || table.schema === schema),
+  );
+}
+
+function matchingColumns(
+  tables: readonly [string, SchemaSnapshot["tables"][string]][],
+  name: string,
+): readonly [string, string][] {
+  return tables.flatMap(([tableKey, table]) =>
+    Object.entries(table.columns)
+      .filter(([columnKey, column]) => columnKey === name || column.name === name)
+      .map(([columnKey]) => [tableKey, columnKey] as const),
+  );
+}
+
+function matchingTypes(values: Readonly<Record<string, unknown>>, name: string, schema?: string): readonly string[] {
+  const matches = Object.keys(values).filter((key) => key === name || key.endsWith(`.${name}`));
+  if (schema === undefined) return matches;
+  const qualified = matches.filter((key) => key === `${schema}.${name}`);
+  return qualified.length === 0 ? matches.filter((key) => !key.includes(".")) : qualified;
+}
+
+function addReference(
+  map: Map<string, CompatibilityQueryReference[]>,
+  key: string,
+  reference: CompatibilityQueryReference,
+): void {
+  map.set(key, [...(map.get(key) ?? []), reference]);
+}
+
+function reference(
+  entryId: string,
+  variant: QueryManifestVariant,
+  source: QueryManifestLocation,
+  dependency?: QueryDependency,
+): CompatibilityQueryReference {
+  return {
+    queryId: entryId,
+    variantFingerprint: variant.fingerprint,
+    source,
+    ...(dependency === undefined ? {} : { dependencyRange: dependency.range }),
+  };
+}
+
+function manifestReferences(manifest: QueryManifest, snapshot: SchemaSnapshot): ManifestReferences {
+  const byKey = new Map<string, CompatibilityQueryReference[]>();
+  const unknown: CompatibilityQueryReference[] = [];
+  for (const entry of manifest.queries) {
+    if (entry.status === "unresolved") {
+      unknown.push({ queryId: entry.id, variantFingerprint: entry.id, source: entry.source });
+      continue;
+    }
+    for (const variant of entry.variants) {
+      if (
+        variant.semantics.operation.value === "unknown" ||
+        variant.semantics.cardinality.maximum === "unknown" ||
+        variant.semantics.volatility.value === "unknown" ||
+        variant.semantics.locking.value === "unknown" ||
+        variant.semantics.connectionAffinity.value === "unknown"
+      ) {
+        unknown.push(reference(entry.id, variant, entry.source));
+      }
+      const relationMatches = new Map<QueryDependency, readonly [string, SchemaSnapshot["tables"][string]][]>();
+      for (const dependency of variant.semantics.dependencies.filter((item) => item.kind === "relation")) {
+        const matches = matchingTables(snapshot, dependency.name, dependency.schema);
+        relationMatches.set(dependency, matches);
+        const item = reference(entry.id, variant, entry.source, dependency);
+        if (matches.length === 1) {
+          addReference(byKey, relationKey(matches[0]![0]), item);
+          if (dependency.access === "write") addReference(byKey, relationWriteKey(matches[0]![0]), item);
+        } else unknown.push(item);
+      }
+      for (const dependency of variant.semantics.dependencies.filter((item) => item.kind !== "relation")) {
+        const item = reference(entry.id, variant, entry.source, dependency);
+        if (dependency.kind === "column") {
+          let matches = dependency.parent === undefined ? [] : matchingTables(snapshot, dependency.parent);
+          if (matches.length === 0) {
+            matches = [...new Map([...relationMatches.values()].flat().map((value) => [value[0], value])).values()];
+          }
+          const columns = matchingColumns(matches, dependency.name);
+          if (columns.length === 1) {
+            addReference(byKey, columnKey(columns[0]![0], columns[0]![1]), item);
+          } else unknown.push(item);
+        } else if (dependency.kind === "function") {
+          const matches = Object.entries(snapshot.functions ?? {}).filter(
+            ([, fn]) =>
+              fn.name === dependency.name && (dependency.schema === undefined || fn.schema === dependency.schema),
+          );
+          if (matches.length === 1) addReference(byKey, functionKey(matches[0]![0]), item);
+          if (matches.length > 0)
+            addReference(byKey, functionNameKey(dependency.schema ?? matches[0]?.[1].schema, dependency.name), item);
+          else if (dependency.certainty === "resolved") unknown.push(item);
+        } else if (dependency.kind === "type") {
+          const enums = matchingTypes(snapshot.enums ?? {}, dependency.name, dependency.schema);
+          const domains = matchingTypes(snapshot.domains ?? {}, dependency.name, dependency.schema);
+          if (enums.length + domains.length === 1) {
+            if (enums.length === 1) addReference(byKey, typeKey("enum", enums[0]!), item);
+            else addReference(byKey, typeKey("domain", domains[0]!), item);
+          } else if (enums.length + domains.length > 1 || dependency.certainty === "resolved") unknown.push(item);
+        } else if (dependency.kind === "unknown" || dependency.kind === "sequence") unknown.push(item);
+      }
+      addReference(byKey, "all-queries", reference(entry.id, variant, entry.source));
+    }
+  }
+  return { byKey, unknown: uniqueReferences(unknown) };
+}
+
+function uniqueReferences(values: readonly CompatibilityQueryReference[]): readonly CompatibilityQueryReference[] {
+  const unique = new Map<string, CompatibilityQueryReference>();
+  for (const value of values) {
+    const key = `${value.queryId}\0${value.variantFingerprint}\0${value.dependencyRange?.start ?? -1}`;
+    unique.set(key, value);
+  }
+  return [...unique.values()].sort(
+    (left, right) =>
+      compareText(left.source.file, right.source.file) ||
+      left.source.range.start - right.source.range.start ||
+      compareText(left.variantFingerprint, right.variantFingerprint) ||
+      (left.dependencyRange?.start ?? -1) - (right.dependencyRange?.start ?? -1),
+  );
+}
+
+function affected(
+  change: InternalChange,
+  references: ManifestReferences,
+  direction: DeploymentDirection,
+): readonly CompatibilityQueryReference[] {
+  const values = change.keys.flatMap((key) => references.byKey.get(key) ?? []);
+  if (
+    change.relationWriteKey !== undefined &&
+    ((change.addedMandatoryColumn === true && direction === "before-app-after-database") ||
+      (change.removedMandatoryColumn === true && direction === "after-app-before-database") ||
+      change.change.kind === "column-default" ||
+      change.change.kind === "column-nullability")
+  ) {
+    values.push(...(references.byKey.get(change.relationWriteKey) ?? []));
+  }
+  return uniqueReferences(values);
+}
+
+function risk(
+  item: InternalChange,
+  direction: DeploymentDirection,
+  queries: readonly CompatibilityQueryReference[],
+): Pick<SchemaCompatibilityAssessment, "classification" | "severity" | "reason"> {
+  const kind = item.change.kind;
+  if (queries.length === 0)
+    return {
+      classification: "compatible",
+      severity: "info",
+      reason: "No compiled query in this application version depends on the changed contract.",
+    };
+  if (kind === "server-version" || kind === "dialect-version")
+    return {
+      classification: "unknown",
+      severity: "warning",
+      reason: "Database-version compatibility requires live verification in a representative environment.",
+    };
+  if (kind === "column-typescript-type" || kind === "domain-typescript-type" || kind === "query-contract") {
+    return {
+      classification: "source-breaking",
+      severity: "error",
+      reason: "The inferred TypeScript query contract changes.",
+    };
+  }
+  if (kind === "function-volatility" || kind === "column-default") {
+    return {
+      classification: "deployment-order-sensitive",
+      severity: "warning",
+      reason: "The query can depend on changed execution or default-value semantics during a rolling deployment.",
+    };
+  }
+  if (kind.endsWith("-added")) {
+    if (direction === "after-app-before-database")
+      return {
+        classification: "runtime-breaking",
+        severity: "error",
+        reason: "The newer application references a contract that the older database does not provide.",
+      };
+    if (kind === "function-added" || item.addedMandatoryColumn === true)
+      return {
+        classification: "deployment-order-sensitive",
+        severity: "error",
+        reason: "The added contract can change overload resolution or make existing writes incomplete.",
+      };
+    return {
+      classification: "compatible",
+      severity: "info",
+      reason: "The older application does not require the additive contract.",
+    };
+  }
+  if (kind.endsWith("-removed")) {
+    if (direction === "before-app-after-database")
+      return {
+        classification: "runtime-breaking",
+        severity: "error",
+        reason: "The older application references a contract removed from the newer database.",
+      };
+    if (kind === "function-removed")
+      return {
+        classification: "deployment-order-sensitive",
+        severity: "warning",
+        reason:
+          "An overload present only on the older database can change function resolution for the newer application.",
+      };
+    if (item.removedMandatoryColumn === true)
+      return {
+        classification: "deployment-order-sensitive",
+        severity: "error",
+        reason: "The newer application can omit a value still required by the older database.",
+      };
+    return {
+      classification: "compatible",
+      severity: "info",
+      reason: "The newer application does not require the removed contract.",
+    };
+  }
+  return {
+    classification: "runtime-breaking",
+    severity: "error",
+    reason: "The database contract used by the query changes incompatibly across deployment versions.",
+  };
+}
+
+function manifestHash(manifest: QueryManifest): string {
+  return `sha256:${sha256(serializeQueryManifest(manifest))}`;
+}
+
+function validateInputs(options: AnalyzeSchemaCompatibilityOptions): void {
+  parseQueryManifest(options.beforeManifest);
+  parseQueryManifest(options.afterManifest);
+  const dialect = options.before.dialect;
+  if (
+    options.after.dialect !== dialect ||
+    options.beforeManifest.dialect.id !== dialect ||
+    options.afterManifest.dialect.id !== dialect
+  ) {
+    throw new TypeError("Compatibility snapshots and manifests must use the same dialect");
+  }
+  const beforeHash = calculateSchemaHash(options.before);
+  const afterHash = calculateSchemaHash(options.after);
+  if (options.beforeManifest.schemaHash !== beforeHash)
+    throw new TypeError("Before manifest is stale for the before snapshot");
+  if (options.afterManifest.schemaHash !== afterHash)
+    throw new TypeError("After manifest is stale for the after snapshot");
+}
+
+function queryContractChanges(before: QueryManifest, after: QueryManifest): InternalChange[] {
+  const output: InternalChange[] = [];
+  const afterEntries = new Map(
+    after.queries
+      .filter((entry) => entry.status === "resolved")
+      .map((entry) => [`${entry.source.file}\0${entry.source.range.start}\0${entry.fingerprint}`, entry] as const),
+  );
+  for (const entry of before.queries) {
+    if (entry.status !== "resolved") continue;
+    const other = afterEntries.get(`${entry.source.file}\0${entry.source.range.start}\0${entry.fingerprint}`);
+    if (other === undefined) continue;
+    const otherVariants = new Map(other.variants.map((variant) => [variant.fingerprint, variant]));
+    for (const variant of entry.variants) {
+      const afterVariant = otherVariants.get(variant.fingerprint);
+      if (
+        afterVariant === undefined ||
+        (variant.rowType === afterVariant.rowType && variant.parameterType === afterVariant.parameterType)
+      )
+        continue;
+      const target: SchemaCompatibilityTarget = { kind: "query", key: entry.id, name: entry.id };
+      const item = change(
+        "query-contract",
+        target,
+        { rowType: variant.rowType, parameterType: variant.parameterType },
+        { rowType: afterVariant.rowType, parameterType: afterVariant.parameterType },
+      );
+      output.push({
+        change: item,
+        keys: [`query:${item.id}`],
+        queryReferences: {
+          "before-app-after-database": reference(entry.id, variant, entry.source),
+          "after-app-before-database": reference(other.id, afterVariant, other.source),
+        },
+      });
+    }
+  }
+  return output;
+}
+
+export function analyzeSchemaCompatibility(options: AnalyzeSchemaCompatibilityOptions): SchemaCompatibilityReport {
+  validateInputs(options);
+  const beforeReferences = manifestReferences(options.beforeManifest, options.before);
+  const afterReferences = manifestReferences(options.afterManifest, options.after);
+  const changes = [
+    ...schemaChanges(options.before, options.after),
+    ...queryContractChanges(options.beforeManifest, options.afterManifest),
+  ].sort(
+    (left, right) =>
+      compareText(targetIdentity(left.change.target), targetIdentity(right.change.target)) ||
+      compareText(left.change.kind, right.change.kind),
+  );
+  const assessments: SchemaCompatibilityAssessment[] = [];
+  for (const item of changes) {
+    for (const direction of ["before-app-after-database", "after-app-before-database"] as const) {
+      const references = direction === "before-app-after-database" ? beforeReferences : afterReferences;
+      const explicit = item.queryReferences?.[direction];
+      const queries = explicit === undefined ? affected(item, references, direction) : [explicit];
+      assessments.push({ direction, changeId: item.change.id, ...risk(item, direction, queries), queries });
+    }
+  }
+  for (const [direction, references] of [
+    ["before-app-after-database", beforeReferences],
+    ["after-app-before-database", afterReferences],
+  ] as const) {
+    for (const query of references.unknown) {
+      assessments.push({
+        direction,
+        classification: "unknown",
+        severity: "warning",
+        reason: "The manifest contains an unresolved query or dependency, so compatibility cannot be proven.",
+        queries: [query],
+      });
+    }
+  }
+  assessments.sort(
+    (left, right) =>
+      compareText(left.direction, right.direction) ||
+      compareText(left.changeId ?? "", right.changeId ?? "") ||
+      compareText(left.queries[0]?.source.file ?? "", right.queries[0]?.source.file ?? "") ||
+      (left.queries[0]?.source.range.start ?? -1) - (right.queries[0]?.source.range.start ?? -1),
+  );
+  const report: SchemaCompatibilityReport = {
+    formatVersion: SCHEMA_COMPATIBILITY_FORMAT_VERSION,
+    analyzerVersion: SCHEMA_COMPATIBILITY_ANALYZER_VERSION,
+    dialect: options.before.dialect,
+    before: {
+      schemaHash: options.beforeManifest.schemaHash,
+      manifestHash: manifestHash(options.beforeManifest),
+      ...(options.before.version === undefined ? {} : { version: options.before.version }),
+    },
+    after: {
+      schemaHash: options.afterManifest.schemaHash,
+      manifestHash: manifestHash(options.afterManifest),
+      ...(options.after.version === undefined ? {} : { version: options.after.version }),
+    },
+    changes: changes.map((item) => item.change),
+    assessments,
+    summary: {
+      info: assessments.filter((item) => item.severity === "info").length,
+      warning: assessments.filter((item) => item.severity === "warning").length,
+      error: assessments.filter((item) => item.severity === "error").length,
+    },
+  };
+  return report;
+}
+
+export function serializeSchemaCompatibilityReport(report: SchemaCompatibilityReport): string {
+  return `${JSON.stringify(canonicalize(report), null, 2)}\n`;
+}
+
+export function parseSchemaCompatibilityReport(value: unknown): SchemaCompatibilityReport {
+  if (!record(value)) throw new TypeError("Compatibility report must be an object");
+  const report = value;
+  if (report.formatVersion !== SCHEMA_COMPATIBILITY_FORMAT_VERSION)
+    throw new TypeError(`Unsupported compatibility report format ${String(report.formatVersion)}`);
+  if (report.analyzerVersion !== SCHEMA_COMPATIBILITY_ANALYZER_VERSION)
+    throw new TypeError(`Unsupported compatibility analyzer ${String(report.analyzerVersion)}`);
+  assertNonEmptyString(report.dialect, "Compatibility report dialect");
+  for (const [name, artifact] of [
+    ["before", report.before],
+    ["after", report.after],
+  ] as const) {
+    if (!record(artifact)) throw new TypeError(`Compatibility report ${name} artifact is invalid`);
+    assertDigest(artifact.schemaHash, `Compatibility report ${name}.schemaHash`);
+    assertHash(artifact.manifestHash, `Compatibility report ${name}.manifestHash`);
+    assertOptionalString(artifact.version, `Compatibility report ${name}.version`);
+  }
+  if (!Array.isArray(report.changes)) throw new TypeError("Compatibility report changes must be an array");
+  const changeIds = new Set<string>();
+  for (const [index, item] of report.changes.entries()) {
+    const description = `Compatibility report change ${index}`;
+    if (!record(item) || !changeKinds.has(item.kind as SchemaCompatibilityChangeKind) || !record(item.target)) {
+      throw new TypeError(`${description} is invalid`);
+    }
+    const target = item.target;
+    if (!targetKinds.has(target.kind as SchemaCompatibilityTarget["kind"])) {
+      throw new TypeError(`${description}.target.kind is invalid`);
+    }
+    assertNonEmptyString(target.key, `${description}.target.key`);
+    assertNonEmptyString(target.name, `${description}.target.name`);
+    assertOptionalString(target.schema, `${description}.target.schema`);
+    assertOptionalString(target.parent, `${description}.target.parent`);
+    if (item.before !== undefined) assertEvidence(item.before, `${description}.before`);
+    if (item.after !== undefined) assertEvidence(item.after, `${description}.after`);
+    assertHash(item.id, `${description}.id`);
+    const expected = change(
+      item.kind as SchemaCompatibilityChangeKind,
+      target as unknown as SchemaCompatibilityTarget,
+      item.before as CompatibilityEvidence | undefined,
+      item.after as CompatibilityEvidence | undefined,
+    ).id;
+    if (item.id !== expected) throw new TypeError(`${description}.id does not match its canonical evidence`);
+    if (changeIds.has(item.id)) throw new TypeError(`${description}.id is duplicated`);
+    changeIds.add(item.id);
+  }
+  if (!Array.isArray(report.assessments)) throw new TypeError("Compatibility report assessments must be an array");
+  const counted: Record<CompatibilitySeverity, number> = { info: 0, warning: 0, error: 0 };
+  for (const [index, item] of report.assessments.entries()) {
+    const description = `Compatibility report assessment ${index}`;
+    if (
+      !record(item) ||
+      !directions.has(item.direction as DeploymentDirection) ||
+      !classifications.has(item.classification as CompatibilityClassification) ||
+      !severities.has(item.severity as CompatibilitySeverity) ||
+      !Array.isArray(item.queries)
+    ) {
+      throw new TypeError(`${description} is invalid`);
+    }
+    assertNonEmptyString(item.reason, `${description}.reason`);
+    if (item.changeId !== undefined) {
+      assertHash(item.changeId, `${description}.changeId`);
+      if (!changeIds.has(item.changeId))
+        throw new TypeError(`${description}.changeId does not identify a report change`);
+    }
+    for (const [queryIndex, query] of item.queries.entries()) {
+      assertQueryReference(query, `${description}.queries[${queryIndex}]`);
+    }
+    counted[item.severity as CompatibilitySeverity] += 1;
+  }
+  if (!record(report.summary)) throw new TypeError("Compatibility report summary is invalid");
+  for (const severity of ["info", "warning", "error"] as const) {
+    if (!Number.isSafeInteger(report.summary[severity]) || report.summary[severity] !== counted[severity])
+      throw new TypeError("Compatibility report summary is invalid");
+  }
+  return value as unknown as SchemaCompatibilityReport;
+}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,6 +1,27 @@
 export type { CheckFileOptions, CheckFileResult, TypeScriptCheckResult } from "./check.js";
 export { checkFile } from "./check.js";
 export type {
+  AnalyzeSchemaCompatibilityOptions,
+  CompatibilityClassification,
+  CompatibilityEvidence,
+  CompatibilityEvidenceValue,
+  CompatibilityQueryReference,
+  CompatibilitySeverity,
+  DeploymentDirection,
+  SchemaCompatibilityAssessment,
+  SchemaCompatibilityChange,
+  SchemaCompatibilityChangeKind,
+  SchemaCompatibilityReport,
+  SchemaCompatibilityTarget,
+} from "./compatibility.js";
+export {
+  analyzeSchemaCompatibility,
+  parseSchemaCompatibilityReport,
+  SCHEMA_COMPATIBILITY_ANALYZER_VERSION,
+  SCHEMA_COMPATIBILITY_FORMAT_VERSION,
+  serializeSchemaCompatibilityReport,
+} from "./compatibility.js";
+export type {
   CompiledFragment,
   CompiledQuery,
   CompiledQueryVariant,

--- a/packages/compiler/test/compatibility.test.ts
+++ b/packages/compiler/test/compatibility.test.ts
@@ -1,0 +1,727 @@
+import { describe, it, strict } from "poku";
+import type { DialectPlugin, SchemaSnapshot } from "../../core/src/index.js";
+import { mysql } from "../../mysql/src/index.js";
+import { postgres } from "../../postgres/src/index.js";
+import {
+  analyzeSchemaCompatibility,
+  buildQueryManifest,
+  parseSchemaCompatibilityReport,
+  serializeSchemaCompatibilityReport,
+} from "../src/index.js";
+
+const beforeSource = (module: string) =>
+  [
+    `import { sql } from ${JSON.stringify(module)};`,
+    "declare const id: bigint;",
+    "const account = sql`SELECT account.id, account.email FROM users AS account WHERE account.id = ${id}`;",
+    'const dynamic = sql.dynamic("SELECT runtime");',
+    "void [account, dynamic];",
+  ].join("\n");
+
+const afterSource = (module: string) =>
+  [
+    `import { sql } from ${JSON.stringify(module)};`,
+    "declare const id: string;",
+    "const account = sql`SELECT account.id, account.tenant_id FROM users AS account WHERE account.id = ${id}`;",
+    'const dynamic = sql.dynamic("SELECT runtime");',
+    "void [account, dynamic];",
+  ].join("\n");
+
+function snapshots(dialect: "postgres" | "mysql") {
+  const schema = dialect === "postgres" ? "public" : "app";
+  const tableKey = dialect === "postgres" ? "public.users" : "users";
+  const before: SchemaSnapshot = {
+    formatVersion: 1,
+    dialect,
+    version: dialect === "postgres" ? "17.8" : "8.0.40",
+    tables: {
+      [tableKey]: {
+        schema,
+        name: "users",
+        columns: {
+          id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+          email: {
+            name: "email",
+            databaseType: dialect === "postgres" ? "text" : "varchar(255)",
+            tsType: "string",
+            nullable: false,
+            defaultExpression: "'recognizable-secret'",
+          },
+          nickname: { name: "nickname", databaseType: "text", tsType: "string", nullable: true },
+          short_label: { name: "short_label", databaseType: "varchar(20)", tsType: "string", nullable: false },
+          quantity: { name: "quantity", databaseType: "bigint", tsType: "bigint", nullable: false },
+          status: {
+            name: "status",
+            databaseType: "enum('active','suspended')",
+            tsType: '"active" | "suspended"',
+            nullable: false,
+          },
+          display_name: { name: "display_name", databaseType: "text", tsType: "string", nullable: false },
+        },
+      },
+    },
+  };
+  const after: SchemaSnapshot = {
+    formatVersion: 1,
+    dialect,
+    version: dialect === "postgres" ? "18.4" : "8.4.11",
+    tables: {
+      [tableKey]: {
+        schema,
+        name: "users",
+        columns: {
+          id: {
+            name: "id",
+            databaseType: dialect === "postgres" ? "numeric" : "decimal",
+            tsType: "string",
+            nullable: false,
+          },
+          tenant_id: { name: "tenant_id", databaseType: "bigint", tsType: "bigint", nullable: false },
+          nickname: {
+            name: "nickname",
+            databaseType: "text",
+            tsType: "string",
+            nullable: false,
+            defaultExpression: "'anonymous'",
+          },
+          short_label: { name: "short_label", databaseType: "varchar(100)", tsType: "string", nullable: false },
+          quantity: { name: "quantity", databaseType: "integer", tsType: "number", nullable: false },
+          status: {
+            name: "status",
+            databaseType: "enum('active','suspended','deleted')",
+            tsType: '"active" | "suspended" | "deleted"',
+            nullable: false,
+          },
+          full_name: { name: "full_name", databaseType: "text", tsType: "string", nullable: false },
+        },
+      },
+    },
+  };
+  return { before, after };
+}
+
+function manifest(dialect: DialectPlugin, snapshot: SchemaSnapshot, source: string) {
+  return buildQueryManifest({
+    rootDir: "/portable/project",
+    sources: [{ file: "/portable/project/src/query.ts", source }],
+    projects: ["/portable/project/tsconfig.json"],
+    dialect,
+    schema: snapshot,
+    compilerVersion: "2.0.0-test",
+  }).manifest;
+}
+
+await describe("schema migration compatibility", async () => {
+  for (const [name, dialect] of [
+    ["PostgreSQL", postgres()],
+    ["MySQL", mysql()],
+  ] as const) {
+    await it(`classifies both rolling-deployment directions for ${name}`, () => {
+      const value = snapshots(dialect.id as "postgres" | "mysql");
+      const beforeManifest = manifest(dialect, value.before, beforeSource(dialect.sqlModule));
+      const afterManifest = manifest(dialect, value.after, afterSource(dialect.sqlModule));
+      const report = analyzeSchemaCompatibility({ ...value, beforeManifest, afterManifest });
+
+      strict.ok(report.changes.some((item) => item.kind === "column-removed" && item.target.name === "email"));
+      strict.ok(report.changes.some((item) => item.kind === "column-added" && item.target.name === "tenant_id"));
+      strict.ok(report.changes.some((item) => item.kind === "column-database-type" && item.target.name === "id"));
+      for (const kind of [
+        "column-added",
+        "column-removed",
+        "column-database-type",
+        "column-typescript-type",
+        "column-nullability",
+        "column-default",
+      ] as const) {
+        strict.ok(
+          report.changes.some((item) => item.kind === kind),
+          `${name} fixture does not cover ${kind}`,
+        );
+      }
+      strict.ok(
+        report.changes.some((item) => item.kind === "column-removed" && item.target.name === "display_name") &&
+          report.changes.some((item) => item.kind === "column-added" && item.target.name === "full_name"),
+        `${name} rename fixture must remain a conservative remove/add pair`,
+      );
+      strict.ok(report.changes.some((item) => item.kind === "server-version"));
+      strict.ok(
+        report.assessments.some(
+          (item) =>
+            item.direction === "before-app-after-database" &&
+            item.classification === "runtime-breaking" &&
+            item.queries.length > 0,
+        ),
+      );
+      strict.ok(
+        report.assessments.some(
+          (item) =>
+            item.direction === "after-app-before-database" &&
+            item.classification === "runtime-breaking" &&
+            item.queries.length > 0,
+        ),
+      );
+      strict.ok(report.assessments.some((item) => item.classification === "unknown"));
+      strict.ok(report.summary.error > 0);
+
+      const serialized = serializeSchemaCompatibilityReport(report);
+      strict.strictEqual(serialized, serializeSchemaCompatibilityReport(report));
+      strict.ok(!serialized.includes("recognizable-secret"));
+      strict.ok(!serialized.includes("/portable/project"));
+      strict.strictEqual(parseSchemaCompatibilityReport(JSON.parse(serialized)).dialect, dialect.id);
+    });
+  }
+
+  await it("fails closed for stale or cross-dialect manifests", () => {
+    const value = snapshots("postgres");
+    const pg = postgres();
+    const beforeManifest = manifest(pg, value.before, beforeSource(pg.sqlModule));
+    const afterManifest = manifest(pg, value.after, afterSource(pg.sqlModule));
+    strict.throws(
+      () =>
+        analyzeSchemaCompatibility({
+          ...value,
+          beforeManifest: { ...beforeManifest, schemaHash: "0".repeat(64) },
+          afterManifest,
+        }),
+      /stale/u,
+    );
+    strict.throws(
+      () =>
+        analyzeSchemaCompatibility({
+          ...value,
+          beforeManifest,
+          afterManifest: { ...afterManifest, dialect: { ...afterManifest.dialect, id: "mysql" } },
+        }),
+      /same dialect/u,
+    );
+    strict.throws(
+      () =>
+        analyzeSchemaCompatibility({
+          ...value,
+          beforeManifest: {
+            ...beforeManifest,
+            queries: beforeManifest.queries.map((entry, index) =>
+              index === 0 ? { ...entry, source: { ...entry.source, file: "/secret/query.ts" } } : entry,
+            ),
+          },
+          afterManifest,
+        }),
+      /relative file/u,
+    );
+    strict.throws(() => parseSchemaCompatibilityReport({ formatVersion: 99 }), /Unsupported/u);
+  });
+
+  await it("fails closed when a resolved variant contains unsupported semantic facts", () => {
+    const value = snapshots("postgres");
+    const dialect = postgres();
+    const source = beforeSource(dialect.sqlModule).replace('const dynamic = sql.dynamic("SELECT runtime");', "");
+    const base = manifest(dialect, value.before, source);
+    const unknown = {
+      ...base,
+      queries: base.queries.map((entry) =>
+        entry.status === "unresolved"
+          ? entry
+          : {
+              ...entry,
+              variants: entry.variants.map((variant) => ({
+                ...variant,
+                semantics: {
+                  ...variant.semantics,
+                  operation: { ...variant.semantics.operation, value: "unknown" as const },
+                },
+              })),
+            },
+      ),
+    };
+    const report = analyzeSchemaCompatibility({
+      before: value.before,
+      after: value.before,
+      beforeManifest: unknown,
+      afterManifest: unknown,
+    });
+    strict.strictEqual(report.changes.length, 0);
+    strict.strictEqual(report.summary.warning, 2);
+    strict.ok(report.assessments.every((item) => item.classification === "unknown"));
+  });
+
+  await it("classifies the complete versioned snapshot change matrix without requiring application queries", () => {
+    const before: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      dialectVersion: "1",
+      tables: {
+        removed_table: { name: "removed_table", columns: {} },
+        users: {
+          name: "users",
+          columns: {
+            removed_optional: { name: "removed_optional", databaseType: "text", tsType: "string", nullable: true },
+            removed_required: { name: "removed_required", databaseType: "text", tsType: "string", nullable: false },
+            changed: {
+              name: "changed",
+              databaseType: "text",
+              tsType: "string",
+              nullable: false,
+              defaultExpression: "'before-secret'",
+            },
+          },
+        },
+      },
+      enums: { removed_enum: ["old"], shared_enum: ["a", "b"] },
+      domains: {
+        removed_domain: { name: "removed_domain", databaseType: "text", tsType: "string", nullable: true },
+        shared_domain: { name: "shared_domain", databaseType: "text", tsType: "string", nullable: true },
+      },
+      functions: {
+        "removed_fn()": { name: "removed_fn", argumentTypes: [], returnType: "string", nullable: true },
+        "shared_fn()": {
+          name: "shared_fn",
+          argumentTypes: [],
+          databaseReturnType: "text",
+          returnType: "string",
+          nullable: true,
+          volatility: "stable",
+        },
+      },
+    };
+    const after: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      dialectVersion: "2",
+      tables: {
+        added_table: { name: "added_table", columns: {} },
+        users: {
+          name: "users",
+          columns: {
+            added_optional: {
+              name: "added_optional",
+              databaseType: "text",
+              tsType: "string",
+              nullable: true,
+              defaultExpression: "'safe'",
+            },
+            added_required: { name: "added_required", databaseType: "bigint", tsType: "bigint", nullable: false },
+            changed: {
+              name: "changed",
+              databaseType: "bigint",
+              tsType: "bigint",
+              nullable: true,
+              array: true,
+              defaultExpression: "'after-secret'",
+            },
+          },
+        },
+      },
+      enums: { added_enum: ["new"], shared_enum: ["b", "a", "c"] },
+      domains: {
+        added_domain: { name: "added_domain", databaseType: "text", tsType: "string", nullable: true },
+        shared_domain: { name: "shared_domain", databaseType: "bigint", tsType: "bigint", nullable: false },
+      },
+      functions: {
+        "added_fn(text)": {
+          name: "added_fn",
+          argumentTypes: ["text"],
+          databaseReturnType: "text",
+          returnType: "string",
+          nullable: true,
+        },
+        "shared_fn()": {
+          name: "shared_fn",
+          argumentTypes: [],
+          databaseReturnType: "bigint",
+          returnType: "bigint",
+          nullable: false,
+          setReturning: true,
+          volatility: "volatile",
+        },
+      },
+    };
+    const dialect = postgres();
+    const emptyManifest = (snapshot: SchemaSnapshot) => manifest(dialect, snapshot, "export {};\n");
+    const report = analyzeSchemaCompatibility({
+      before,
+      after,
+      beforeManifest: emptyManifest(before),
+      afterManifest: emptyManifest(after),
+    });
+    const kinds = new Set(report.changes.map((item) => item.kind));
+    for (const expected of [
+      "relation-added",
+      "relation-removed",
+      "column-added",
+      "column-removed",
+      "column-database-type",
+      "column-typescript-type",
+      "column-nullability",
+      "column-array",
+      "column-default",
+      "enum-added",
+      "enum-removed",
+      "enum-values",
+      "domain-added",
+      "domain-removed",
+      "domain-database-type",
+      "domain-typescript-type",
+      "domain-nullability",
+      "function-added",
+      "function-removed",
+      "function-return-type",
+      "function-nullability",
+      "function-set-returning",
+      "function-volatility",
+      "dialect-version",
+    ] as const) {
+      strict.ok(kinds.has(expected), `Missing ${expected}`);
+    }
+    strict.ok(report.assessments.every((item) => item.classification === "compatible"));
+    const serialized = serializeSchemaCompatibilityReport(report);
+    strict.ok(!serialized.includes("before-secret"));
+    strict.ok(!serialized.includes("after-secret"));
+  });
+
+  await it("records source-breaking query contracts for unchanged SQL across snapshots", () => {
+    const dialect = postgres();
+    const before: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      tables: {
+        users: {
+          name: "users",
+          columns: { id: { name: "id", databaseType: "text", tsType: "string", nullable: false } },
+        },
+      },
+    };
+    const after: SchemaSnapshot = {
+      ...before,
+      tables: {
+        users: {
+          name: "users",
+          columns: { id: { name: "id", databaseType: "text", tsType: "bigint", nullable: false } },
+        },
+      },
+    };
+    const source = 'import { sql } from "@typed-sql/postgres"; export const query = sql`SELECT users.id FROM users`;';
+    const report = analyzeSchemaCompatibility({
+      before,
+      after,
+      beforeManifest: manifest(dialect, before, source),
+      afterManifest: manifest(dialect, after, source),
+    });
+    strict.ok(report.changes.some((item) => item.kind === "query-contract"));
+    strict.ok(report.assessments.some((item) => item.classification === "source-breaking"));
+  });
+
+  await it("resolves dependencies through declared column names instead of assuming map keys", () => {
+    const dialect = postgres();
+    const before: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      tables: {
+        users: {
+          name: "users",
+          columns: { id_key: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false } },
+        },
+      },
+    };
+    const after: SchemaSnapshot = {
+      ...before,
+      tables: {
+        users: {
+          name: "users",
+          columns: { id_key: { name: "id", databaseType: "numeric", tsType: "string", nullable: false } },
+        },
+      },
+    };
+    const source = 'import { sql } from "@typed-sql/postgres"; export const query = sql`SELECT users.id FROM users`;';
+    const report = analyzeSchemaCompatibility({
+      before,
+      after,
+      beforeManifest: manifest(dialect, before, source),
+      afterManifest: manifest(dialect, after, source),
+    });
+    strict.ok(
+      report.assessments.some(
+        (item) => item.changeId !== undefined && item.classification === "runtime-breaking" && item.queries.length > 0,
+      ),
+    );
+  });
+
+  await it("detects default, mandatory-column, and overload hazards through write and function dependencies", () => {
+    const dialect = postgres();
+    const before: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      tables: {
+        users: {
+          name: "users",
+          columns: {
+            id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+            legacy: { name: "legacy", databaseType: "text", tsType: "string", nullable: false },
+            changing: {
+              name: "changing",
+              databaseType: "text",
+              tsType: "string",
+              nullable: false,
+              defaultExpression: "'before'",
+            },
+          },
+        },
+      },
+      functions: {
+        "calculate(text)": {
+          name: "calculate",
+          argumentTypes: ["text"],
+          databaseReturnType: "text",
+          returnType: "string",
+          nullable: false,
+          volatility: "stable",
+        },
+      },
+    };
+    const after: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      tables: {
+        users: {
+          name: "users",
+          columns: {
+            id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+            tenant: { name: "tenant", databaseType: "bigint", tsType: "bigint", nullable: false },
+            changing: {
+              name: "changing",
+              databaseType: "text",
+              tsType: "string",
+              nullable: false,
+              defaultExpression: "'after'",
+            },
+          },
+        },
+      },
+      functions: {
+        "calculate(bigint)": {
+          name: "calculate",
+          argumentTypes: ["bigint"],
+          databaseReturnType: "bigint",
+          returnType: "bigint",
+          nullable: false,
+          volatility: "stable",
+        },
+      },
+    };
+    const beforeSql = [
+      'import { sql } from "@typed-sql/postgres";',
+      "declare const id: bigint; declare const legacy: string;",
+      "const insert = sql`INSERT INTO users (id, legacy) VALUES (${id}, ${legacy})`;",
+      "const call = sql`SELECT calculate(${legacy}) AS value`;",
+      "void [insert, call];",
+    ].join("\n");
+    const afterSql = [
+      'import { sql } from "@typed-sql/postgres";',
+      "declare const id: bigint; declare const tenant: bigint;",
+      "const insert = sql`INSERT INTO users (id, tenant) VALUES (${id}, ${tenant})`;",
+      "const call = sql`SELECT calculate(${id}) AS value`;",
+      "void [insert, call];",
+    ].join("\n");
+    const report = analyzeSchemaCompatibility({
+      before,
+      after,
+      beforeManifest: manifest(dialect, before, beforeSql),
+      afterManifest: manifest(dialect, after, afterSql),
+    });
+    strict.ok(
+      report.assessments.some(
+        (item) => item.classification === "deployment-order-sensitive" && item.severity === "warning",
+      ),
+    );
+    strict.ok(
+      report.assessments.some(
+        (item) => item.classification === "deployment-order-sensitive" && item.severity === "error",
+      ),
+    );
+    strict.ok(report.assessments.some((item) => item.classification === "runtime-breaking"));
+  });
+
+  await it("links enum and domain changes through explicit cast dependencies", () => {
+    const dialect = postgres();
+    const before: SchemaSnapshot = {
+      formatVersion: 1,
+      dialect: "postgres",
+      tables: {},
+      enums: {
+        "public.account_status": ["active", "suspended"],
+        "tenant.account_status": ["active"],
+      },
+      domains: {
+        "public.email_address": {
+          name: "email_address",
+          databaseType: "text",
+          tsType: "string",
+          nullable: false,
+        },
+        "tenant.email_address": {
+          name: "email_address",
+          databaseType: "text",
+          tsType: "string",
+          nullable: false,
+        },
+      },
+    };
+    const after: SchemaSnapshot = {
+      ...before,
+      enums: {
+        "public.account_status": ["active", "suspended", "deleted"],
+        "tenant.account_status": ["active"],
+      },
+      domains: {
+        "public.email_address": {
+          name: "email_address",
+          databaseType: "varchar",
+          tsType: "string",
+          nullable: false,
+        },
+        "tenant.email_address": {
+          name: "email_address",
+          databaseType: "text",
+          tsType: "string",
+          nullable: false,
+        },
+      },
+    };
+    const source = [
+      'import { sql } from "@typed-sql/postgres";',
+      "declare const value: string;",
+      "const status = sql`SELECT CAST(${value} AS public.account_status) AS value`;",
+      "const email = sql`SELECT CAST(${value} AS public.email_address) AS value`;",
+      "void [status, email];",
+    ].join("\n");
+    const report = analyzeSchemaCompatibility({
+      before,
+      after,
+      beforeManifest: manifest(dialect, before, source),
+      afterManifest: manifest(dialect, after, source),
+    });
+    strict.ok(
+      report.assessments.some(
+        (item) => item.classification === "runtime-breaking" && item.queries.some((query) => query.dependencyRange),
+      ),
+    );
+  });
+
+  await it("validates report envelopes", () => {
+    const artifact = { schemaHash: "0".repeat(64), manifestHash: `sha256:${"0".repeat(64)}` };
+    const valid = {
+      formatVersion: 1,
+      analyzerVersion: "typed-sql-v1",
+      dialect: "postgres",
+      before: artifact,
+      after: artifact,
+      changes: [],
+      assessments: [],
+      summary: { info: 0, warning: 0, error: 0 },
+    } as const;
+    for (const [value, pattern] of [
+      [null, /must be an object/u],
+      [{ formatVersion: 1, analyzerVersion: "future" }, /analyzer/u],
+      [{ ...valid, dialect: "" }, /dialect/u],
+      [{ ...valid, before: { ...artifact, schemaHash: "invalid" } }, /schemaHash/u],
+      [{ ...valid, summary: { info: "0", warning: 0, error: 0 } }, /summary/u],
+    ] as const) {
+      strict.throws(() => parseSchemaCompatibilityReport(value), pattern);
+    }
+    strict.strictEqual(parseSchemaCompatibilityReport(valid).dialect, "postgres");
+
+    type MutableReport = {
+      before: Record<string, unknown>;
+      changes: Array<Record<string, unknown> & { target: Record<string, unknown> }>;
+      assessments: Array<Record<string, unknown> & { queries: Array<Record<string, unknown>> }>;
+    };
+    const value = snapshots("postgres");
+    const dialect = postgres();
+    const complete = analyzeSchemaCompatibility({
+      ...value,
+      beforeManifest: manifest(dialect, value.before, beforeSource(dialect.sqlModule)),
+      afterManifest: manifest(dialect, value.after, afterSource(dialect.sqlModule)),
+    });
+    const mutable = () => JSON.parse(serializeSchemaCompatibilityReport(complete)) as MutableReport;
+    const expectInvalid = (mutate: (report: MutableReport) => void, pattern: RegExp) => {
+      const report = mutable();
+      mutate(report);
+      strict.throws(() => parseSchemaCompatibilityReport(report), pattern);
+    };
+    const assessmentWithQuery = (report: MutableReport) => {
+      const assessment = report.assessments.find((item) => item.queries.length > 0);
+      if (assessment === undefined) throw new Error("Fixture must contain an affected query");
+      return assessment;
+    };
+    expectInvalid((report) => {
+      report.before.version = "";
+    }, /version/u);
+    expectInvalid((report) => {
+      report.before.manifestHash = "invalid";
+    }, /manifestHash/u);
+    expectInvalid((report) => {
+      (report as unknown as Record<string, unknown>).changes = null;
+    }, /changes/u);
+    expectInvalid((report) => {
+      report.changes[0] = { target: {} };
+    }, /change 0/u);
+    expectInvalid((report) => {
+      report.changes[0]!.target.kind = "invalid";
+    }, /target.kind/u);
+    expectInvalid((report) => {
+      report.changes[0]!.target.key = "";
+    }, /target.key/u);
+    expectInvalid((report) => {
+      report.changes[0]!.target.parent = 42;
+    }, /target.parent/u);
+    expectInvalid((report) => {
+      report.changes[0]!.before = { unsupported: 42 };
+    }, /evidence/u);
+    expectInvalid((report) => {
+      report.changes[0]!.id = `sha256:${"f".repeat(64)}`;
+    }, /canonical evidence/u);
+    expectInvalid((report) => {
+      report.changes.push(structuredClone(report.changes[0]!));
+    }, /duplicated/u);
+    expectInvalid((report) => {
+      report.assessments[0]!.direction = "sideways";
+    }, /assessment 0/u);
+    expectInvalid((report) => {
+      (report as unknown as Record<string, unknown>).assessments = null;
+    }, /assessments/u);
+    expectInvalid((report) => {
+      report.assessments[0]!.reason = "";
+    }, /reason/u);
+    expectInvalid((report) => {
+      report.assessments[0]!.changeId = `sha256:${"f".repeat(64)}`;
+    }, /identify/u);
+    expectInvalid((report) => {
+      const assessment = assessmentWithQuery(report);
+      assessment.queries[0]!.source = { file: "/secret/query.ts", range: {} };
+    }, /relative path/u);
+    expectInvalid((report) => {
+      const assessment = assessmentWithQuery(report);
+      assessment.queries[0]!.queryId = "invalid";
+    }, /queryId/u);
+    expectInvalid((report) => {
+      const assessment = assessmentWithQuery(report);
+      assessment.queries[0]!.source = null;
+    }, /source/u);
+    expectInvalid((report) => {
+      const assessment = assessmentWithQuery(report);
+      const source = assessment.queries[0]!.source as { range: Record<string, unknown> };
+      source.range.start = -1;
+    }, /source range/u);
+    expectInvalid((report) => {
+      const assessment = report.assessments.find((item) =>
+        item.queries.some((query) => query.dependencyRange !== undefined),
+      );
+      if (assessment === undefined) throw new Error("Fixture must contain a dependency range");
+      const query = assessment.queries.find((item) => item.dependencyRange !== undefined);
+      if (query === undefined) throw new Error("Fixture must contain a dependency range");
+      query.dependencyRange = { start: 1, end: 0, line: 1, column: 1 };
+    }, /dependencyRange/u);
+    expectInvalid((report) => {
+      (report as unknown as Record<string, unknown>).summary = null;
+    }, /summary/u);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -191,6 +191,12 @@ export interface TypedSqlConfig<Snapshot extends SchemaSnapshot = SchemaSnapshot
     readonly proofFile?: string;
     readonly concurrency?: number;
   };
+  readonly compatibility?: {
+    /** Report path relative to the typed-sql config file. */
+    readonly reportFile?: string;
+    /** Lowest severity that makes `typed-sql compat` fail. */
+    readonly failOn?: "none" | "warning" | "error";
+  };
 }
 
 function record(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -253,6 +259,18 @@ export function defineConfig<Snapshot extends SchemaSnapshot, Policy>(
     for (const method of ["server", "verify", "close"] as const) {
       if (typeof live[method] !== "function") throw new TypeError(`verification.live.${method} must be a function`);
     }
+  }
+  if (
+    config.compatibility?.reportFile !== undefined &&
+    (typeof config.compatibility.reportFile !== "string" || config.compatibility.reportFile.length === 0)
+  ) {
+    throw new TypeError("compatibility.reportFile must be a non-empty string");
+  }
+  if (
+    config.compatibility?.failOn !== undefined &&
+    !(["none", "warning", "error"] as const).includes(config.compatibility.failOn)
+  ) {
+    throw new TypeError("compatibility.failOn must be none, warning, or error");
   }
   return Object.freeze(config);
 }

--- a/packages/core/test/query.test.ts
+++ b/packages/core/test/query.test.ts
@@ -532,6 +532,34 @@ await describe("core contracts", async () => {
         }),
       /does not match/u,
     );
+    strict.doesNotThrow(() =>
+      defineConfig({
+        dialect,
+        schema: { file: "schema.json" },
+        outDir: "generated",
+        compatibility: { reportFile: ".typed-sql/compatibility.json", failOn: "warning" },
+      }),
+    );
+    strict.throws(
+      () =>
+        defineConfig({
+          dialect,
+          schema: { file: "schema.json" },
+          outDir: "generated",
+          compatibility: { reportFile: "" },
+        }),
+      /compatibility\.reportFile/u,
+    );
+    strict.throws(
+      () =>
+        defineConfig({
+          dialect,
+          schema: { file: "schema.json" },
+          outDir: "generated",
+          compatibility: { failOn: "all" as never },
+        }),
+      /compatibility\.failOn/u,
+    );
   });
 
   await it("validates every public dialect contract boundary", () => {

--- a/performance-budgets.json
+++ b/performance-budgets.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "methodology": {
     "warmups": 3,
     "samples": 20,
@@ -13,6 +13,7 @@
     "compiler.queryManifest": { "p50": 25, "p95": 60 },
     "compiler.queryManifestIncremental": { "p50": 0.5, "p95": 1 },
     "compiler.queryVerification": { "p50": 40, "p95": 60 },
+    "compiler.schemaCompatibility": { "p50": 70, "p95": 120 },
     "compiler.semanticMetadata": { "p50": 10, "p95": 25 },
     "compiler.correlatedConditions": { "p50": 5, "p95": 10 },
     "compiler.independentConditions": { "p50": 10, "p95": 25 },

--- a/scripts/performance-gate.mjs
+++ b/scripts/performance-gate.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  analyzeSchemaCompatibility,
   buildQueryManifest,
   collectQueryVerificationCandidates,
   compileSource,
@@ -138,6 +139,64 @@ await latency(
   },
   { iterations: methodology.subMillisecondIterations },
 );
+
+const compatibilityTables = Object.fromEntries(
+  Array.from({ length: 250 }, (_, index) => [
+    `account_${index}`,
+    {
+      name: `account_${index}`,
+      columns: {
+        id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+        email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
+      },
+    },
+  ]),
+);
+const compatibilityAfterTables = Object.fromEntries(
+  Object.entries(compatibilityTables).map(([key, table], index) => [
+    key,
+    index % 5 === 0
+      ? {
+          ...table,
+          columns: {
+            ...table.columns,
+            id: { name: "id", databaseType: "numeric", tsType: "string", nullable: false },
+          },
+        }
+      : table,
+  ]),
+);
+const compatibilitySource = [
+  'import { sql } from "@typed-sql/postgres";',
+  ...Array.from(
+    { length: 250 },
+    (_, index) => `export const account_${index} = sql\`SELECT id, email FROM account_${index}\`;`,
+  ),
+].join("\n");
+const compatibilityBefore = { ...snapshot, tables: compatibilityTables };
+const compatibilityAfter = { ...snapshot, tables: compatibilityAfterTables };
+const compatibilityManifestOptions = {
+  ...manifestOptions,
+  sources: [{ file: "/benchmark/project/src/compatibility.ts", source: compatibilitySource }],
+};
+const compatibilityBeforeManifest = buildQueryManifest({
+  ...compatibilityManifestOptions,
+  schema: compatibilityBefore,
+}).manifest;
+const compatibilityAfterManifest = buildQueryManifest({
+  ...compatibilityManifestOptions,
+  schema: compatibilityAfter,
+}).manifest;
+await latency("compiler.schemaCompatibility", () => {
+  const report = analyzeSchemaCompatibility({
+    before: compatibilityBefore,
+    after: compatibilityAfter,
+    beforeManifest: compatibilityBeforeManifest,
+    afterManifest: compatibilityAfterManifest,
+  });
+  assert.equal(report.changes.length, 150);
+  assert.equal(report.assessments.length, 300);
+});
 
 const verificationCandidates = collectQueryVerificationCandidates({
   ...manifestOptions,

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -19,6 +19,7 @@ const expectedPublicDocs = [
   "docs/guides/editors.md",
   "docs/guides/execution.md",
   "docs/guides/live-verification.md",
+  "docs/guides/migration-compatibility.md",
   "docs/guides/observability.md",
   "docs/guides/query-manifests.md",
   "docs/guides/schema-snapshots.md",

--- a/test/contracts/performance-policy.test.ts
+++ b/test/contracts/performance-policy.test.ts
@@ -36,6 +36,7 @@ await describe("performance regression policy", async () => {
       "compiler.queryManifest",
       "compiler.queryManifestIncremental",
       "compiler.queryVerification",
+      "compiler.schemaCompatibility",
       "compiler.semanticMetadata",
       "compiler.structuralLimit",
       "editor.cancelledRequest",

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -3,16 +3,23 @@ import { describe, it, strict } from "poku";
 import type { SqlAstContext, SqlAstVisitor } from "../../packages/ast/src/index.js";
 import * as astApi from "../../packages/ast/src/index.js";
 import type {
+  AnalyzeSchemaCompatibilityOptions,
   BuildQueryManifestOptions,
   BuildQueryManifestResult,
   CheckFileOptions,
   CheckFileResult,
   CollectQueryVerificationCandidatesOptions,
+  CompatibilityClassification,
+  CompatibilityEvidence,
+  CompatibilityEvidenceValue,
+  CompatibilityQueryReference,
+  CompatibilitySeverity,
   CompiledFragment,
   CompiledQuery,
   CompiledQueryVariant,
   CompileSourceOptions,
   CompileSourceResult,
+  DeploymentDirection,
   ExtractedDynamicQuery,
   ExtractedInterpolation,
   ExtractedQuery,
@@ -38,6 +45,11 @@ import type {
   QueryVerificationProof,
   QueryVerificationProofEntry,
   ResolvedQueryManifestEntry,
+  SchemaCompatibilityAssessment,
+  SchemaCompatibilityChange,
+  SchemaCompatibilityChangeKind,
+  SchemaCompatibilityReport,
+  SchemaCompatibilityTarget,
   TypeScriptCheckResult,
   UnresolvedQueryManifestEntry,
   VerifyQueryManifestOptions,
@@ -325,6 +337,7 @@ async function transactionBatchContract(
 }
 
 type ReferencedStableTypes =
+  | AnalyzeSchemaCompatibilityOptions
   | CheckFileOptions
   | CheckFileResult
   | BuildQueryManifestOptions<SchemaSnapshot, unknown>
@@ -339,6 +352,12 @@ type ReferencedStableTypes =
   | ExtractedQuery
   | ListProjectSourceFilesOptions
   | CollectQueryVerificationCandidatesOptions<SchemaSnapshot, unknown>
+  | CompatibilityClassification
+  | CompatibilityEvidence
+  | CompatibilityEvidenceValue
+  | CompatibilityQueryReference
+  | CompatibilitySeverity
+  | DeploymentDirection
   | QueryManifest
   | QueryManifestBuildStats
   | QueryManifestColumn
@@ -359,6 +378,11 @@ type ReferencedStableTypes =
   | QueryVerificationMismatchKind
   | QueryVerificationProof
   | QueryVerificationProofEntry
+  | SchemaCompatibilityAssessment
+  | SchemaCompatibilityChange
+  | SchemaCompatibilityChangeKind
+  | SchemaCompatibilityReport
+  | SchemaCompatibilityTarget
   | ResolvedQueryManifestEntry
   | UnresolvedQueryManifestEntry
   | VerifyQueryManifestOptions
@@ -482,6 +506,9 @@ const expectedRuntimeExports = {
     "QUERY_MANIFEST_JSON_SCHEMA",
     "QUERY_VERIFICATION_FORMAT_VERSION",
     "QUERY_VERIFIER_VERSION",
+    "SCHEMA_COMPATIBILITY_ANALYZER_VERSION",
+    "SCHEMA_COMPATIBILITY_FORMAT_VERSION",
+    "analyzeSchemaCompatibility",
     "assertQueryVerificationProofCurrent",
     "buildQueryManifest",
     "checkFile",
@@ -493,8 +520,10 @@ const expectedRuntimeExports = {
     "mapSqlRange",
     "parseQueryManifest",
     "parseQueryVerificationProof",
+    "parseSchemaCompatibilityReport",
     "serializeQueryManifest",
     "serializeQueryVerificationProof",
+    "serializeSchemaCompatibilityReport",
     "verifyQueryManifest",
   ],
   conformance: [

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
           { text: "Observe database work", link: "/guides/observability" },
           { text: "Emit query manifests", link: "/guides/query-manifests" },
           { text: "Verify against a database", link: "/guides/live-verification" },
+          { text: "Check migration compatibility", link: "/guides/migration-compatibility" },
           { text: "Compose conditional SQL", link: "/guides/composition" },
           { text: "Manage schema snapshots", link: "/guides/schema-snapshots" },
           { text: "Configure editors", link: "/guides/editors" },


### PR DESCRIPTION
Closes #60.

## What changed

- add a grammar-neutral compatibility analyzer over deterministic before/after snapshots and query manifests
- classify both mixed-version deployment directions as compatible, source-breaking, runtime-breaking, deployment-order-sensitive, or unknown
- link every affected query variant to relative source and dependency ranges
- detect table, column, enum, domain, function, inferred row/parameter, default, nullability, grammar, and server changes
- expose a validated, canonical, secret-free report format and public compiler API
- add `typed-sql compat` with durable JSON output, complete human output, and configurable CI severity
- document plain SQL and external migration-runner workflows without introducing a migration DSL
- cover PostgreSQL and MySQL additive, destructive, rename, widening/narrowing, enum/domain, default, and nullability fixtures
- add a production-build performance budget for 250 queries across 50 changed contracts

## Verification

- `pnpm verify`
- `TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:packed`
- compiler coverage: 98.59% lines / 88.69% branches; global compiler threshold passes at 90.37% branches
- migration analyzer benchmark: 23.63 ms p50 / 24.75 ms p95 locally on an Apple M3 Pro
