### PR TITLE
feat(editor): stabilize shared language-server integration

### DIFF
--- a/.changeset/steady-editors-share.md
+++ b/.changeset/steady-editors-share.md
@@ -1,0 +1,9 @@
+---
+"@typed-sql/language-server": patch
+"@typed-sql/ts-bridge": patch
+---
+
+Expose a protocol status request, suppress diagnostics from superseded document versions, and verify
+the shared editor soundness contract across PostgreSQL, MySQL, and SQLite. The VS Code integration now
+uses this standalone server instead of maintaining a second analyzer and preview bridge. Static SQL
+navigation now fails closed inside runtime interpolation expressions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       - run: cargo test --manifest-path editors/zed/Cargo.toml
       - run: cargo build --release --target wasm32-wasip2 --manifest-path editors/zed/Cargo.toml
       - run: cp editors/zed/target/wasm32-wasip2/release/typed_sql_zed.wasm artifacts/typed-sql-zed.wasm
+      - run: pnpm editor:artifacts:smoke
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: typed-sql-editor-artifacts

--- a/docs/guides/editors.md
+++ b/docs/guides/editors.md
@@ -5,7 +5,7 @@ description: Configure the experimental typed-sql language server for Zed, VS Co
 
 # Editor setup
 
-The experimental language server applies typed-sql's inferred overlay before TypeScript checks the program. It provides exact query and downstream hovers, diagnostics, completion, definitions, quick fixes, schema reloads, and bounded project caches.
+The experimental language server applies typed-sql's inferred overlay before TypeScript checks the program. It provides exact query and downstream hovers, diagnostics, completion, definitions, quick fixes, schema reloads, stale-result suppression, and bounded project caches. PostgreSQL, MySQL, and SQLite use the same protocol and compiler evidence.
 
 Install it in the application:
 
@@ -47,7 +47,14 @@ Do not run `vtsls` or `typescript-language-server` beside this proxy. An ordinar
 
 ## VS Code
 
-The repository includes an experimental VS Code extension that bundles the typed-sql language client. Build and install the VSIX using the instructions in the [`packages/vscode`](https://github.com/Lojhan/typed-sql/tree/main/packages/vscode) package.
+The repository includes an experimental VS Code extension that runs one thin language client per workspace folder. It resolves that folder's installed `@typed-sql/language-server`, so the VS Code integration does not carry a second analyzer or TypeScript bridge. Build and install the VSIX using the instructions in the [`packages/vscode`](https://github.com/Lojhan/typed-sql/tree/main/packages/vscode) package.
+
+Disable VS Code's built-in TypeScript language-features extension for the workspace while using the
+typed-sql proxy. Otherwise both servers can answer hover and diagnostic requests, and the built-in
+server sees the conservative `Query<unknown>` declaration.
+
+Run **typed-sql: Show TypeScript Bridge Status** to inspect the pinned TypeScript version and the
+open/indexed document counts reported by each workspace server.
 
 ## Other LSP clients
 
@@ -71,3 +78,7 @@ Initialization settings accept:
 ```
 
 Relative paths resolve from the LSP workspace root. Each workspace folder receives its own config, grammar, schema, TypeScript project, and bounded cache.
+
+The custom `typedSql/status` request returns the server mode, exact pinned TypeScript version,
+workspace roots, and document counts. It is informational; CLI/compiler output remains the
+correctness boundary.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -52,6 +52,11 @@ The language server installs an exact TypeScript preview as an internal dependen
 
 The language server replaces the normal TypeScript server for a configured project. Running a second TypeScript server can show the safe baseline `Query<unknown>` beside typed-sql's transformed hover.
 
+The TypeScript 7.1 package currently publishes the native program APIs used by the bridge through
+explicit `unstable/*` entrypoints. For that reason `ts-bridge`, `language-server`, and both editor
+integrations remain experimental even though the CLI/compiler path is stable. The preview dependency
+and its API-specific code remain isolated from grammar and stable packages.
+
 ## Grammar and snapshot compatibility
 
 PostgreSQL, MySQL, and the SQLite preview implement the current typed-sql dialect contract. A grammar's `grammarVersion` describes its snapshot and resolution semantics independently from the package version. Generated snapshots record that version, and the grammar rejects incompatible snapshots.

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -66,7 +66,7 @@ impl zed::Extension for TypedSqlExtension {
             .is_err()
         {
             return Err(
-                "typed-sql language server was not found; run `pnpm add -D @typed-sql/language-server@next`, or configure lsp.typed-sql.binary.path"
+                "typed-sql language server was not found; run `pnpm add -D @typed-sql/language-server`, or configure lsp.typed-sql.binary.path"
                     .to_string(),
             );
         }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs:start": "pnpm --filter typed-sql-docs start",
     "docs:build": "pnpm --filter typed-sql-docs build",
     "docs:serve": "pnpm --filter typed-sql-docs serve",
+    "editor:artifacts:smoke": "node scripts/assert-editor-artifacts.mjs",
     "test:pack": "poku test/contracts/packed-consumer.test.ts --reporter=compact --enforce",
     "test:soundness": "poku packages/postgres/test/soundness.test.ts packages/mysql/test/soundness.test.ts packages/sqlite/test/soundness.test.ts packages/compiler/test/soundness.test.ts packages/cli/test/soundness.test.ts packages/ts-bridge/test/soundness.test.ts packages/language-server/test/soundness.test.ts --reporter=compact --enforce",
     "performance": "pnpm build && pnpm performance:gate",

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -4,7 +4,7 @@
 
 The grammar-neutral typed-sql language server provides TypeScript semantics plus inferred SQL
 hovers, downstream value types, diagnostics, completion, definitions, quick fixes, cancellation,
-and bounded workspace caches.
+stale-result suppression, bounded workspace caches, and a protocol status request.
 
 ```sh
 pnpm add -D @typed-sql/language-server
@@ -18,6 +18,10 @@ workspace `tsserver.js`, and source files are never rewritten.
 Initialization settings include `configPath`, `schemaPath`, `projectFile`, `nativePreview`,
 `maxCacheEntries`, and `maxWorkspaceFiles`. Relative paths resolve from the LSP workspace root;
 each workspace folder receives an independent config, grammar, schema, project, and bounded cache.
+
+Clients can request `typedSql/status` to inspect the exact pinned TypeScript preview version,
+workspace roots, and open/indexed document counts. The server suppresses diagnostics from document
+versions that have already been superseded.
 
 Use typed-sql as the sole TypeScript language server for a configured project. A second server sees
 the conservative package declaration and may display a competing `Query<unknown>` hover.

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -5,7 +5,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { fromConfig, loadConfig } from "@typed-sql/config";
 import type { SchemaSnapshot, TableSnapshot } from "@typed-sql/core";
 import { loadSchemaSnapshot } from "@typed-sql/schema";
-import { analyzeSource, type BridgeAnalysis, type NativeTypeInspection, queryAtPosition } from "@typed-sql/ts-bridge";
+import {
+  analyzeSource,
+  type BridgeAnalysis,
+  isStaticQueryPosition,
+  type NativeTypeInspection,
+  queryAtPosition,
+} from "@typed-sql/ts-bridge";
 import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-preview";
 import {
   type CodeAction,
@@ -28,6 +34,17 @@ export interface TypedSqlLanguageServerSettings {
   readonly nativePreview?: boolean;
   readonly maxCacheEntries?: number;
   readonly maxWorkspaceFiles?: number;
+}
+
+export const TYPED_SQL_STATUS_REQUEST = "typedSql/status";
+
+export interface TypedSqlLanguageServerStatus {
+  readonly name: "@typed-sql/language-server";
+  readonly mode: "pinned-preview-proxy";
+  readonly typescriptVersion: string;
+  readonly workspaceRoots: readonly string[];
+  readonly openDocuments: number;
+  readonly indexedDocuments: number;
 }
 
 interface CachedSchema {
@@ -244,7 +261,7 @@ export class TypedSqlLanguageService {
     if (result === undefined) return [];
     const offset = document.offsetAt(position);
     const query = queryAtPosition(result.analysis, offset);
-    if (query === undefined) return [];
+    if (query === undefined || !isStaticQueryPosition(query, offset)) return [];
     cancelled(token);
     const source = document.getText();
     const before = source.slice(query.sourceRange.start, offset);
@@ -304,7 +321,7 @@ export class TypedSqlLanguageService {
     if (result === undefined) return undefined;
     const offset = document.offsetAt(position);
     const query = queryAtPosition(result.analysis, offset);
-    if (query === undefined) return undefined;
+    if (query === undefined || !isStaticQueryPosition(query, offset)) return undefined;
     const word = this.#wordAt(document.getText(), offset);
     if (word === undefined) return undefined;
     cancelled(token);

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -7,9 +7,20 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { BridgeAnalysis } from "@typed-sql/ts-bridge";
 import { typescriptPreviewCliPath } from "@typed-sql/ts-bridge/native-lsp";
 import { TYPESCRIPT_PREVIEW_VERSION } from "@typed-sql/ts-bridge/native-preview";
-import { createMessageConnection, type MessageConnection, NullLogger } from "vscode-jsonrpc/node";
+import {
+  type CancellationToken,
+  createMessageConnection,
+  type MessageConnection,
+  NullLogger,
+  ResponseError,
+} from "vscode-jsonrpc/node";
 import { TextDocument, type TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
-import { settingsFrom, TypedSqlLanguageService } from "./index.js";
+import {
+  settingsFrom,
+  TYPED_SQL_STATUS_REQUEST,
+  type TypedSqlLanguageServerStatus,
+  TypedSqlLanguageService,
+} from "./index.js";
 
 interface Position {
   readonly line: number;
@@ -74,7 +85,7 @@ function previewError(cause: string): Error {
       `CLI: ${previewCli}`,
       `Cause: ${cause}`,
       previewStderr.length === 0 ? "" : `Preview stderr: ${previewStderr.trim()}`,
-      "Reinstall @typed-sql/language-server@next in the workspace and restart the editor.",
+      "Reinstall @typed-sql/language-server in the workspace and restart the editor.",
     ]
       .filter((part) => part.length > 0)
       .join(" "),
@@ -102,6 +113,8 @@ const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
 const pendingDocuments = new Map<string, Promise<void>>();
+const latestDocumentVersions = new Map<string, number>();
+const LSP_REQUEST_CANCELLED = -32800;
 let workspaceReady: Promise<void> = Promise.resolve();
 let workspaceRoots: readonly string[] = [resolve(cwd())];
 let services = new Map([[workspaceRoots[0]!, new TypedSqlLanguageService(workspaceRoots[0]!)]]);
@@ -112,7 +125,7 @@ preview.stderr.on("data", (chunk: Buffer | string) => {
   stderr.write(`[typed-sql/typescript-${TYPESCRIPT_PREVIEW_VERSION}] ${message}`);
 });
 
-async function nativeRequest<T = unknown>(method: string, ...params: [] | [unknown]): Promise<T> {
+async function nativeRequest<T = unknown>(method: string, params?: unknown, token?: CancellationToken): Promise<T> {
   if (previewFailure !== undefined) throw previewFailure;
   let rejectFailure!: (error: Error) => void;
   const failure = new Promise<never>((_resolveFailure, reject) => {
@@ -121,7 +134,13 @@ async function nativeRequest<T = unknown>(method: string, ...params: [] | [unkno
   });
   try {
     const request =
-      params.length === 0 ? typescript.sendRequest<T>(method) : typescript.sendRequest<T>(method, params[0]);
+      params === undefined
+        ? token === undefined
+          ? typescript.sendRequest<T>(method)
+          : typescript.sendRequest<T>(method, token)
+        : token === undefined
+          ? typescript.sendRequest<T>(method, params)
+          : typescript.sendRequest<T>(method, params, token);
     return await Promise.race([request, failure]);
   } finally {
     previewFailureWaiters.delete(rejectFailure);
@@ -229,6 +248,25 @@ function queueDocument(uri: string, operation: () => Promise<void>): Promise<voi
   });
 }
 
+async function waitForDocument(uri: string, token: CancellationToken): Promise<void> {
+  const pending = pendingDocuments.get(uri);
+  if (pending === undefined) return;
+  if (token.isCancellationRequested) throw new ResponseError(LSP_REQUEST_CANCELLED, "Request cancelled");
+  let cancellation: { dispose(): void } | undefined;
+  try {
+    await Promise.race([
+      pending,
+      new Promise<never>((_resolve, reject) => {
+        cancellation = token.onCancellationRequested(() => {
+          reject(new ResponseError(LSP_REQUEST_CANCELLED, "Request cancelled"));
+        });
+      }),
+    ]);
+  } finally {
+    cancellation?.dispose();
+  }
+}
+
 function mapProtocolValue(value: unknown, direction: MappingDirection, fallback?: DocumentState): unknown {
   if (Array.isArray(value)) return value.map((item) => mapProtocolValue(item, direction, fallback));
   if (!isObject(value)) return value;
@@ -266,6 +304,7 @@ async function combinedDiagnostics(state: DocumentState): Promise<readonly unkno
 }
 
 async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
+  if (latestDocumentVersions.get(state.original.uri) !== state.original.version) return;
   await client.sendNotification("textDocument/publishDiagnostics", {
     uri: state.original.uri,
     version: state.original.version,
@@ -361,7 +400,7 @@ client.onRequest("textDocument/completion", async (rawParams, token) => {
   await workspaceReady;
   const params = rawParams as JsonObject;
   const uri = documentUri(params);
-  if (uri !== undefined) await pendingDocuments.get(uri);
+  if (uri !== undefined) await waitForDocument(uri, token);
   const state = stateFor(params);
   if (state !== undefined && isObject(params.position)) {
     const items = await serviceForUri(state.original.uri).completions(
@@ -372,14 +411,14 @@ client.onRequest("textDocument/completion", async (rawParams, token) => {
     if (items.length > 0) return { isIncomplete: false, items };
   }
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  return mapProtocolValue(await nativeRequest("textDocument/completion", mapped), "virtual-to-source", state);
+  return mapProtocolValue(await nativeRequest("textDocument/completion", mapped, token), "virtual-to-source", state);
 });
 
 client.onRequest("textDocument/definition", async (rawParams, token) => {
   await workspaceReady;
   const params = rawParams as JsonObject;
   const uri = documentUri(params);
-  if (uri !== undefined) await pendingDocuments.get(uri);
+  if (uri !== undefined) await waitForDocument(uri, token);
   const state = stateFor(params);
   if (state !== undefined && isObject(params.position)) {
     const definition = await serviceForUri(state.original.uri).definition(
@@ -390,34 +429,47 @@ client.onRequest("textDocument/definition", async (rawParams, token) => {
     if (definition !== undefined) return definition;
   }
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  return mapProtocolValue(await nativeRequest("textDocument/definition", mapped), "virtual-to-source", state);
+  return mapProtocolValue(await nativeRequest("textDocument/definition", mapped, token), "virtual-to-source", state);
 });
 
 client.onRequest("textDocument/codeAction", async (rawParams, token) => {
   await workspaceReady;
   const params = rawParams as JsonObject;
   const uri = documentUri(params);
-  if (uri !== undefined) await pendingDocuments.get(uri);
+  if (uri !== undefined) await waitForDocument(uri, token);
   const state = stateFor(params);
   const context = isObject(params.context) ? params.context : undefined;
   const diagnostics = Array.isArray(context?.diagnostics) ? context.diagnostics : [];
   const typedActions =
     state === undefined ? [] : await serviceForUri(state.original.uri).codeActions(state.original, diagnostics, token);
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
-  const native = await nativeRequest("textDocument/codeAction", mapped);
+  const native = await nativeRequest("textDocument/codeAction", mapped, token);
   const nativeActions = Array.isArray(native)
     ? (mapProtocolValue(native, "virtual-to-source", state) as readonly unknown[])
     : [];
   return [...typedActions, ...nativeActions];
 });
 
-client.onRequest(async (method, params) => {
+client.onRequest(TYPED_SQL_STATUS_REQUEST, async (): Promise<TypedSqlLanguageServerStatus> => {
+  await workspaceReady;
+  await previewReady;
+  return {
+    name: "@typed-sql/language-server",
+    mode: "pinned-preview-proxy",
+    typescriptVersion: TYPESCRIPT_PREVIEW_VERSION,
+    workspaceRoots,
+    openDocuments: documents.size,
+    indexedDocuments: virtualDocuments.size,
+  };
+});
+
+client.onRequest(async (method, params, token) => {
   await workspaceReady;
   const uri = documentUri(params);
-  if (uri !== undefined) await pendingDocuments.get(uri);
+  if (uri !== undefined) await waitForDocument(uri, token);
   const state = isObject(params) ? stateFor(params) : undefined;
   const mappedParams = mapProtocolValue(params, "source-to-virtual", state);
-  const result = await nativeRequest(method, mappedParams);
+  const result = await nativeRequest(method, mappedParams, token);
   const mappedResult = mapProtocolValue(result, "virtual-to-source", state);
   if (method !== "textDocument/diagnostic" || state === undefined || !isObject(mappedResult)) {
     return mappedResult;
@@ -432,6 +484,7 @@ client.onRequest(async (method, params) => {
 client.onNotification("textDocument/didOpen", (rawParams) => {
   const params = rawParams as DidOpenParams;
   const item = params.textDocument;
+  latestDocumentVersions.set(item.uri, item.version);
   return queueDocument(item.uri, async () => {
     await workspaceReady;
     const original = TextDocument.create(item.uri, item.languageId, item.version, item.text);
@@ -454,6 +507,7 @@ client.onNotification("textDocument/didOpen", (rawParams) => {
 
 client.onNotification("textDocument/didChange", (rawParams) => {
   const params = rawParams as DidChangeParams;
+  latestDocumentVersions.set(params.textDocument.uri, params.textDocument.version);
   return queueDocument(params.textDocument.uri, async () => {
     await workspaceReady;
     const previous = documents.get(params.textDocument.uri);
@@ -475,6 +529,7 @@ client.onNotification("textDocument/didChange", (rawParams) => {
 
 client.onNotification("textDocument/didClose", (rawParams) => {
   const params = rawParams as DidCloseParams;
+  latestDocumentVersions.delete(params.textDocument.uri);
   return queueDocument(params.textDocument.uri, async () => {
     await workspaceReady;
     const previous = documents.get(params.textDocument.uri);
@@ -577,6 +632,7 @@ typescript.onNotification("textDocument/publishDiagnostics", async (params) => {
     await client.sendNotification("textDocument/publishDiagnostics", params);
     return;
   }
+  if (latestDocumentVersions.get(params.uri) !== state.original.version) return;
   const mapped = mapProtocolValue(params, "virtual-to-source", state);
   const diagnostics = isObject(mapped) && Array.isArray(mapped.diagnostics) ? mapped.diagnostics : [];
   nativeDiagnostics.set(params.uri, diagnostics);

--- a/packages/language-server/test/language-server.test.ts
+++ b/packages/language-server/test/language-server.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, it, strict } from "poku";
 import { ProtocolClient, positionAt } from "../../../test/helpers/protocol-client.js";
+import { TYPED_SQL_STATUS_REQUEST, type TypedSqlLanguageServerStatus } from "../src/index.js";
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceDirectory = resolve(testDirectory, "../../..");
@@ -27,7 +28,7 @@ await describe("typed-sql stdio language server", async () => {
             rootUri: pathToFileURL(workspaceDirectory).href,
             capabilities: {},
           }),
-        /pinned TypeScript preview process[\s\S]*Reinstall @typed-sql\/language-server@next/u,
+        /pinned TypeScript preview process[\s\S]*Reinstall @typed-sql\/language-server/u,
       );
     } finally {
       await client.close().catch(() => undefined);
@@ -145,6 +146,14 @@ await describe("typed-sql stdio language server", async () => {
       });
       const diagnostics = (await diagnosticsPromise) as { readonly diagnostics?: readonly unknown[] };
       strict.deepStrictEqual(diagnostics.diagnostics, []);
+
+      const status = (await client.request(TYPED_SQL_STATUS_REQUEST, null)) as TypedSqlLanguageServerStatus;
+      strict.strictEqual(status.name, "@typed-sql/language-server");
+      strict.strictEqual(status.mode, "pinned-preview-proxy");
+      strict.match(status.typescriptVersion, /^7\.1\.0-dev\./u);
+      strict.deepStrictEqual(status.workspaceRoots, [workspaceDirectory]);
+      strict.strictEqual(status.openDocuments, 1);
+      strict.ok(status.indexedDocuments >= 1);
 
       const hoverAt = async (needle: string): Promise<string> => {
         const hover = (await client.request("textDocument/hover", {

--- a/packages/language-server/test/service.test.ts
+++ b/packages/language-server/test/service.test.ts
@@ -42,6 +42,16 @@ await describe("typed-sql language service", async () => {
     const definition = await service.definition(current, positionAt(source, tableOffset));
     strict.strictEqual(Array.isArray(definition), false);
     strict.strictEqual((definition as { readonly uri?: string } | undefined)?.uri, pathToFileURL(schemaFile).href);
+
+    const dynamicSource = [
+      'import { sql } from "@typed-sql/postgres";',
+      'const users = "users";',
+      "const query = sql`SELECT user.id FROM users AS user WHERE user.name = ${users}`;",
+    ].join("\n");
+    const dynamic = document("dynamic-navigation.ts", dynamicSource);
+    const dynamicOffset = dynamicSource.lastIndexOf("users") + 1;
+    strict.strictEqual(await service.definition(dynamic, positionAt(dynamicSource, dynamicOffset)), undefined);
+    strict.deepStrictEqual(await service.completions(dynamic, positionAt(dynamicSource, dynamicOffset)), []);
   });
 
   await it("returns preferred safe spelling fixes from resolver suggestions", async () => {

--- a/packages/language-server/test/soundness.test.ts
+++ b/packages/language-server/test/soundness.test.ts
@@ -1,5 +1,6 @@
-import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, it, strict } from "poku";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -12,6 +13,7 @@ import { compileSource } from "../../compiler/src/index.js";
 import type { DialectPlugin, SchemaSnapshot } from "../../core/src/index.js";
 import { type MySqlSchemaSnapshot, mysql } from "../../mysql/src/index.js";
 import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
+import { type SqliteSchemaSnapshot, sqlite } from "../../sqlite/src/index.js";
 import { TypedSqlLanguageService } from "../src/index.js";
 
 const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -25,7 +27,7 @@ const mysqlSchema = JSON.parse(
 ) as MySqlSchemaSnapshot;
 
 interface EditorFixture<Snapshot extends SchemaSnapshot, Policy> {
-  readonly name: "postgres" | "mysql";
+  readonly name: "postgres" | "mysql" | "sqlite";
   readonly directory: string;
   readonly schema: Snapshot;
   readonly dialect: DialectPlugin<Snapshot, Policy>;
@@ -78,6 +80,54 @@ async function verifyCase<Snapshot extends SchemaSnapshot, Policy>(
 }
 
 await describe("editor service soundness parity", async () => {
+  const sqliteDirectory = await mkdtemp(join(tmpdir(), "typed-sql-editor-sqlite-"));
+  const sqliteSchema = {
+    formatVersion: 1,
+    dialect: "sqlite",
+    dialectVersion: "1.0.0",
+    tables: {
+      users: {
+        schema: "main",
+        name: "users",
+        kind: "table",
+        strict: true,
+        withoutRowid: false,
+        indexes: [],
+        foreignKeys: [],
+        columns: {
+          id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
+          email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
+          status: { name: "status", databaseType: "TEXT", tsType: "string", nullable: false },
+          deleted_at: { name: "deleted_at", databaseType: "TEXT", tsType: "string", nullable: true },
+        },
+      },
+      projects: {
+        schema: "main",
+        name: "projects",
+        kind: "table",
+        strict: true,
+        withoutRowid: false,
+        indexes: [],
+        foreignKeys: [],
+        columns: {
+          id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
+          owner_id: { name: "owner_id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
+        },
+      },
+    },
+  } as const satisfies SqliteSchemaSnapshot;
+  const sqliteSchemaPath = join(sqliteDirectory, "schema.json");
+  const sqliteConfigPath = join(sqliteDirectory, "typed-sql.config.mjs");
+  const sqliteProjectPath = join(sqliteDirectory, "tsconfig.json");
+  const sqliteModule = pathToFileURL(resolve(workspace, "packages/sqlite/dist/packages/sqlite/src/index.js")).href;
+  await Promise.all([
+    writeFile(sqliteSchemaPath, `${JSON.stringify(sqliteSchema, null, 2)}\n`),
+    writeFile(
+      sqliteConfigPath,
+      `import { sqlite } from ${JSON.stringify(sqliteModule)};\nexport default { dialect: sqlite(), schema: { file: "schema.json" }, outDir: "generated", projects: ["tsconfig.json"] };\n`,
+    ),
+    writeFile(sqliteProjectPath, `${JSON.stringify({ compilerOptions: { strict: true }, include: ["*.ts"] })}\n`),
+  ]);
   const postgresFixture = {
     name: "postgres" as const,
     directory: postgresDirectory,
@@ -92,12 +142,26 @@ await describe("editor service soundness parity", async () => {
     dialect: mysql(),
     service: editorService(mysqlDirectory),
   };
+  const sqliteFixture = {
+    name: "sqlite" as const,
+    directory: sqliteDirectory,
+    schema: sqliteSchema,
+    dialect: sqlite(),
+    service: new TypedSqlLanguageService(sqliteDirectory, {
+      configPath: sqliteConfigPath,
+      schemaPath: sqliteSchemaPath,
+      projectFile: sqliteProjectPath,
+      nativePreview: false,
+    }),
+  };
   try {
     for (const [index, testCase] of sourceSoundnessCorpus.entries()) {
       await it(`postgres: ${testCase.id}`, () => verifyCase(postgresFixture, testCase, index));
       await it(`mysql: ${testCase.id}`, () => verifyCase(mysqlFixture, testCase, index));
+      await it(`sqlite: ${testCase.id}`, () => verifyCase(sqliteFixture, testCase, index));
     }
   } finally {
-    await Promise.all([postgresFixture.service.close(), mysqlFixture.service.close()]);
+    await Promise.all([postgresFixture.service.close(), mysqlFixture.service.close(), sqliteFixture.service.close()]);
+    await rm(sqliteDirectory, { recursive: true, force: true });
   }
 });

--- a/packages/ts-bridge/src/index.ts
+++ b/packages/ts-bridge/src/index.ts
@@ -18,6 +18,7 @@ export interface BridgeQuery {
   readonly queryType: string;
   readonly sourceRange: OffsetRange;
   readonly transformedRange: OffsetRange;
+  readonly interpolationRanges: readonly OffsetRange[];
   readonly binding?: QueryBinding;
 }
 
@@ -106,6 +107,10 @@ export function analyzeSource<Snapshot extends SchemaSnapshot, Policy>(
         start: query.range.start + shiftBefore(query.range.start),
         end: query.range.end + shiftBefore(query.range.end),
       },
+      interpolationRanges: query.interpolations.map(({ sourceStart, sourceEnd }) => ({
+        start: sourceStart,
+        end: sourceEnd,
+      })),
       ...(() => {
         const binding = bindingBefore(source, query.range.start);
         return binding === undefined ? {} : { binding };
@@ -127,5 +132,13 @@ export function queryAtPosition(analysis: BridgeAnalysis, position: number): Bri
     (query) =>
       (position >= query.sourceRange.start && position <= query.sourceRange.end) ||
       (query.binding !== undefined && position >= query.binding.range.start && position <= query.binding.range.end),
+  );
+}
+
+export function isStaticQueryPosition(query: BridgeQuery, position: number): boolean {
+  return (
+    position >= query.sourceRange.start &&
+    position <= query.sourceRange.end &&
+    query.interpolationRanges.every(({ start, end }) => position < start || position >= end)
   );
 }

--- a/packages/ts-bridge/test/bridge.test.ts
+++ b/packages/ts-bridge/test/bridge.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it, strict } from "poku";
 import { type PostgresSchemaSnapshot, postgres } from "../../postgres/src/index.js";
 import { loadSchemaSnapshot } from "../../schema/src/index.js";
-import { analyzeSource, queryAtPosition } from "../src/index.js";
+import { analyzeSource, isStaticQueryPosition, queryAtPosition } from "../src/index.js";
 import { NativePreviewTypeScriptBridge, TYPESCRIPT_PREVIEW_VERSION } from "../src/native-preview.js";
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
@@ -52,6 +52,20 @@ await describe("TypeScript 7 editor bridge", async () => {
         (insertion, index, values) => index === 0 || insertion.position >= (values[index - 1]?.position ?? 0),
       ),
     );
+  });
+
+  await it("distinguishes static SQL tokens from runtime interpolation expressions", () => {
+    const parameterizedSource = [
+      'import { sql } from "@typed-sql/postgres";',
+      'const name = "Ada";',
+      "const query = sql`SELECT users.id FROM users WHERE users.name = ${name}`;",
+    ].join("\n");
+    const parameterized = analyzeSource(parameterizedSource, schema as PostgresSchemaSnapshot, postgres());
+    const query = parameterized.queries[0];
+    if (query === undefined) throw new Error("Expected a parameterized query");
+    strict.strictEqual(query.interpolationRanges.length, 1);
+    strict.strictEqual(isStaticQueryPosition(query, parameterizedSource.indexOf("users.id")), true);
+    strict.strictEqual(isStaticQueryPosition(query, parameterizedSource.lastIndexOf("name")), false);
   });
 
   await it("maps conditional structural fragment overlays as complete SQL variants", () => {

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -2,9 +2,16 @@
 
 > Experimental: the extension distribution and preview TypeScript integration may change.
 
-The VS Code extension loads each workspace folder's installed grammar and generated schema. It
-provides inferred SQL hovers, downstream value types, diagnostics, completion, definitions, and
-safe quick fixes without rewriting source files.
+The VS Code extension is a thin client for each workspace folder's installed
+`@typed-sql/language-server`. PostgreSQL, MySQL, and SQLite therefore use the same analysis,
+diagnostics, completion, definition, quick-fix, cache, and TypeScript preview path in VS Code, Zed,
+and other LSP clients.
+
+Install the server in the application before installing the extension:
+
+```sh
+pnpm add -D @typed-sql/language-server
+```
 
 Build the current VSIX from a clean checkout:
 
@@ -20,12 +27,19 @@ Configuration is optional and scoped per workspace folder:
 {
   "typedSql.configPath": "typed-sql.config.ts",
   "typedSql.schemaPath": "src/generated/db/schema.json",
+  "typedSql.projectFile": "tsconfig.json",
   "typedSql.nativePreview": true
 }
 ```
 
-Leave path values empty to discover the config and its `schema.file`. Run **typed-sql: Show
-TypeScript Bridge Status** to inspect the active semantic path.
+Leave path values empty to discover the config, its `schema.file`, and configured projects. Each
+workspace folder receives its own language-server process and settings. `typedSql.serverPath` can
+override the workspace-installed server for development.
+
+Use typed-sql as the workspace's sole TypeScript language server. Disable VS Code's built-in
+TypeScript language-features extension for that workspace so its conservative `Query<unknown>`
+hover does not compete with the transformed program. Run **typed-sql: Show TypeScript Bridge
+Status** to see the exact pinned TypeScript version and document counts reported by every server.
 
 Read the [editor setup guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/editors.md).
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -53,10 +53,32 @@
           "default": "",
           "description": "Optional generated schema override. Empty uses schema.file from typed-sql.config.ts."
         },
+        "typedSql.projectFile": {
+          "type": "string",
+          "default": "",
+          "description": "Optional tsconfig override. Empty uses the projects declared by typed-sql.config.ts."
+        },
+        "typedSql.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional language-server module override. Empty uses the workspace-installed @typed-sql/language-server."
+        },
         "typedSql.nativePreview": {
           "type": "boolean",
           "default": true,
-          "description": "Use the TypeScript 7.1 preview API connection for authoritative transformed-source type hovers when available."
+          "description": "Use the language server's pinned TypeScript 7.1 preview for authoritative transformed-source semantics."
+        },
+        "typedSql.maxCacheEntries": {
+          "type": "number",
+          "default": 256,
+          "minimum": 1,
+          "description": "Maximum document analyses and native inspections retained by each workspace server."
+        },
+        "typedSql.maxWorkspaceFiles": {
+          "type": "number",
+          "default": 2000,
+          "minimum": 1,
+          "description": "Maximum TypeScript files preloaded by each workspace server."
         }
       }
     }
@@ -66,10 +88,7 @@
     "package:vsix": "node -e \"require('node:fs').mkdirSync('../../artifacts',{recursive:true})\" && pnpm build:bundle && vsce package --no-dependencies --out ../../artifacts/typed-sql-vscode.vsix"
   },
   "dependencies": {
-    "@typed-sql/config": "workspace:*",
-    "@typed-sql/core": "workspace:*",
-    "@typed-sql/schema": "workspace:*",
-    "@typed-sql/ts-bridge": "workspace:*"
+    "vscode-languageclient": "10.1.0"
   },
   "devDependencies": {
     "@types/vscode": "1.134.0",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,396 +1,220 @@
-import { readFile, stat } from "node:fs/promises";
-import { isAbsolute, resolve } from "node:path";
-import { fromConfig, loadConfig } from "@typed-sql/config";
-import type { SchemaSnapshot } from "@typed-sql/core";
-import { loadSchemaSnapshot } from "@typed-sql/schema";
-import { analyzeSource, type BridgeAnalysis, type NativeTypeInspection, queryAtPosition } from "@typed-sql/ts-bridge";
-import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-preview";
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import * as vscode from "vscode";
+import {
+  LanguageClient,
+  type LanguageClientOptions,
+  type ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
 
-interface NativeTypeScriptExtensionAPI {
-  readonly initializeAPIConnection: (pipe?: string) => Promise<string>;
+interface TypedSqlServerStatus {
+  readonly name: string;
+  readonly mode: "pinned-preview-proxy";
+  readonly typescriptVersion: string;
+  readonly workspaceRoots: readonly string[];
+  readonly openDocuments: number;
+  readonly indexedDocuments: number;
 }
 
-interface CachedSchema {
-  readonly modified: number;
-  readonly snapshot: SchemaSnapshot;
+interface RunningClient {
+  readonly client: LanguageClient;
+  readonly watcher: vscode.FileSystemWatcher;
+  readonly server: string;
 }
 
-interface DocumentAnalysis {
-  readonly version: number;
-  readonly schemaPath: string;
-  readonly schemaModified: number;
-  readonly snapshot: SchemaSnapshot;
-  readonly analysis: BridgeAnalysis;
+const SERVER_RELATIVE_PATH = join(
+  "node_modules",
+  "@typed-sql",
+  "language-server",
+  "dist",
+  "packages",
+  "language-server",
+  "src",
+  "server.js",
+);
+const DEVELOPMENT_SERVER_RELATIVE_PATH = join(
+  "packages",
+  "language-server",
+  "dist",
+  "packages",
+  "language-server",
+  "src",
+  "server.js",
+);
+const clients = new Map<string, RunningClient>();
+const failures = new Map<string, string>();
+const output = vscode.window.createOutputChannel("typed-sql", { log: true });
+let statusBar: vscode.StatusBarItem;
+
+function optionalSetting(settings: vscode.WorkspaceConfiguration, name: string): string | undefined {
+  const value = settings.get<string>(name, "").trim();
+  return value.length === 0 ? undefined : value;
 }
 
-const languageSelector: vscode.DocumentSelector = [
-  { language: "typescript", scheme: "file" },
-  { language: "typescriptreact", scheme: "file" },
-];
-
-const schemaCache = new Map<string, CachedSchema>();
-const analysisCache = new Map<string, DocumentAnalysis>();
-const inspectionCache = new Map<string, readonly NativeTypeInspection[]>();
-const diagnosticSuggestions = new Map<string, string>();
-const MAX_CACHE_ENTRIES = 256;
-const MAX_SCHEMA_CACHE_ENTRIES = 16;
-const output = vscode.window.createOutputChannel("typed-sql");
-let diagnostics: vscode.DiagnosticCollection;
-let nativeBridgePromise: Promise<NativePreviewTypeScriptBridge | undefined> | undefined;
-let nativeBridgeStatus = "not connected";
-
-function cacheSet<K, V>(cache: Map<K, V>, key: K, value: V, maximum: number): void {
-  cache.delete(key);
-  cache.set(key, value);
-  while (cache.size > maximum) cache.delete(cache.keys().next().value!);
+function initializationOptions(folder: vscode.WorkspaceFolder): Record<string, unknown> {
+  const settings = vscode.workspace.getConfiguration("typedSql", folder.uri);
+  const configPath = optionalSetting(settings, "configPath");
+  const schemaPath = optionalSetting(settings, "schemaPath");
+  const projectFile = optionalSetting(settings, "projectFile");
+  return {
+    ...(configPath === undefined ? {} : { configPath }),
+    ...(schemaPath === undefined ? {} : { schemaPath }),
+    ...(projectFile === undefined ? {} : { projectFile }),
+    nativePreview: settings.get<boolean>("nativePreview", true),
+    maxCacheEntries: settings.get<number>("maxCacheEntries", 256),
+    maxWorkspaceFiles: settings.get<number>("maxWorkspaceFiles", 2_000),
+  };
 }
 
-function configuredPath(document: vscode.TextDocument, value: string): string | undefined {
-  if (isAbsolute(value)) return value;
-  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
-  return folder === undefined ? undefined : resolve(folder.uri.fsPath, value);
-}
-
-async function schemaAt(path: string): Promise<CachedSchema> {
-  const file = await stat(path);
-  const cached = schemaCache.get(path);
-  if (cached !== undefined && cached.modified === file.mtimeMs) return cached;
-  const snapshot = await loadSchemaSnapshot(path);
-  const result = { modified: file.mtimeMs, snapshot };
-  cacheSet(schemaCache, path, result, MAX_SCHEMA_CACHE_ENTRIES);
-  return result;
-}
-
-async function documentAnalysis(document: vscode.TextDocument): Promise<DocumentAnalysis | undefined> {
-  const key = document.uri.toString();
-  try {
-    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
-    if (folder === undefined) return undefined;
-    const settings = vscode.workspace.getConfiguration("typedSql", document.uri);
-    const configSetting = settings.get<string>("configPath", "").trim();
-    const loaded = await loadConfig({
-      cwd: folder.uri.fsPath,
-      ...(configSetting.length === 0 ? {} : { file: configuredPath(document, configSetting)! }),
-    });
-    const schemaSetting = settings.get<string>("schemaPath", "").trim();
-    const schemaPath =
-      schemaSetting.length === 0
-        ? fromConfig(loaded.directory, loaded.config.schema.file)
-        : configuredPath(document, schemaSetting)!;
-    const schema = await schemaAt(schemaPath);
-    const cached = analysisCache.get(key);
-    if (
-      cached !== undefined &&
-      cached.version === document.version &&
-      cached.schemaPath === schemaPath &&
-      cached.schemaModified === schema.modified
-    )
-      return cached;
-    const result = {
-      version: document.version,
-      schemaPath,
-      schemaModified: schema.modified,
-      snapshot: schema.snapshot,
-      analysis: analyzeSource(
-        document.getText(),
-        loaded.config.dialect.validateSnapshot(schema.snapshot),
-        loaded.config.dialect,
-        loaded.config.typePolicy ?? loaded.config.dialect.defaultTypePolicy,
-      ),
-    };
-    cacheSet(analysisCache, key, result, MAX_CACHE_ENTRIES);
-    return result;
-  } catch (error) {
-    output.appendLine(
-      `Unable to analyze ${document.uri.fsPath}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return undefined;
+function serverPath(folder: vscode.WorkspaceFolder): string | undefined {
+  const configured = optionalSetting(vscode.workspace.getConfiguration("typedSql", folder.uri), "serverPath");
+  if (configured !== undefined) {
+    const candidate = isAbsolute(configured) ? configured : resolve(folder.uri.fsPath, configured);
+    return existsSync(candidate) ? candidate : undefined;
   }
-}
-
-function diagnosticSeverity(severity: "error" | "info" | "warning"): vscode.DiagnosticSeverity {
-  if (severity === "error") return vscode.DiagnosticSeverity.Error;
-  return severity === "warning" ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Information;
-}
-
-async function refreshDiagnostics(document: vscode.TextDocument): Promise<void> {
-  if (document.languageId !== "typescript" && document.languageId !== "typescriptreact") return;
-  const startingVersion = document.version;
-  const result = await documentAnalysis(document);
-  if (document.version !== startingVersion) return;
-  if (result === undefined) {
-    diagnostics.delete(document.uri);
-    return;
+  for (const candidate of [
+    join(folder.uri.fsPath, SERVER_RELATIVE_PATH),
+    join(folder.uri.fsPath, DEVELOPMENT_SERVER_RELATIVE_PATH),
+  ]) {
+    if (existsSync(candidate)) return candidate;
   }
-  for (const key of diagnosticSuggestions.keys())
-    if (key.startsWith(`${document.uri.toString()}@`)) diagnosticSuggestions.delete(key);
-  diagnostics.set(
-    document.uri,
-    result.analysis.diagnostics.map((item) => {
-      const diagnostic = new vscode.Diagnostic(
-        new vscode.Range(document.positionAt(item.range.start), document.positionAt(item.range.end)),
-        `${item.code}: ${item.message}`,
-        diagnosticSeverity(item.severity),
-      );
-      diagnostic.source = "typed-sql";
-      diagnostic.code = item.code;
-      if (item.suggestion !== undefined)
-        diagnosticSuggestions.set(
-          `${document.uri.toString()}@${diagnostic.range.start.line}:${diagnostic.range.start.character}:${diagnostic.range.end.line}:${diagnostic.range.end.character}`,
-          item.suggestion,
-        );
-      return diagnostic;
-    }),
-  );
-}
-
-function tableForAlias(sqlText: string, alias: string, snapshot: SchemaSnapshot) {
-  const escaped = alias.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const match = new RegExp(
-    `(?:FROM|JOIN)\\s+(?:[A-Za-z_$][\\w$]*\\.)?([A-Za-z_$][\\w$]*)(?:\\s+(?:AS\\s+)?${escaped})\\b`,
-    "iu",
-  ).exec(sqlText);
-  const tableName = match?.[1];
-  return tableName === undefined
-    ? undefined
-    : Object.values(snapshot.tables).find((table) => table.name.toLowerCase() === tableName.toLowerCase());
-}
-
-async function provideCompletionItems(
-  document: vscode.TextDocument,
-  position: vscode.Position,
-  token: vscode.CancellationToken,
-): Promise<vscode.CompletionItem[]> {
-  const result = await documentAnalysis(document);
-  if (result === undefined || token.isCancellationRequested) return [];
-  const offset = document.offsetAt(position);
-  const query = queryAtPosition(result.analysis, offset);
-  if (query === undefined) return [];
-  const before = document.getText().slice(query.sourceRange.start, offset);
-  const qualifier = /([A-Za-z_$][A-Za-z0-9_$]*)\.[A-Za-z0-9_$]*$/u.exec(before)?.[1];
-  const selected =
-    qualifier === undefined
-      ? undefined
-      : tableForAlias(
-          document.getText().slice(query.sourceRange.start, query.sourceRange.end),
-          qualifier,
-          result.snapshot,
-        );
-  const tables = selected === undefined ? Object.values(result.snapshot.tables) : [selected];
-  const items = new Map<string, vscode.CompletionItem>();
-  if (qualifier === undefined) {
-    for (const table of tables)
-      items.set(table.name, new vscode.CompletionItem(table.name, vscode.CompletionItemKind.Class));
-    for (const keyword of [
-      "SELECT",
-      "FROM",
-      "WHERE",
-      "JOIN",
-      "GROUP BY",
-      "ORDER BY",
-      "INSERT",
-      "UPDATE",
-      "DELETE",
-      "RETURNING",
-    ]) {
-      items.set(keyword, new vscode.CompletionItem(keyword, vscode.CompletionItemKind.Keyword));
-    }
-  }
-  for (const table of tables) {
-    for (const column of Object.values(table.columns)) {
-      const item = new vscode.CompletionItem(column.name, vscode.CompletionItemKind.Field);
-      item.detail = `${column.databaseType}${column.nullable ? " nullable" : " not null"} — ${column.tsType}`;
-      items.set(column.name, item);
-    }
-  }
-  return [...items.values()];
-}
-
-async function provideDefinition(
-  document: vscode.TextDocument,
-  position: vscode.Position,
-  token: vscode.CancellationToken,
-): Promise<vscode.Location | undefined> {
-  const result = await documentAnalysis(document);
-  if (result === undefined || token.isCancellationRequested) return undefined;
-  const offset = document.offsetAt(position);
-  if (queryAtPosition(result.analysis, offset) === undefined) return undefined;
-  const range = document.getWordRangeAtPosition(position, /[A-Za-z0-9_$]+/u);
-  if (range === undefined) return undefined;
-  const word = document.getText(range);
-  const schemaText = await readFile(result.schemaPath, "utf8");
-  const match = schemaText.indexOf(JSON.stringify(word));
-  if (match < 0) return undefined;
-  const schemaDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(result.schemaPath));
-  return new vscode.Location(
-    schemaDocument.uri,
-    new vscode.Range(schemaDocument.positionAt(match + 1), schemaDocument.positionAt(match + word.length + 1)),
-  );
-}
-
-function provideCodeActions(
-  document: vscode.TextDocument,
-  _range: vscode.Range | vscode.Selection,
-  context: vscode.CodeActionContext,
-): vscode.CodeAction[] {
-  const actions: vscode.CodeAction[] = [];
-  for (const diagnostic of context.diagnostics) {
-    if (diagnostic.source !== "typed-sql") continue;
-    const key = `${document.uri.toString()}@${diagnostic.range.start.line}:${diagnostic.range.start.character}:${diagnostic.range.end.line}:${diagnostic.range.end.character}`;
-    const suggestion = diagnosticSuggestions.get(key);
-    const replacement =
-      suggestion === undefined ? undefined : /^Did you mean ([A-Za-z_$][\w$]*)\?$/u.exec(suggestion)?.[1];
-    if (replacement === undefined) continue;
-    const action = new vscode.CodeAction(`Replace with ${replacement}`, vscode.CodeActionKind.QuickFix);
-    action.isPreferred = true;
-    action.diagnostics = [diagnostic];
-    action.edit = new vscode.WorkspaceEdit();
-    action.edit.replace(document.uri, diagnostic.range, replacement);
-    actions.push(action);
-  }
-  return actions;
-}
-
-async function connectNativeBridge(): Promise<NativePreviewTypeScriptBridge | undefined> {
-  if (!vscode.workspace.getConfiguration("typedSql").get<boolean>("nativePreview", true)) {
-    nativeBridgeStatus = "disabled by typedSql.nativePreview";
-    return undefined;
-  }
-  for (const extensionId of ["TypeScriptTeam.native-preview", "vscode.typescript-language-features"]) {
-    const extension = vscode.extensions.getExtension<NativeTypeScriptExtensionAPI | undefined>(extensionId);
-    if (extension === undefined) continue;
-    try {
-      const extensionApi = await extension.activate();
-      if (extensionApi?.initializeAPIConnection === undefined) continue;
-      const pipe = await extensionApi.initializeAPIConnection();
-      const bridge = await NativePreviewTypeScriptBridge.connect(pipe);
-      nativeBridgeStatus = `connected through ${extensionId}`;
-      output.appendLine(`TypeScript 7 preview bridge ${nativeBridgeStatus}`);
-      return bridge;
-    } catch (error) {
-      output.appendLine(
-        `Could not connect through ${extensionId}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
-  nativeBridgeStatus = "resolver fallback (TypeScript 7 API connection unavailable)";
   return undefined;
 }
 
-function nativeBridge(): Promise<NativePreviewTypeScriptBridge | undefined> {
-  nativeBridgePromise ??= connectNativeBridge();
-  return nativeBridgePromise;
+function serverOptions(server: string, folder: vscode.WorkspaceFolder): ServerOptions {
+  const options = { cwd: folder.uri.fsPath };
+  return {
+    run: { module: server, transport: TransportKind.stdio, options },
+    debug: { module: server, transport: TransportKind.stdio, options },
+  };
 }
 
-async function inspectWithNativeBridge(
-  document: vscode.TextDocument,
-  result: DocumentAnalysis,
-): Promise<readonly NativeTypeInspection[] | undefined> {
-  const key = `${document.uri.toString()}@${document.version}:${result.schemaPath}@${result.schemaModified}`;
-  const cached = inspectionCache.get(key);
-  if (cached !== undefined) return cached;
-  const bridge = await nativeBridge();
-  if (bridge === undefined) return undefined;
-  try {
-    const inspections = await bridge.inspectFile({ fileName: document.uri.fsPath, analysis: result.analysis });
-    cacheSet(inspectionCache, key, inspections, MAX_CACHE_ENTRIES);
-    return inspections;
-  } catch (error) {
-    nativeBridgeStatus = "resolver fallback (preview request failed)";
-    output.appendLine(
-      `TypeScript preview inspection failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return undefined;
+function clientOptions(folder: vscode.WorkspaceFolder, watcher: vscode.FileSystemWatcher): LanguageClientOptions {
+  const workspacePattern = { baseUri: folder.uri.toString(), pattern: "**/*" } as const;
+  return {
+    documentSelector: [
+      { language: "typescript", scheme: "file", pattern: workspacePattern },
+      { language: "typescriptreact", scheme: "file", pattern: workspacePattern },
+    ],
+    workspaceFolder: folder,
+    initializationOptions: initializationOptions(folder),
+    synchronize: { configurationSection: "typedSql", fileEvents: watcher },
+    outputChannel: output,
+  };
+}
+
+function refreshStatusBar(): void {
+  const folders = vscode.workspace.workspaceFolders?.length ?? 0;
+  if (folders === 0) {
+    statusBar.text = "$(database) typed-sql: no workspace";
+    statusBar.tooltip = "Open a workspace containing typed-sql.config.ts.";
+  } else if (failures.size > 0) {
+    statusBar.text = "$(warning) typed-sql";
+    statusBar.tooltip = [...failures.values()].join("\n");
+  } else {
+    statusBar.text = `$(database) typed-sql: ${clients.size}/${folders}`;
+    statusBar.tooltip = `${clients.size} typed-sql language server${clients.size === 1 ? "" : "s"} running`;
   }
+  statusBar.show();
 }
 
-async function provideHover(
-  document: vscode.TextDocument,
-  position: vscode.Position,
-): Promise<vscode.Hover | undefined> {
-  const result = await documentAnalysis(document);
-  if (result === undefined) return undefined;
-  const offset = document.offsetAt(position);
-  const query = queryAtPosition(result.analysis, offset);
-  if (query === undefined) return undefined;
-  const nativeInspections = await inspectWithNativeBridge(document, result);
-  const nativeType = nativeInspections?.find((inspection) => inspection.queryIndex === query.index)?.typeText;
-  const typeText = nativeType ?? query.queryType;
-  const markdown = new vscode.MarkdownString();
-  markdown.appendMarkdown("**typed-sql inferred query type**\n\n");
-  markdown.appendCodeblock(typeText, "typescript");
-  markdown.appendMarkdown(
-    nativeType === undefined
-      ? "\nResolver result; install/enable the TypeScript 7 extension for native snapshot verification."
-      : "\nVerified through a temporary TypeScript 7.1 preview snapshot.",
+async function startClient(folder: vscode.WorkspaceFolder): Promise<void> {
+  const key = folder.uri.toString();
+  if (clients.has(key)) return;
+  const server = serverPath(folder);
+  if (server === undefined) {
+    const message = `${folder.name}: install @typed-sql/language-server in the workspace or configure typedSql.serverPath.`;
+    failures.set(key, message);
+    output.appendLine(message);
+    refreshStatusBar();
+    return;
+  }
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(folder, "**/{typed-sql.config.*,schema.json}"),
   );
-  const range =
-    query.binding !== undefined && offset >= query.binding.range.start && offset <= query.binding.range.end
-      ? query.binding.range
-      : query.sourceRange;
-  return new vscode.Hover(markdown, new vscode.Range(document.positionAt(range.start), document.positionAt(range.end)));
+  const client = new LanguageClient(
+    `typed-sql-${folder.index}`,
+    `typed-sql (${folder.name})`,
+    serverOptions(server, folder),
+    clientOptions(folder, watcher),
+  );
+  try {
+    await client.start();
+    failures.delete(key);
+    clients.set(key, { client, watcher, server });
+    output.appendLine(`${folder.name}: started ${server}`);
+  } catch (error) {
+    watcher.dispose();
+    const message = `${folder.name}: ${error instanceof Error ? error.message : String(error)}`;
+    failures.set(key, message);
+    output.appendLine(`Could not start typed-sql: ${message}`);
+  }
+  refreshStatusBar();
 }
 
-async function resetNativeBridge(): Promise<void> {
-  const current = await nativeBridgePromise;
-  nativeBridgePromise = undefined;
-  nativeBridgeStatus = "not connected";
-  inspectionCache.clear();
-  await current?.close();
+async function stopClient(folder: vscode.WorkspaceFolder): Promise<void> {
+  const key = folder.uri.toString();
+  failures.delete(key);
+  const running = clients.get(key);
+  clients.delete(key);
+  if (running !== undefined) {
+    running.watcher.dispose();
+    await running.client.stop();
+  }
+  refreshStatusBar();
+}
+
+async function restartClients(): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  await Promise.all(folders.map(stopClient));
+  await Promise.all(folders.map(startClient));
+}
+
+async function showStatus(): Promise<void> {
+  const reports = await Promise.all(
+    [...clients.entries()].map(async ([key, running]) => {
+      try {
+        const status = await running.client.sendRequest<TypedSqlServerStatus>("typedSql/status");
+        const folderName = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(key))?.name ?? key;
+        return `${folderName}: ${status.mode}, TypeScript ${status.typescriptVersion}; ${status.openDocuments} open, ${status.indexedDocuments} indexed (${running.server})`;
+      } catch (error) {
+        return `${key}: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    }),
+  );
+  reports.push(...failures.values());
+  const message = reports.length === 0 ? "No typed-sql language server is running." : reports.join("\n");
+  output.appendLine(message);
+  const selection = await vscode.window.showInformationMessage(message, "Show output");
+  if (selection === "Show output") output.show();
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  diagnostics = vscode.languages.createDiagnosticCollection("typed-sql");
+  statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 90);
+  statusBar.command = "typedSql.showBridgeStatus";
   context.subscriptions.push(
-    diagnostics,
     output,
-    vscode.languages.registerHoverProvider(languageSelector, { provideHover }),
-    vscode.languages.registerCompletionItemProvider(languageSelector, { provideCompletionItems }, "."),
-    vscode.languages.registerDefinitionProvider(languageSelector, { provideDefinition }),
-    vscode.languages.registerCodeActionsProvider(
-      languageSelector,
-      { provideCodeActions },
-      { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] },
-    ),
-    vscode.commands.registerCommand("typedSql.showBridgeStatus", async () => {
-      await nativeBridge();
-      await vscode.window.showInformationMessage(`typed-sql TypeScript bridge: ${nativeBridgeStatus}`);
+    statusBar,
+    vscode.commands.registerCommand("typedSql.showBridgeStatus", showStatus),
+    vscode.workspace.onDidChangeWorkspaceFolders(async ({ added, removed }) => {
+      await Promise.all(removed.map(stopClient));
+      await Promise.all(added.map(startClient));
     }),
-    vscode.workspace.onDidOpenTextDocument((document) => {
-      void refreshDiagnostics(document);
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("typedSql")) await restartClients();
     }),
-    vscode.workspace.onDidSaveTextDocument((document) => {
-      void refreshDiagnostics(document);
-    }),
-    vscode.workspace.onDidChangeTextDocument(({ document }) => {
-      analysisCache.delete(document.uri.toString());
-      for (const key of inspectionCache.keys())
-        if (key.startsWith(`${document.uri.toString()}@`)) inspectionCache.delete(key);
-      void refreshDiagnostics(document);
-    }),
-    vscode.workspace.onDidCloseTextDocument((document) => {
-      analysisCache.delete(document.uri.toString());
-      for (const key of diagnosticSuggestions.keys())
-        if (key.startsWith(`${document.uri.toString()}@`)) diagnosticSuggestions.delete(key);
-      diagnostics.delete(document.uri);
-    }),
-    vscode.workspace.onDidChangeConfiguration((event) => {
-      if (!event.affectsConfiguration("typedSql")) return;
-      schemaCache.clear();
-      analysisCache.clear();
-      void resetNativeBridge();
-      for (const document of vscode.workspace.textDocuments) void refreshDiagnostics(document);
-    }),
-    {
-      dispose: () => {
-        void resetNativeBridge();
-      },
-    },
   );
-  for (const document of vscode.workspace.textDocuments) void refreshDiagnostics(document);
+  await Promise.all((vscode.workspace.workspaceFolders ?? []).map(startClient));
+  refreshStatusBar();
 }
 
 export async function deactivate(): Promise<void> {
-  await resetNativeBridge();
+  await Promise.all(
+    [...clients.values()].map(async ({ client, watcher }) => {
+      watcher.dispose();
+      await client.stop();
+    }),
+  );
+  clients.clear();
 }

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "types": ["node", "vscode"]
   },
-  "include": ["src/**/*.ts"],
-  "references": [{ "path": "../config" }, { "path": "../core" }, { "path": "../schema" }, { "path": "../ts-bridge" }]
+  "include": ["src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,18 +278,9 @@ importers:
 
   packages/vscode:
     dependencies:
-      '@typed-sql/config':
-        specifier: workspace:*
-        version: link:../config
-      '@typed-sql/core':
-        specifier: workspace:*
-        version: link:../core
-      '@typed-sql/schema':
-        specifier: workspace:*
-        version: link:../schema
-      '@typed-sql/ts-bridge':
-        specifier: workspace:*
-        version: link:../ts-bridge
+      vscode-languageclient:
+        specifier: 10.1.0
+        version: 10.1.0
     devDependencies:
       '@types/vscode':
         specifier: 1.134.0
@@ -2977,11 +2968,18 @@ packages:
     resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
     engines: {node: '>=14.0.0'}
 
+  vscode-languageclient@10.1.0:
+    resolution: {integrity: sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==}
+    engines: {vscode: ^1.91.0}
+
   vscode-languageserver-protocol@3.18.2:
     resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
 
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-textdocument@1.0.13:
+    resolution: {integrity: sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==}
 
   vscode-languageserver-types@3.18.0:
     resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
@@ -5792,12 +5790,21 @@ snapshots:
 
   vscode-jsonrpc@9.0.1: {}
 
+  vscode-languageclient@10.1.0:
+    dependencies:
+      minimatch: 10.2.6
+      semver: 7.8.5
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.13
+
   vscode-languageserver-protocol@3.18.2:
     dependencies:
       vscode-jsonrpc: 9.0.1
       vscode-languageserver-types: 3.18.0
 
   vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-textdocument@1.0.13: {}
 
   vscode-languageserver-types@3.18.0: {}
 

--- a/scripts/assert-editor-artifacts.mjs
+++ b/scripts/assert-editor-artifacts.mjs
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { execFile as execFileCallback } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const workspace = resolve(import.meta.dirname, "..");
+const vsix = resolve(workspace, process.argv[2] ?? "artifacts/typed-sql-vscode.vsix");
+const wasm = resolve(workspace, process.argv[3] ?? "artifacts/typed-sql-zed.wasm");
+
+const listing = (await execFile("unzip", ["-Z1", vsix])).stdout.split("\n");
+for (const expected of [
+  "extension/package.json",
+  "extension/readme.md",
+  "extension/LICENSE.txt",
+  "extension/bundle/extension.cjs",
+]) {
+  assert.ok(listing.includes(expected), `VSIX is missing ${expected}`);
+}
+const bundle = (await execFile("unzip", ["-p", vsix, "extension/bundle/extension.cjs"])).stdout;
+assert.match(bundle, /typedSql\/status/u);
+assert.match(bundle, /@typed-sql[\\/]language-server/u);
+assert.doesNotMatch(bundle, /NativePreviewTypeScriptBridge|function analyzeSource/u);
+assert.doesNotMatch(bundle, /\/Users\/|\/home\/runner\//u);
+
+const wasmBytes = await readFile(wasm);
+assert.deepEqual([...wasmBytes.subarray(0, 4)], [0x00, 0x61, 0x73, 0x6d]);
+assert.ok((await stat(wasm)).size > 1_024, "Zed artifact is unexpectedly small");
+
+console.log("typed-sql editor artifacts are portable and use the shared language server");

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -36,7 +36,8 @@ await describe("external editor distribution", async () => {
     strict.ok(path > installed);
     strict.ok(development >= 0);
     strict.ok(source.indexOf("join(DEVELOPMENT_SERVER)") > path);
-    strict.ok(source.includes("pnpm add -D @typed-sql/language-server@next"));
+    strict.ok(source.includes("pnpm add -D @typed-sql/language-server"));
+    strict.ok(!source.includes("@next"));
     strict.ok(!source.includes("/Users/"));
   });
 
@@ -59,9 +60,32 @@ await describe("external editor distribution", async () => {
     const server = await text("packages/language-server/src/server.ts");
     strict.ok(server.includes("could not start or communicate with its pinned TypeScript preview process"));
     strict.ok(server.includes("TYPESCRIPT_PREVIEW_VERSION"));
-    strict.ok(server.includes("Reinstall @typed-sql/language-server@next"));
+    strict.ok(server.includes("Reinstall @typed-sql/language-server"));
+    strict.ok(!server.includes("@next"));
     strict.ok(server.includes('preview.once("error"'));
     strict.ok(server.includes('preview.on("exit"'));
     strict.ok(server.includes("nativeRequest"));
+  });
+
+  await it("keeps VS Code a thin client of the shared language server", async () => {
+    const source = await text("packages/vscode/src/extension.ts");
+    const manifest = JSON.parse(await text("packages/vscode/package.json")) as {
+      readonly dependencies?: Readonly<Record<string, string>>;
+    };
+    strict.ok(source.includes('from "vscode-languageclient/node"'));
+    strict.ok(source.includes("@typed-sql/language-server"));
+    strict.ok(source.includes('sendRequest<TypedSqlServerStatus>("typedSql/status")'));
+    strict.ok(!source.includes("analyzeSource"));
+    strict.ok(!source.includes("NativePreviewTypeScriptBridge"));
+    strict.deepStrictEqual(manifest.dependencies, { "vscode-languageclient": "10.1.0" });
+  });
+
+  await it("smokes the packaged VS Code and Zed artifacts in CI", async () => {
+    const workflow = await text(".github/workflows/ci.yml");
+    const smoke = await text("scripts/assert-editor-artifacts.mjs");
+    strict.ok(workflow.includes("pnpm editor:artifacts:smoke"));
+    strict.ok(smoke.includes('execFile("unzip", ["-Z1", vsix])'));
+    strict.ok(smoke.includes("[0x00, 0x61, 0x73, 0x6d]"));
+    strict.ok(smoke.includes("typedSql\\/status"));
   });
 });

--- a/test/soundness/source-corpus.ts
+++ b/test/soundness/source-corpus.ts
@@ -22,7 +22,7 @@ export interface SourceSoundnessCase {
   readonly expectation: SourceSoundnessExpectation;
 }
 
-export function sourceForDialect(testCase: SourceSoundnessCase, dialect: "postgres" | "mysql"): string {
+export function sourceForDialect(testCase: SourceSoundnessCase, dialect: "postgres" | "mysql" | "sqlite"): string {
   return testCase.source.replace("@typed-sql/postgres", `@typed-sql/${dialect}`);
 }
 


### PR DESCRIPTION
## Summary

- replace the duplicate VS Code analyzer and TypeScript bridge with one workspace-local shared language-server client
- add cancellation, stale-diagnostic suppression, multi-root status reporting, and static-position guards for SQL navigation
- exercise one editor protocol contract across PostgreSQL, MySQL, and SQLite
- smoke the packaged VS Code and Zed artifacts in CI and document the experimental TypeScript boundary

## Verification

-  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> typed-sql-workspace@ verify /Users/viniciuslojhan/Development/OSS/typed-sql
> pnpm quality && pnpm test && pnpm coverage && pnpm build && pnpm docs:build && pnpm performance:gate

 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> typed-sql-workspace@ quality /Users/viniciuslojhan/Development/OSS/typed-sql
> biome check .

Checked 276 files in 113ms. No fixes applied.
 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> typed-sql-workspace@ test /Users/viniciuslojhan/Development/OSS/typed-sql
> pnpm typecheck && pnpm --filter @typed-sql/e2e-postgres generate:snapshot && pnpm --filter @typed-sql/e2e-mysql generate:snapshot && pnpm --filter './packages/**' --if-present test && pnpm --filter './examples/**' --if-present test && pnpm test:contracts

 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
 WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> typed-sql-workspace@ typecheck /Users/viniciuslojhan/Development/OSS/typed-sql
> node scripts/require-typescript-7.mjs && tsc -b --pretty false

.                                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> @typed-sql/e2e-postgres@0.0.0 generate:snapshot /Users/viniciuslojhan/Development/OSS/typed-sql/e2e/postgres
> node ../../packages/cli/dist/packages/cli/src/cli.js generate --config typed-sql.config.ts --snapshot schema/catalog.snapshot.json

Generated schema a117e5853ecf01a22b6892736501740c945ff65ac9fbd8df818377cf1c524758
.                                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> @typed-sql/e2e-mysql@0.0.0 generate:snapshot /Users/viniciuslojhan/Development/OSS/typed-sql/e2e/mysql
> node ../../packages/cli/dist/packages/cli/src/cli.js generate --config typed-sql.config.ts --snapshot schema/catalog.snapshot.json

Generated schema 9a6271e19fe409b96cb299206e33cc4465d1ab7040df245bb2c8a7c3e40ef1bb
.                                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ast                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/cli                             |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/compiler                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/config                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/conformance                     |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/core                            |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/language-server                 |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/mysql                           |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/opentelemetry                   |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/postgres                        |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/schema                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/sqlite                          |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
packages/ts-bridge                       |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
website                                  |  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})
Scope: 14 of 20 workspace projects
packages/ast test$ poku test --reporter=compact --enforce
packages/schema test$ poku test --reporter=compact --enforce
packages/core test$ poku test --reporter=compact --enforce
packages/core test: [102m[1m PASS [0m test/semantics.test.ts
packages/core test: [102m[1m PASS [0m test/execution.test.ts
packages/ast test: [102m[1m PASS [0m test/parser.test.ts
packages/ast test: [102m[1m PASS [0m test/matrix.test.ts
packages/ast test: [102m[1m PASS [0m test/walk.test.ts
packages/core test: [102m[1m PASS [0m test/query.test.ts
packages/core test: [102m[1m PASS [0m test/observation.test.ts
packages/schema test: [102m[1m PASS [0m test/loader.test.ts
packages/schema test: [102m[1m PASS [0m test/generator.test.ts
packages/schema test: [1m[2m2[0m [2mtest file(s) passed[0m
packages/schema test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/schema test: [2mFinished in ±0.30 seconds[0m
packages/schema test: Done
packages/core test: [102m[1m PASS [0m test/routing.test.ts
packages/ast test: [102m[1m PASS [0m test/fuzz.test.ts
packages/ast test: [1m[2m4[0m [2mtest file(s) passed[0m
packages/ast test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/ast test: [2mFinished in ±0.34 seconds[0m
packages/ast test: Done
packages/core test: [102m[1m PASS [0m test/performance.test.ts
packages/core test: [1m[2m6[0m [2mtest file(s) passed[0m
packages/core test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/core test: [2mFinished in ±0.34 seconds[0m
packages/core test: Done
packages/config test$ poku test --reporter=compact --enforce
packages/opentelemetry test$ poku test --reporter=compact --enforce
packages/mysql test$ poku test --reporter=compact --enforce
packages/compiler test$ poku test --reporter=compact --enforce
packages/opentelemetry test: [102m[1m PASS [0m test/opentelemetry.test.ts
packages/opentelemetry test: [1m[2m1[0m [2mtest file(s) passed[0m
packages/opentelemetry test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/opentelemetry test: [2mFinished in ±0.46 seconds[0m
packages/opentelemetry test: Done
packages/postgres test$ poku test --reporter=compact --enforce
packages/mysql test: [102m[1m PASS [0m test/execute-lifecycle.test.ts
packages/mysql test: [102m[1m PASS [0m test/batch.test.ts
packages/mysql test: [102m[1m PASS [0m test/decoder-cache.test.ts
packages/mysql test: [102m[1m PASS [0m test/runtime-decoding.test.ts
packages/mysql test: [102m[1m PASS [0m test/streaming.test.ts
packages/mysql test: [102m[1m PASS [0m test/soundness.test.ts
packages/mysql test: [102m[1m PASS [0m test/verification.test.ts
packages/mysql test: [102m[1m PASS [0m test/provider-runtime.test.ts
packages/mysql test: [102m[1m PASS [0m test/resolver-matrix.test.ts
packages/mysql test: [102m[1m PASS [0m test/routing.test.ts
packages/mysql test: [102m[1m PASS [0m test/mysql.test.ts
packages/compiler test: [102m[1m PASS [0m test/plans.test.ts
packages/mysql test: [102m[1m PASS [0m test/mysql2.test.ts
packages/mysql test: [1m[2m12[0m [2mtest file(s) passed[0m
packages/mysql test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/mysql test: [2mFinished in ±0.70 seconds[0m
packages/compiler test: [102m[1m PASS [0m test/compatibility.test.ts
packages/compiler test: [102m[1m PASS [0m test/soundness.test.ts
packages/compiler test: [102m[1m PASS [0m test/performance.test.ts
packages/mysql test: Done
packages/compiler test: [102m[1m PASS [0m test/verification.test.ts
packages/config test: [102m[1m PASS [0m test/config.test.ts
packages/config test: [1m[2m1[0m [2mtest file(s) passed[0m
packages/config test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/config test: [2mFinished in ±0.94 seconds[0m
packages/config test: Done
packages/compiler test: [102m[1m PASS [0m test/manifest.test.ts
packages/postgres test: [102m[1m PASS [0m test/provider.test.ts
packages/postgres test: [102m[1m PASS [0m test/pipeline.test.ts
packages/postgres test: [102m[1m PASS [0m test/batch.test.ts
packages/postgres test: [102m[1m PASS [0m test/live.test.ts
packages/postgres test: [102m[1m PASS [0m test/plugin.test.ts
packages/postgres test: [102m[1m PASS [0m test/resolver-matrix.test.ts
packages/postgres test: [102m[1m PASS [0m test/stream.test.ts
packages/postgres test: [102m[1m PASS [0m test/runtime.test.ts
packages/postgres test: [102m[1m PASS [0m test/resolver.test.ts
packages/postgres test: [102m[1m PASS [0m test/routing.test.ts
packages/postgres test: [102m[1m PASS [0m test/soundness.test.ts
packages/postgres test: [102m[1m PASS [0m test/pg.test.ts
packages/postgres test: [102m[1m PASS [0m test/type-policy.test.ts
packages/postgres test: [102m[1m PASS [0m test/verification.test.ts
packages/postgres test: [1m[2m14[0m [2mtest file(s) passed[0m
packages/postgres test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/postgres test: [2mFinished in ±0.65 seconds[0m
packages/postgres test: Done
packages/compiler test: [102m[1m PASS [0m test/compiler.test.ts
packages/compiler test: [1m[2m7[0m [2mtest file(s) passed[0m
packages/compiler test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/compiler test: [2mFinished in ±3.13 seconds[0m
packages/compiler test: Done
packages/cli test$ poku test --reporter=compact --enforce
packages/conformance test$ poku test --reporter=compact --enforce
packages/ts-bridge test$ poku test --reporter=compact --enforce
packages/conformance test: [102m[1m PASS [0m test/conformance.test.ts
packages/conformance test: [1m[2m1[0m [2mtest file(s) passed[0m
packages/conformance test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/conformance test: [2mFinished in ±0.21 seconds[0m
packages/conformance test: Done
packages/ts-bridge test: [102m[1m PASS [0m test/soundness.test.ts
packages/ts-bridge test: [102m[1m PASS [0m test/bridge.test.ts
packages/ts-bridge test: [1m[2m2[0m [2mtest file(s) passed[0m
packages/ts-bridge test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/ts-bridge test: [2mFinished in ±0.34 seconds[0m
packages/ts-bridge test: Done
packages/cli test: [102m[1m PASS [0m test/soundness.test.ts
packages/cli test: [102m[1m PASS [0m test/cli.test.ts
packages/cli test: [1m[2m2[0m [2mtest file(s) passed[0m
packages/cli test: [1m[2m0[0m [2mtest file(s) failed[0m
packages/cli test: [2mFinished in ±4.51 seconds[0m
packages/cli test: Done
packages/sqlite test$ poku test --reporter=compact --enforce
packages/language-server test$ poku test --reporter=compact --enforce
packages/sqlite test: [101m[1m FAIL [0m test/runtime.test.ts
packages/sqlite test: [101m[1m FAIL [0m test/provider.test.ts
packages/sqlite test: [102m[1m PASS [0m test/runtime-edge.test.ts
packages/sqlite test: [102m[1m PASS [0m test/soundness.test.ts
packages/sqlite test: [102m[1m PASS [0m test/sqlite.test.ts
packages/sqlite test: [102m[1m PASS [0m test/conformance.test.ts
packages/sqlite test: [102m[1m PASS [0m test/snapshot.test.ts
packages/sqlite test: [102m[1m PASS [0m test/performance.test.ts
packages/sqlite test: [2m[90m────────────────────────────────────────[0m
packages/sqlite test: [91m[1m2[0m [1mtest file(s) failed:[0m
packages/sqlite test: [2m[1m1)[0m [4mtest/runtime.test.ts[0m
packages/sqlite test:   node:internal/modules/esm/translators:412
packages/sqlite test:       throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
packages/sqlite test:             ^
packages/sqlite test:   Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
packages/sqlite test:       at ModuleLoader.builtinStrategy (node:internal/modules/esm/translators:412:11)
packages/sqlite test:       at callTranslator (node:internal/modules/esm/loader:439:14)
packages/sqlite test:       at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:445:30) {
packages/sqlite test:     code: 'ERR_UNKNOWN_BUILTIN_MODULE'
packages/sqlite test:   }
packages/sqlite test:   Node.js v22.5.1
packages/sqlite test: [2m[1m2)[0m [4mtest/provider.test.ts[0m
packages/sqlite test:   node:internal/modules/esm/translators:412
packages/sqlite test:       throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
packages/sqlite test:             ^
packages/sqlite test:   Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
packages/sqlite test:       at ModuleLoader.builtinStrategy (node:internal/modules/esm/translators:412:11)
packages/sqlite test:       at callTranslator (node:internal/modules/esm/loader:439:14)
packages/sqlite test:       at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:445:30) {
packages/sqlite test:     code: 'ERR_UNKNOWN_BUILTIN_MODULE'
packages/sqlite test:   }
packages/sqlite test:   Node.js v22.5.1
packages/sqlite test: [2m[90m────────────────────────────────────────[0m
packages/sqlite test: [1m[2m6[0m [2mtest file(s) passed[0m
packages/sqlite test: [1m[2m2[0m [2mtest file(s) failed[0m
packages/sqlite test: [2mFinished in ±0.31 seconds[0m
packages/sqlite test: Failed
/Users/viniciuslojhan/Development/OSS/typed-sql/packages/sqlite:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @typed-sql/sqlite@1.0.0-rc.0 test: `poku test --reporter=compact --enforce`
Exit status 1
 ELIFECYCLE  Test failed. See above for more details.
 ELIFECYCLE  Command failed with exit code 1.
-  WARN  Unsupported engine: wanted: {"node":">=22.11"} (current: {"node":"v22.5.1","pnpm":"10.32.1"})

> typed-sql-workspace@ editor:artifacts:smoke /Users/viniciuslojhan/Development/OSS/typed-sql
> node scripts/assert-editor-artifacts.mjs

typed-sql editor artifacts are portable and use the shared language server
- VSIX package and Zed WASM builds

Closes #61