### PR TITLE
feat: add native bulk adapter capabilities

### DIFF
--- a/.changeset/large-streams-transfer.md
+++ b/.changeset/large-streams-transfer.md
@@ -1,0 +1,11 @@
+---
+"@typed-sql/core": major
+"@typed-sql/postgres": major
+"@typed-sql/mysql": major
+---
+
+Add grammar-neutral optional adapter capability discovery, typed PostgreSQL COPY import and export
+through application-owned `pg-copy-streams`, and typed MySQL LOAD DATA import through mysql2's
+application-owned infile stream. Bulk transfers preserve ordinary `INSERT` parameter evidence,
+enforce structural row stability, apply bounded backpressure, support cancellation and progress,
+and integrate with transaction ownership and conservative connection cleanup.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ codecs. The interpolation is also checked as `bigint` because it is compared wit
   deployment directions and link breaks to exact query variants.
 - **Route with semantic proof.** Opt-in routed databases send only proven-safe reads to
   application-owned replicas and support bounded retries for explicit transactions.
+- **Use native bulk protocols without losing SQL.** Optional PostgreSQL COPY and MySQL LOAD DATA
+  capabilities compile ordinary typed `INSERT` factories into backpressured application streams.
 
 ## Install
 
@@ -160,6 +162,7 @@ the structural-variant bound.
 - [Documentation site](https://lojhan.github.io/typed-sql/)
 - [Documentation source](./docs/index.md)
 - [Execution adapters](./docs/guides/execution.md)
+- [Bulk data transfer](./docs/guides/bulk-data.md)
 - [Database observability](./docs/guides/observability.md)
 - [Query manifests](./docs/guides/query-manifests.md)
 - [Live database verification](./docs/guides/live-verification.md)

--- a/benchmarks/runtime-comparison/README.md
+++ b/benchmarks/runtime-comparison/README.md
@@ -1,11 +1,20 @@
 # Runtime comparison benchmark
 
-This isolated workspace compares the runtime cost of one indexed account lookup through:
+This isolated workspace contains two reproducible database-backed comparisons.
+
+The indexed lookup workload compares:
 
 - raw `pg` and raw `mysql2`;
 - typed-sql on PostgreSQL and MySQL;
 - Drizzle, Kysely, Prisma, and TypeORM on PostgreSQL;
 - named/prepared paths where the library exposes a comparable public API.
+
+The bulk-ingestion workload compares multiple row counts through:
+
+- typed-sql PostgreSQL COPY, ordered batch, and native pipeline;
+- direct `pg-copy-streams` COPY and raw named `pg` inserts;
+- typed-sql MySQL LOAD DATA and ordered batch;
+- direct mysql2 LOAD DATA and raw mysql2 execute inserts.
 
 It is a reproducible experiment, not a universal leaderboard. Database version, host scheduling, connection transport, driver version, result decoding, pool configuration, and query shape all affect the result. The committed harness is the claim; generated numbers are intentionally ignored.
 
@@ -20,10 +29,20 @@ pnpm install --frozen-lockfile
 pnpm run
 ```
 
-`pnpm run` starts fixed PostgreSQL and MySQL containers, generates Prisma Client, warms every candidate, measures sequential request latency, and writes `results/latest.json`. The runner uses Docker Compose when available and falls back to Podman Compose; set `TYPED_SQL_CONTAINER_ENGINE=docker` or `podman` to require one explicitly. Stop and remove the databases afterward:
+`pnpm run` starts fixed PostgreSQL and MySQL containers, generates Prisma Client, warms every candidate, runs both workloads, and writes `results/latest.json` plus `results/bulk-latest.json`. The runner uses Docker Compose when available and falls back to Podman Compose; set `TYPED_SQL_CONTAINER_ENGINE=docker` or `podman` to require one explicitly. Stop and remove the databases afterward:
 
 ```sh
 pnpm databases:stop
+```
+
+If the default host ports are occupied, keep the container mappings and benchmark URLs aligned:
+
+```sh
+TYPED_SQL_BENCHMARK_POSTGRES_PORT=55440 \
+TYPED_SQL_BENCHMARK_MYSQL_PORT=53310 \
+POSTGRES_URL=postgresql://typed_sql:typed_sql@127.0.0.1:55440/typed_sql_benchmark \
+MYSQL_URL=mysql://typed_sql:typed_sql@127.0.0.1:53310/typed_sql_benchmark \
+pnpm run
 ```
 
 The workspace applies a narrow pnpm override from Prisma's config package to
@@ -38,6 +57,12 @@ You can adjust measurement depth without editing the fixture:
 BENCHMARK_WARMUPS=500 BENCHMARK_SAMPLES=20 BENCHMARK_ITERATIONS=2000 pnpm benchmark
 ```
 
+Run or resize only the bulk workload with:
+
+```sh
+BULK_BENCHMARK_ROW_COUNTS=100,1000,5000 BULK_BENCHMARK_WARMUPS=1 BULK_BENCHMARK_SAMPLES=3 pnpm benchmark:bulk
+```
+
 ## Methodology
 
 The request workload constructs and executes each library's idiomatic lookup API. It includes SQL/query-builder work, driver dispatch, a local database round trip, and row decoding. The prepared workload is reported separately because only raw `pg`, typed-sql, and Drizzle expose directly comparable named/prepared APIs here; `mysql2.execute()` already uses its per-connection statement cache.
@@ -45,5 +70,13 @@ The request workload constructs and executes each library's idiomatic lookup API
 All candidates select the same three columns from the same 1,000-row indexed table. They use a pool limit of ten and execute sequentially so pool contention does not obscure per-request overhead. Each measured sample contains many operations; the report uses per-operation p50 and p95 sample latency.
 
 The harness deliberately does not compare migrations, schema authoring, relation loading, unit-of-work behavior, or application-level ergonomics. Those are product capabilities, not runtime lookup costs.
+
+The bulk workload truncates its isolated target before every warm-up and sample, times only the
+ingestion call, then verifies the committed row count outside the timed region. Inputs are generated
+before timing. Every strategy inserts the same three scalar columns; COPY and LOAD DATA use
+application-owned streams rather than server filesystem paths. Batch and direct prepared-insert
+paths remain intentionally sequential, while PostgreSQL pipeline dispatches all statements before
+awaiting results. The benchmark reports throughput separately for each row count instead of
+extrapolating one small transfer.
 
 The APIs follow the projects' public documentation: [Drizzle PostgreSQL](https://orm.drizzle.team/docs/get-started-postgresql), [Drizzle prepared queries](https://orm.drizzle.team/docs/perf-queries), [Kysely](https://kysely.dev/), [Prisma PostgreSQL driver adapter](https://www.prisma.io/docs/orm/overview/databases/postgresql), and [TypeORM QueryBuilder](https://typeorm.io/docs/query-builder/select-query-builder/).

--- a/benchmarks/runtime-comparison/compose.yaml
+++ b/benchmarks/runtime-comparison/compose.yaml
@@ -11,12 +11,13 @@ services:
       timeout: 5s
       retries: 30
     ports:
-      - "55432:5432"
+      - "${TYPED_SQL_BENCHMARK_POSTGRES_PORT:-55432}:5432"
     volumes:
       - ./schema/postgres.sql:/docker-entrypoint-initdb.d/001-schema.sql:ro
 
   mysql:
     image: mysql:9.5
+    command: ["--local-infile=ON"]
     environment:
       MYSQL_DATABASE: typed_sql_benchmark
       MYSQL_PASSWORD: typed_sql
@@ -28,6 +29,6 @@ services:
       timeout: 5s
       retries: 60
     ports:
-      - "53306:3306"
+      - "${TYPED_SQL_BENCHMARK_MYSQL_PORT:-53306}:3306"
     volumes:
       - ./schema/mysql.sql:/docker-entrypoint-initdb.d/001-schema.sql:ro

--- a/benchmarks/runtime-comparison/package.json
+++ b/benchmarks/runtime-comparison/package.json
@@ -11,8 +11,9 @@
     "databases:stop": "node scripts/databases.mjs stop",
     "generate": "prisma generate",
     "benchmark": "tsx src/benchmark.ts",
+    "benchmark:bulk": "tsx src/bulk.ts",
     "typecheck": "tsc --noEmit",
-    "run": "pnpm databases:start && pnpm generate && pnpm benchmark"
+    "run": "pnpm databases:start && pnpm generate && pnpm benchmark && pnpm benchmark:bulk"
   },
   "dependencies": {
     "@prisma/adapter-pg": "7.10.0",
@@ -23,11 +24,13 @@
     "kysely": "0.29.5",
     "mysql2": "3.24.1",
     "pg": "8.23.0",
+    "pg-copy-streams": "7.0.0",
     "typeorm": "1.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/pg": "8.23.1",
+    "@types/pg-copy-streams": "1.2.5",
     "prisma": "7.10.0",
     "tsx": "4.23.12",
     "typescript": "7.0.2"

--- a/benchmarks/runtime-comparison/pnpm-lock.yaml
+++ b/benchmarks/runtime-comparison/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       pg:
         specifier: 8.23.0
         version: 8.23.0
+      pg-copy-streams:
+        specifier: 7.0.0
+        version: 7.0.0
       typeorm:
         specifier: 1.1.0
         version: 1.1.0(mysql2@3.24.1(@types/node@24.13.3))(pg@8.23.0)
@@ -45,6 +48,9 @@ importers:
       '@types/pg':
         specifier: 8.23.1
         version: 8.23.1
+      '@types/pg-copy-streams':
+        specifier: 1.2.5
+        version: 1.2.5
       prisma:
         specifier: 7.10.0
         version: 7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
@@ -411,6 +417,9 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/pg-copy-streams@1.2.5':
+    resolution: {integrity: sha512-7D6/GYW2uHIaVU6S/5omI+6RZnwlZBpLQDZAH83xX1rjxAOK0f6/deKyyUTewxqts145VIGn6XWYz1YGf50G5g==}
 
   '@types/pg@8.23.1':
     resolution: {integrity: sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==}
@@ -969,6 +978,9 @@ packages:
 
   pg-connection-string@2.14.0:
     resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-copy-streams@7.0.0:
+    resolution: {integrity: sha512-zBvnY6wtaBRE2ae2xXWOOGMaNVPkXh1vhypAkNSKgMdciJeTyIQAHZaEeRAxUjs/p1El5jgzYmwG5u871Zj3dQ==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -1544,6 +1556,11 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/pg-copy-streams@1.2.5':
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/pg': 8.23.1
+
   '@types/pg@8.23.1':
     dependencies:
       '@types/node': 24.13.3
@@ -1983,6 +2000,8 @@ snapshots:
     optional: true
 
   pg-connection-string@2.14.0: {}
+
+  pg-copy-streams@7.0.0: {}
 
   pg-int8@1.0.1: {}
 

--- a/benchmarks/runtime-comparison/schema/mysql.sql
+++ b/benchmarks/runtime-comparison/schema/mysql.sql
@@ -17,3 +17,9 @@ SELECT
   IF(MOD(value, 5) = 0, 'suspended', 'active'),
   value * 10.25
 FROM sequence;
+
+CREATE TABLE bulk_account (
+  id bigint PRIMARY KEY,
+  email varchar(255) NOT NULL UNIQUE,
+  status enum('active', 'suspended') NOT NULL
+);

--- a/benchmarks/runtime-comparison/schema/postgres.sql
+++ b/benchmarks/runtime-comparison/schema/postgres.sql
@@ -12,3 +12,9 @@ SELECT
   CASE WHEN value % 5 = 0 THEN 'suspended' ELSE 'active' END,
   value * 10.25
 FROM generate_series(1, 1000) AS value;
+
+CREATE TABLE bulk_account (
+  id bigint PRIMARY KEY,
+  email text NOT NULL UNIQUE,
+  status text NOT NULL CHECK (status IN ('active', 'suspended'))
+);

--- a/benchmarks/runtime-comparison/src/bulk.ts
+++ b/benchmarks/runtime-comparison/src/bulk.ts
@@ -1,0 +1,353 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { requireAdapterCapability } from "@typed-sql/core";
+import { mysqlBulk, sql as mysqlSql } from "@typed-sql/mysql";
+import { createMySql2Database } from "@typed-sql/mysql/mysql2";
+import { postgresCopy, sql as postgresSql } from "@typed-sql/postgres";
+import { createPgDatabase } from "@typed-sql/postgres/pg";
+import mysqlCallback from "mysql2";
+import mysql from "mysql2/promise";
+import pg from "pg";
+import * as pgCopyStreams from "pg-copy-streams";
+
+const postgresUrl = process.env.POSTGRES_URL ?? "postgresql://typed_sql:typed_sql@127.0.0.1:55432/typed_sql_benchmark";
+const mysqlUrl = process.env.MYSQL_URL ?? "mysql://typed_sql:typed_sql@127.0.0.1:53306/typed_sql_benchmark";
+const samples = positiveInteger("BULK_BENCHMARK_SAMPLES", 3);
+const warmups = positiveInteger("BULK_BENCHMARK_WARMUPS", 1);
+const rowCounts = positiveIntegerList("BULK_BENCHMARK_ROW_COUNTS", [100, 1_000, 5_000]);
+
+interface AccountInput {
+  readonly id: bigint;
+  readonly email: string;
+  readonly status: "active" | "suspended";
+}
+
+interface BulkCandidate {
+  readonly database: "postgres" | "mysql";
+  readonly strategy: "bulk" | "batch" | "pipeline" | "direct-driver";
+  readonly name: string;
+  reset(): Promise<void>;
+  execute(rows: readonly AccountInput[]): Promise<void>;
+  count(): Promise<number>;
+}
+
+interface BulkMeasurement {
+  readonly database: BulkCandidate["database"];
+  readonly strategy: BulkCandidate["strategy"];
+  readonly name: string;
+  readonly rows: number;
+  readonly samples: number;
+  readonly milliseconds: {
+    readonly p50: number;
+    readonly p95: number;
+    readonly minimum: number;
+    readonly maximum: number;
+  };
+  readonly rowsPerSecond: number;
+}
+
+function positiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isSafeInteger(value) || value < 1) throw new TypeError(`${name} must be a positive integer`);
+  return value;
+}
+
+function positiveIntegerList(name: string, fallback: readonly number[]): readonly number[] {
+  const source = process.env[name];
+  const values = source === undefined ? [...fallback] : source.split(",").map((value) => Number(value.trim()));
+  if (values.length === 0 || values.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    throw new TypeError(`${name} must be a comma-separated list of positive integers`);
+  }
+  return Object.freeze([...new Set(values)].sort((left, right) => left - right));
+}
+
+function percentile(sorted: readonly number[], ratio: number): number {
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
+}
+
+function inputRows(count: number): readonly AccountInput[] {
+  return Array.from({ length: count }, (_, index) => {
+    const id = BigInt(index + 1);
+    return {
+      id,
+      email: `bulk-${id}@example.com`,
+      status: index % 5 === 0 ? "suspended" : "active",
+    };
+  });
+}
+
+function postgresRowQuery(row: AccountInput) {
+  return postgresSql`
+    INSERT INTO bulk_account (id, email, status)
+    VALUES (${row.id}, ${row.email}, ${row.status})
+  `;
+}
+
+function mysqlRowQuery(row: AccountInput) {
+  return mysqlSql`
+    INSERT INTO bulk_account (id, email, status)
+    VALUES (${row.id}, ${row.email}, ${row.status})
+  `;
+}
+
+function tabRows(rows: readonly AccountInput[]): Readable {
+  return Readable.from(
+    rows.map((row) => `${row.id}\t${row.email}\t${row.status}\n`),
+    { objectMode: false },
+  );
+}
+
+async function measure(candidate: BulkCandidate, rows: readonly AccountInput[]): Promise<BulkMeasurement> {
+  const executeOnce = async (): Promise<number> => {
+    await candidate.reset();
+    const start = performance.now();
+    await candidate.execute(rows);
+    const duration = performance.now() - start;
+    const actual = await candidate.count();
+    if (actual !== rows.length) {
+      throw new Error(`${candidate.name} inserted ${actual} rows; expected ${rows.length}`);
+    }
+    return duration;
+  };
+
+  for (let index = 0; index < warmups; index += 1) await executeOnce();
+  const durations: number[] = [];
+  for (let index = 0; index < samples; index += 1) durations.push(await executeOnce());
+  durations.sort((left, right) => left - right);
+  const p50 = percentile(durations, 0.5);
+  return {
+    database: candidate.database,
+    strategy: candidate.strategy,
+    name: candidate.name,
+    rows: rows.length,
+    samples,
+    milliseconds: {
+      p50,
+      p95: percentile(durations, 0.95),
+      minimum: durations[0] ?? 0,
+      maximum: durations.at(-1) ?? 0,
+    },
+    rowsPerSecond: (rows.length * 1_000) / p50,
+  };
+}
+
+const rawPgPool = new pg.Pool({ connectionString: postgresUrl, max: 1 });
+const typedPostgres = await createPgDatabase({
+  connectionString: postgresUrl,
+  poolConfig: { max: 1, pipeline: true },
+  copyStreamsImporter: async () => pgCopyStreams,
+});
+const postgresBulk = requireAdapterCapability(typedPostgres, postgresCopy);
+
+const rawMysqlPool = mysql.createPool({ uri: mysqlUrl, connectionLimit: 1 });
+const rawMysqlBulkPool = mysqlCallback.createPool(mysqlUrl);
+const typedMysql = await createMySql2Database({ connectionUri: mysqlUrl, poolConfig: { connectionLimit: 1 } });
+const mysqlBulkCapability = requireAdapterCapability(typedMysql, mysqlBulk);
+
+const resetPostgres = async (): Promise<void> => {
+  await rawPgPool.query("TRUNCATE TABLE bulk_account");
+};
+const resetMysql = async (): Promise<void> => {
+  await rawMysqlPool.query("TRUNCATE TABLE bulk_account");
+};
+const countPostgres = async (): Promise<number> =>
+  Number(
+    (await rawPgPool.query<{ readonly count: string }>("SELECT COUNT(*) AS count FROM bulk_account")).rows[0]?.count,
+  );
+const countMysql = async (): Promise<number> => {
+  const [result] = await rawMysqlPool.query("SELECT COUNT(*) AS count FROM bulk_account");
+  return Number((result as unknown as readonly { readonly count: number }[])[0]?.count);
+};
+
+const candidates: readonly BulkCandidate[] = [
+  {
+    database: "postgres",
+    strategy: "bulk",
+    name: "typed-sql COPY FROM",
+    reset: resetPostgres,
+    execute: async (rows) => {
+      await postgresBulk.copyFrom(postgresRowQuery, rows);
+    },
+    count: countPostgres,
+  },
+  {
+    database: "postgres",
+    strategy: "batch",
+    name: "typed-sql ordered batch",
+    reset: resetPostgres,
+    execute: async (rows) => {
+      await typedPostgres.batch(rows.map(postgresRowQuery));
+    },
+    count: countPostgres,
+  },
+  {
+    database: "postgres",
+    strategy: "pipeline",
+    name: "typed-sql native pipeline",
+    reset: resetPostgres,
+    execute: async (rows) => {
+      await typedPostgres.pipeline(rows.map(postgresRowQuery));
+    },
+    count: countPostgres,
+  },
+  {
+    database: "postgres",
+    strategy: "direct-driver",
+    name: "raw pg-copy-streams",
+    reset: resetPostgres,
+    execute: async (rows) => {
+      const client = await rawPgPool.connect();
+      try {
+        const sink = client.query(
+          pgCopyStreams.from("COPY bulk_account (id, email, status) FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')"),
+        );
+        await pipeline(tabRows(rows), sink);
+      } finally {
+        client.release();
+      }
+    },
+    count: countPostgres,
+  },
+  {
+    database: "postgres",
+    strategy: "direct-driver",
+    name: "raw pg named inserts",
+    reset: resetPostgres,
+    execute: async (rows) => {
+      const client = await rawPgPool.connect();
+      try {
+        for (const row of rows) {
+          await client.query({
+            name: "bulk-benchmark-account-insert",
+            text: "INSERT INTO bulk_account (id, email, status) VALUES ($1, $2, $3)",
+            values: [row.id, row.email, row.status],
+          });
+        }
+      } finally {
+        client.release();
+      }
+    },
+    count: countPostgres,
+  },
+  {
+    database: "mysql",
+    strategy: "bulk",
+    name: "typed-sql LOAD DATA",
+    reset: resetMysql,
+    execute: async (rows) => {
+      await mysqlBulkCapability.loadData(mysqlRowQuery, rows);
+    },
+    count: countMysql,
+  },
+  {
+    database: "mysql",
+    strategy: "batch",
+    name: "typed-sql ordered batch",
+    reset: resetMysql,
+    execute: async (rows) => {
+      await typedMysql.batch(rows.map(mysqlRowQuery));
+    },
+    count: countMysql,
+  },
+  {
+    database: "mysql",
+    strategy: "direct-driver",
+    name: "raw mysql2 LOAD DATA",
+    reset: resetMysql,
+    execute: (rows) =>
+      new Promise<void>((resolve, reject) => {
+        rawMysqlBulkPool.query(
+          {
+            sql: "LOAD DATA LOCAL INFILE 'typed-sql-benchmark' INTO TABLE bulk_account CHARACTER SET utf8mb4 FIELDS TERMINATED BY '\\t' LINES TERMINATED BY '\\n' (id, email, status)",
+            infileStreamFactory(path) {
+              if (path !== "typed-sql-benchmark") throw new Error(`Unexpected local infile path: ${path}`);
+              return tabRows(rows);
+            },
+          },
+          (error) => {
+            if (error === null) resolve();
+            else reject(error);
+          },
+        );
+      }),
+    count: countMysql,
+  },
+  {
+    database: "mysql",
+    strategy: "direct-driver",
+    name: "raw mysql2 execute inserts",
+    reset: resetMysql,
+    execute: async (rows) => {
+      const connection = await rawMysqlPool.getConnection();
+      try {
+        for (const row of rows) {
+          await connection.execute("INSERT INTO bulk_account (id, email, status) VALUES (?, ?, ?)", [
+            row.id.toString(),
+            row.email,
+            row.status,
+          ]);
+        }
+      } finally {
+        connection.release();
+      }
+    },
+    count: countMysql,
+  },
+];
+
+const results: BulkMeasurement[] = [];
+try {
+  for (const count of rowCounts) {
+    const rows = inputRows(count);
+    for (const candidate of candidates) {
+      process.stdout.write(`Measuring ${candidate.database}/${candidate.name}/${count} rows... `);
+      const result = await measure(candidate, rows);
+      results.push(result);
+      console.log(`${result.milliseconds.p50.toFixed(2)} ms p50`);
+    }
+  }
+} finally {
+  await Promise.allSettled([
+    rawPgPool.end(),
+    typedPostgres.close(),
+    rawMysqlPool.end(),
+    typedMysql.close(),
+    new Promise<void>((resolve, reject) => {
+      rawMysqlBulkPool.end((error) => {
+        if (error === undefined) resolve();
+        else reject(error);
+      });
+    }),
+  ]);
+}
+
+const output = {
+  generatedAt: new Date().toISOString(),
+  environment: {
+    node: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    rowCounts,
+    samples,
+    warmups,
+  },
+  results,
+};
+const root = fileURLToPath(new URL("..", import.meta.url));
+await mkdir(new URL("../results", import.meta.url), { recursive: true });
+await writeFile(new URL("../results/bulk-latest.json", import.meta.url), `${JSON.stringify(output, null, 2)}\n`);
+console.table(
+  results.map((result) => ({
+    database: result.database,
+    strategy: result.strategy,
+    library: result.name,
+    rows: result.rows,
+    "p50 (ms)": result.milliseconds.p50.toFixed(2),
+    "p95 (ms)": result.milliseconds.p95.toFixed(2),
+    "rows/s": result.rowsPerSecond.toFixed(0),
+  })),
+);
+console.log(`Machine-readable bulk results: ${root}results/bulk-latest.json`);

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -33,9 +33,9 @@ Adapter microbenchmarks are tracking baselines rather than database latency clai
 
 ## Driver and ORM comparison
 
-The repository also contains an [isolated runtime comparison](https://github.com/Lojhan/typed-sql/tree/main/benchmarks/runtime-comparison) against raw `pg`, raw `mysql2`, Drizzle, Kysely, Prisma, and TypeORM. It runs one indexed lookup against fixed PostgreSQL and MySQL containers and reports ordinary request paths separately from comparable prepared paths.
+The repository also contains an [isolated runtime comparison](https://github.com/Lojhan/typed-sql/tree/main/benchmarks/runtime-comparison) against raw `pg`, raw `mysql2`, Drizzle, Kysely, Prisma, and TypeORM. Its indexed-lookup workload reports ordinary request paths separately from comparable prepared paths. A second real-database workload measures PostgreSQL COPY, pipeline, ordered batch, and direct-driver inserts plus MySQL LOAD DATA, ordered batch, and direct-driver inserts across multiple row counts.
 
-Generated comparison results are not committed. They depend on the machine, database transport, operating-system scheduling, and dependency versions. The durable public artifact is the pinned fixture and its methodology, which lets maintainers and users reproduce a result on the hardware that matters to them.
+Generated comparison results are not committed. They depend on the machine, database transport, operating-system scheduling, and dependency versions. The durable public artifact is the pinned fixture and its methodology, which lets maintainers and users reproduce a result on the hardware that matters to them. Bulk samples time ingestion only, verify committed row counts outside the timed region, and keep every protocol dependency application-owned.
 
 At runtime, interpolation-free fragment templates may reuse their complete immutable value at the same JavaScript callsite. Query templates and parameterized fragments reuse only immutable text segments; their containing query and value segments remain isolated per call so one invocation cannot retain another invocation's execution metadata or parameters.
 

--- a/docs/dialects/mysql.md
+++ b/docs/dialects/mysql.md
@@ -47,6 +47,18 @@ The adapter controls mysql2 options that affect row shape and decoding. Supplyin
 
 The runtime constructors and mysql2 adapter accept a grammar-neutral `observer`. Query, prepared-query, batch, stream, cancellation, and nested-transaction lifecycles carry MySQL compiler-compatible fingerprints without exposing SQL or values. See [Observe database work](../guides/observability.md).
 
+## Bulk transfer
+
+The package root exports the `mysqlBulk` capability token. The mysql2 adapter implements
+`loadData()` with `LOAD DATA LOCAL INFILE`, but supplies the infile stream from the application's
+typed row source and rejects every path except its fixed internal sentinel. It never opens an
+arbitrary local or server-provided path. The MySQL server must explicitly enable `local_infile`.
+
+The input remains an ordinary typed single-row `INSERT` factory. Stable text-safe scalar values use
+an escaped UTF-8 tab stream with bounded buffering. Binary, structured, and connection-timezone
+dependent Date values fail closed and should use normal parameter execution. No native bulk export capability is claimed. See
+[Transfer bulk data](../guides/bulk-data.md).
+
 ## Streaming
 
 MySQL streaming uses mysql2's protocol-backed execute stream and does not require another package. `batchSize` maps to the object-mode high-water mark, so it controls client-side buffering rather than server cursor page size.

--- a/docs/dialects/postgresql.md
+++ b/docs/dialects/postgresql.md
@@ -57,6 +57,18 @@ The runtime constructors and `pg` adapter accept a grammar-neutral `observer`. Q
 
 `database.pipeline(queries)` is the explicit lower-latency alternative for independent PostgreSQL statements. It requires `pg` 8.23.0 or newer. Enable node-postgres's public pipeline mode through `poolConfig: { pipeline: true }` or an application-created `Pool({ pipeline: true })`. The adapter checks the leased client's public `pipeline` flag, dispatches every typed query before awaiting results, and preserves exact tuple order and prepared names. It waits for all responses before releasing the client. Because later statements are already in flight, pipeline failure semantics are intentionally different from `batch()`: dispatch does not stop at the first server error. Root pipelines are non-atomic; transaction pipelines are atomic only through the surrounding PostgreSQL transaction.
 
+## Bulk transfer
+
+The package root exports the `postgresCopy` capability token. Applications that use it install
+`pg-copy-streams` beside `pg`; ordinary execution and cursor streaming do not load that optional
+package. `copyFrom()` derives PostgreSQL COPY FROM STDIN from a typed single-row `INSERT` factory,
+while `copyTo()` streams raw CSV bytes from a static typed `SELECT`.
+
+Both directions use client STDIN or STDOUT streams. The adapter never accepts a server filesystem
+path or `PROGRAM`, applies native backpressure, and owns connection cleanup for completion,
+cancellation, early export return, producer failure, and server rejection. See
+[Transfer bulk data](../guides/bulk-data.md).
+
 ## Streaming
 
 Install `pg-cursor` only in applications that call `stream()`:

--- a/docs/guides/bulk-data.md
+++ b/docs/guides/bulk-data.md
@@ -1,0 +1,182 @@
+---
+title: Transfer bulk data
+description: Stream typed rows through optional PostgreSQL COPY and MySQL LOAD DATA adapter capabilities.
+---
+
+# Transfer bulk data
+
+Bulk transfer is an optional adapter capability. It does not change the `sql` tag into a query
+builder and it does not add database protocols to the grammar-neutral `Database` interface.
+Applications discover the capability they need, while each dialect owns its native protocol and
+failure semantics.
+
+The input contract is an ordinary typed, single-row `INSERT` factory. The compiler therefore checks
+the target columns, their order, nullability, scalar types, and every interpolated value using the
+same schema evidence as normal execution.
+
+## Import rows with PostgreSQL COPY
+
+Install the protocol stream beside the `pg` driver in the application:
+
+```sh
+pnpm add pg pg-copy-streams
+```
+
+```ts
+import { requireAdapterCapability } from "@typed-sql/core";
+import { postgresCopy, sql } from "@typed-sql/postgres";
+import { createPgDatabase } from "@typed-sql/postgres/pg";
+
+const database = await createPgDatabase({
+  connectionString: process.env.DATABASE_URL!,
+  // Resolve the application-owned package from the application's module graph.
+  copyStreamsImporter: () => import("pg-copy-streams"),
+});
+
+const copy = requireAdapterCapability(database, postgresCopy);
+
+interface AccountInput {
+  readonly id: bigint;
+  readonly email: string;
+  readonly note: string | null;
+}
+
+const accountInsert = (row: AccountInput) => sql`
+  INSERT INTO account (id, email, note)
+  VALUES (${row.id}, ${row.email}, ${row.note})
+`;
+
+const result = await copy.copyFrom(accountInsert, accountSource(), {
+  chunkBytes: 64 * 1024,
+  onProgress(progress) {
+    console.log(progress.rows, progress.bytes);
+  },
+});
+```
+
+`copyFrom()` accepts an `Iterable` or `AsyncIterable`, pulls it under native stream backpressure,
+and keeps only a bounded encoded chunk in memory. The first query compiles the target table,
+explicit column list, and structural SQL skeleton. Every later row must produce the same statement
+shape. A conditional table, column, identifier, or fragment fails before that row is sent.
+
+The factory must produce a plain single-row `INSERT` with one ordered parameter for each explicit
+target column and no `RETURNING` clause. Values use PostgreSQL text input forms compatible with
+ordinary typed-sql inputs, including bigint, finite numbers, booleans, dates, JSON values, arrays,
+and `Uint8Array` bytea values. Unsupported JavaScript values fail closed.
+
+Progress describes rows encoded and bytes yielded to the native stream. It is not a commit receipt.
+Only the fulfilled `copyFrom()` result confirms that PostgreSQL accepted the complete transfer; an
+outer transaction controls commit.
+
+### Export raw PostgreSQL CSV
+
+`copyTo()` accepts a static typed `SELECT` with no parameters and returns a lazy
+`QueryStream<Uint8Array>`:
+
+```ts
+const output = copy.copyTo(sql`
+  SELECT account.id, account.email, account.note
+  FROM account
+  ORDER BY account.id
+`);
+
+for await (const chunk of output) {
+  await destination.write(chunk);
+}
+```
+
+The query remains compiler-checked, but COPY returns PostgreSQL CSV bytes rather than decoded row
+objects. A `break`, explicit `close()`, or async disposal stops the native stream and settles its
+connection lease.
+
+## Import rows with MySQL LOAD DATA
+
+The mysql2 adapter provides an application-stream-only `LOAD DATA LOCAL INFILE` capability. The
+application already owns its `mysql2` dependency; no additional protocol package is required.
+MySQL must explicitly allow local infile requests, for example through the server's
+`local_infile=ON` setting.
+
+```ts
+import { requireAdapterCapability } from "@typed-sql/core";
+import { mysqlBulk, sql } from "@typed-sql/mysql";
+import { createMySql2Database } from "@typed-sql/mysql/mysql2";
+
+const database = await createMySql2Database({
+  connectionUri: process.env.DATABASE_URL!,
+});
+const bulk = requireAdapterCapability(database, mysqlBulk);
+
+interface AccountInput {
+  readonly id: bigint;
+  readonly email: string;
+  readonly note: string | null;
+}
+
+const accountInsert = (row: AccountInput) => sql`
+  INSERT INTO account (id, email, note)
+  VALUES (${row.id}, ${row.email}, ${row.note})
+`;
+
+const result = await bulk.loadData(accountInsert, accountSource(), {
+  chunkBytes: 64 * 1024,
+});
+```
+
+The adapter supplies mysql2's `infileStreamFactory` itself and accepts only typed-sql's internal
+sentinel path. It never opens a path requested by the server. Rows use an escaped UTF-8 tab format;
+null is encoded distinctly from an empty string. Strings, bigint, finite numbers, and booleans use
+the same stable scalar forms as ordinary execution. Date encoding depends on mysql2's connection
+timezone, while binary and structured parameters have type-specific driver behavior; those values
+are deliberately rejected in bulk text mode. Use ordinary parameterized execution when exact
+driver encoding is required.
+
+MySQL bulk export is not exposed because the selected adapter has no equally safe, application-owned
+counterpart to PostgreSQL COPY TO. Use a typed query stream for large MySQL result sets.
+
+## Transactions, cancellation, and failures
+
+Resolve the capability from the transaction object to reuse its checked-out connection:
+
+```ts
+await database.transaction(async (transaction) => {
+  const bulk = requireAdapterCapability(transaction, postgresCopy);
+  await bulk.copyFrom(accountInsert, rows);
+});
+```
+
+Always await bulk work before the transaction callback returns. While a native bulk protocol owns
+the transaction connection, typed-sql rejects competing queries, batches, pipelines, streams, and
+nested transactions.
+
+Cancellation, a producer error, a database rejection, or native stream failure prevents a root
+connection from returning to the reusable pool when its protocol state is uncertain. Inside a
+transaction, the scope is invalidated and rolls back. An asynchronous producer should observe the
+same `AbortSignal` when it performs its own cancellable I/O; JavaScript cannot forcibly interrupt an
+arbitrary pending `iterator.next()` promise.
+
+An empty input returns `{ rows: 0, bytes: 0 }` without loading the optional protocol package or
+leasing a connection.
+
+## Capability discovery
+
+Generic infrastructure can inspect a capability without importing a driver:
+
+```ts
+import { getAdapterCapability } from "@typed-sql/core";
+import { postgresCopy } from "@typed-sql/postgres";
+
+const copy = getAdapterCapability(database, postgresCopy);
+if (copy !== undefined) {
+  await copy.copyFrom(accountInsert, rows);
+}
+```
+
+`requireAdapterCapability()` throws `UnsupportedAdapterCapabilityError` with code
+`TSQL_UNSUPPORTED_ADAPTER_CAPABILITY` when the selected adapter does not advertise the token.
+The official PostgreSQL adapter advertises COPY before loading `pg-copy-streams`; if the application
+did not install it, the first COPY operation instead reports the exact install command without
+leasing a connection.
+
+Capability tokens are namespaced, immutable, and based on stable global symbols. Adapter authors
+can define additional services with `defineAdapterCapability()` and install them through the
+grammar-neutral resolver contract without widening every database implementation.

--- a/docs/guides/execution.md
+++ b/docs/guides/execution.md
@@ -114,7 +114,7 @@ All three retain the query's inferred row type. Cardinality is checked after the
 
 Inspect `database.executionCapabilities` before accepting optional controls in adapter-generic infrastructure. The official `pg` and `mysql2` adapters advertise cancellation and deadlines. A custom adapter that cannot safely interrupt work reports the unsupported capability immediately. `execute(query)` and `all(query)` without controls retain the existing thin buffered path.
 
-Execution options intentionally do not alter `batch()`, PostgreSQL `pipeline()`, or `stream()`. Those APIs own multiple operations or a longer-lived resource and keep their documented cleanup semantics.
+Execution options intentionally do not alter `batch()`, PostgreSQL `pipeline()`, or `stream()`. Those APIs own multiple operations or a longer-lived resource and keep their documented cleanup semantics. Optional PostgreSQL COPY and MySQL LOAD DATA capabilities accept their own execution options; see [Transfer bulk data](./bulk-data.md).
 
 ## Prepare repeated queries
 
@@ -169,6 +169,12 @@ const [accounts, projects] = await database.transaction((transaction) =>
 Always await a transaction batch before returning from its callback. The adapters reject escaped or concurrent batch work rather than allowing queries to run after commit or connection release.
 
 The surrounding database's transaction rules still apply. For example, MySQL statements that implicitly commit cannot be made atomic by placing them in a batch.
+
+For high-volume ingestion, do not emulate a bulk protocol with a larger batch. PostgreSQL COPY and
+MySQL LOAD DATA have distinct dependencies, wire behavior, encoding, and security constraints, so
+they are exposed through optional dialect-owned capabilities. The [bulk data guide](./bulk-data.md)
+starts from an ordinary typed `INSERT` factory and explains backpressure, transaction ownership,
+cancellation, and export behavior.
 
 ## Pipeline independent PostgreSQL queries
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -57,6 +57,21 @@ The declarations contain an internal `sql.__typed` member used by compiler overl
 
 Most applications use `createPgDatabase` or `createMySql2Database` rather than constructing a neutral adapter directly.
 
+### Optional adapter capabilities
+
+`defineAdapterCapability<Service>(id)` creates an immutable namespaced token for functionality that
+does not belong on every database. `getAdapterCapability(host, token)` returns the typed service or
+`undefined`; `requireAdapterCapability(host, token)` returns it or throws
+`UnsupportedAdapterCapabilityError` with code `TSQL_UNSUPPORTED_ADAPTER_CAPABILITY`.
+
+Official dialect tokens include `postgresCopy` for PostgreSQL COPY FROM/TO and `mysqlBulk` for MySQL
+LOAD DATA. Their services are available on both root databases and transaction scopes when the
+selected adapter supports them. Driver and protocol types remain outside `@typed-sql/core`; see
+[Transfer bulk data](../guides/bulk-data.md).
+
+Adapter authors install services with `adapterCapabilities` and
+`createAdapterCapabilityResolver()`. Capability IDs must be namespaced and globally unique.
+
 ### Semantic routing and transaction retry
 
 `createRoutedDatabase(options)` composes application-owned databases through a grammar-neutral `QuerySemanticResolver`. The PostgreSQL and MySQL roots expose `createPostgresRoutedDatabase()` and `createMySqlRoutedDatabase()` with dialect resolvers configured from a schema snapshot.

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -2,8 +2,21 @@ import { spawn } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart, Query } from "@typed-sql/core";
-import { createMySqlRoutedDatabase, type MySqlSchemaSnapshot, mysql, sql, typePolicy } from "@typed-sql/mysql";
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  type DatabaseOperationStart,
+  type Query,
+  requireAdapterCapability,
+} from "@typed-sql/core";
+import {
+  createMySqlRoutedDatabase,
+  type MySqlSchemaSnapshot,
+  mysql,
+  mysqlBulk,
+  sql,
+  typePolicy,
+} from "@typed-sql/mysql";
 import { createMySql2Database } from "@typed-sql/mysql/mysql2";
 import { analyzeSource } from "@typed-sql/ts-bridge";
 import { NativePreviewTypeScriptBridge } from "@typed-sql/ts-bridge/native-preview";
@@ -98,6 +111,7 @@ try {
     "--env",
     "MYSQL_ROOT_PASSWORD=typed_sql_root",
     imageName,
+    "--local-infile=ON",
   ]);
   containerStarted = true;
   try {
@@ -576,6 +590,67 @@ try {
           strict.ok(!("values" in operation));
           strict.ok(!("connectionUri" in operation));
         }
+      } finally {
+        await database.close();
+      }
+    });
+
+    await it("loads typed rows through mysql2's application-owned local infile stream", async () => {
+      const database = await createMySql2Database({
+        connectionUri,
+        typePolicy,
+        poolConfig: { connectionLimit: 1 },
+      });
+      try {
+        await database.execute(sql`
+          CREATE TABLE bulk_accounts (
+            id BIGINT PRIMARY KEY,
+            email VARCHAR(255) NOT NULL,
+            note TEXT
+          )
+        `);
+        const bulk = requireAdapterCapability(database, mysqlBulk);
+        const rowQuery = (row: { readonly id: bigint; readonly email: string; readonly note: string | null }) =>
+          sql`INSERT INTO bulk_accounts (id, email, note) VALUES (${row.id}, ${row.email}, ${row.note})`;
+        const loaded = await bulk.loadData(rowQuery, [
+          { id: 1n, email: "one@example.com", note: null },
+          { id: 2n, email: "two\texample.com", note: "line\nbreak\\tail" },
+        ]);
+        strict.strictEqual(loaded.rows, 2);
+        strict.ok(loaded.bytes > 0);
+
+        await database.transaction(async (transaction) => {
+          await requireAdapterCapability(transaction, mysqlBulk).loadData(rowQuery, [
+            { id: 3n, email: "three@example.com", note: "committed" },
+          ]);
+        });
+
+        strict.deepStrictEqual(
+          await database.execute(
+            sql<{
+              readonly id: bigint;
+              readonly email: string;
+              readonly note: string | null;
+            }>`SELECT id, email, note FROM bulk_accounts ORDER BY id`,
+          ),
+          [
+            { id: 1n, email: "one@example.com", note: null },
+            { id: 2n, email: "two\texample.com", note: "line\nbreak\\tail" },
+            { id: 3n, email: "three@example.com", note: "committed" },
+          ],
+        );
+
+        const producerError = new Error("producer failed");
+        async function* failedRows() {
+          yield { id: 4n, email: "four@example.com", note: null };
+          throw producerError;
+        }
+        await strict.rejects(() => bulk.loadData(rowQuery, failedRows()), producerError);
+        strict.deepStrictEqual(
+          await database.execute(sql<{ readonly total: bigint }>`SELECT COUNT(*) AS total FROM bulk_accounts`),
+          [{ total: 3n }],
+        );
+        await database.execute(sql`DROP TABLE bulk_accounts`);
       } finally {
         await database.close();
       }

--- a/e2e/postgres/package.json
+++ b/e2e/postgres/package.json
@@ -16,6 +16,7 @@
     "@typed-sql/postgres": "workspace:*",
     "@typed-sql/ts-bridge": "workspace:*",
     "pg": "8.23.0",
+    "pg-copy-streams": "7.0.0",
     "pg-cursor": "2.22.0"
   },
   "devDependencies": {

--- a/e2e/postgres/test/developer-flow.e2e.test.ts
+++ b/e2e/postgres/test/developer-flow.e2e.test.ts
@@ -2,11 +2,17 @@ import { spawn } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart } from "@typed-sql/core";
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  type DatabaseOperationStart,
+  requireAdapterCapability,
+} from "@typed-sql/core";
 import {
   createPostgresRoutedDatabase,
   type PostgresSchemaSnapshot,
   postgres,
+  postgresCopy,
   sql,
   typePolicy,
 } from "@typed-sql/postgres";
@@ -50,6 +56,7 @@ interface GeneratedSnapshot {
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workspaceDirectory = resolve(packageDirectory, "../..");
 const pgCursorPackage: string = "pg-cursor";
+const pgCopyStreamsPackage: string = "pg-copy-streams";
 const generatedDirectory = join(packageDirectory, "generated");
 const generatedDatabaseDirectory = join(generatedDirectory, "db");
 const generatedSnapshotPath = join(generatedDatabaseDirectory, "schema.json");
@@ -714,6 +721,61 @@ try {
           strict.ok(!("values" in operation));
           strict.ok(!("connectionString" in operation));
         }
+      } finally {
+        await database.close();
+      }
+    });
+
+    await it("imports and exports typed rows through application-owned PostgreSQL COPY", async () => {
+      const database = await createPgDatabase({
+        connectionString,
+        typePolicy,
+        poolConfig: { max: 1, connectionTimeoutMillis: 2_000 },
+        copyStreamsImporter: () => import(pgCopyStreamsPackage),
+      });
+      try {
+        await database.execute(sql`
+          CREATE TABLE bulk_accounts (
+            id BIGINT PRIMARY KEY,
+            email TEXT NOT NULL,
+            note TEXT
+          )
+        `);
+        const copy = requireAdapterCapability(database, postgresCopy);
+        const rowQuery = (row: { readonly id: bigint; readonly email: string; readonly note: string | null }) =>
+          sql`INSERT INTO bulk_accounts (id, email, note) VALUES (${row.id}, ${row.email}, ${row.note})`;
+        const imported = await copy.copyFrom(rowQuery, [
+          { id: 1n, email: "one@example.com", note: null },
+          { id: 2n, email: 'two,"quoted"@example.com', note: "line\nbreak" },
+        ]);
+        strict.strictEqual(imported.rows, 2);
+        strict.ok(imported.bytes > 0);
+
+        await database.transaction(async (transaction) => {
+          const transactionalCopy = requireAdapterCapability(transaction, postgresCopy);
+          await transactionalCopy.copyFrom(rowQuery, [{ id: 3n, email: "three@example.com", note: "committed" }]);
+        });
+
+        const exported: Uint8Array[] = [];
+        for await (const chunk of copy.copyTo(sql`SELECT id, email, note FROM bulk_accounts ORDER BY id`)) {
+          exported.push(chunk);
+        }
+        strict.strictEqual(
+          new TextDecoder().decode(Buffer.concat(exported)),
+          '1,one@example.com,\n2,"two,""quoted""@example.com","line\nbreak"\n3,three@example.com,committed\n',
+        );
+
+        const producerError = new Error("producer failed");
+        async function* failedRows() {
+          yield { id: 4n, email: "four@example.com", note: null };
+          throw producerError;
+        }
+        await strict.rejects(() => copy.copyFrom(rowQuery, failedRows()), producerError);
+        strict.deepStrictEqual(
+          await database.execute(sql<{ readonly total: bigint }>`SELECT COUNT(*) AS total FROM bulk_accounts`),
+          [{ total: 3n }],
+        );
+        await database.execute(sql`DROP TABLE bulk_accounts`);
       } finally {
         await database.close();
       }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,6 +31,10 @@ preserve the inferred row, accept optional signals or absolute deadlines, and ex
 cardinality and cancellation errors. Adapter capabilities are explicit; unsupported controls are
 never silently ignored.
 
+Optional adapter services use namespaced capability tokens rather than widening the common
+`Database` interface. `getAdapterCapability` and `requireAdapterCapability` preserve the service
+type without adding a protocol or driver dependency to core.
+
 `DatabaseObserver` provides redacted query, batch, pipeline, stream, cancellation, and nested
 transaction lifecycles. It is disabled by default and does not add a telemetry dependency to core.
 
@@ -45,7 +49,8 @@ database driver, TypeScript compiler, or editor dependency.
 
 Read the [query API](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/api.md),
 [architecture](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/architecture.md),
-[routing and retry guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/routing-and-retries.md), and
+[routing and retry guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/routing-and-retries.md),
+[bulk data guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/bulk-data.md), and
 [custom grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/extending/custom-grammars.md).
 
 MIT © typed-sql contributors

--- a/packages/core/src/adapter-capabilities.ts
+++ b/packages/core/src/adapter-capabilities.ts
@@ -1,0 +1,78 @@
+const adapterCapabilityBrand: unique symbol = Symbol("@typed-sql/core.adapter-capability") as never;
+
+/** A namespaced token describing one optional service exposed by a database adapter. */
+export interface AdapterCapability<Service> {
+  readonly id: string;
+  readonly key: symbol;
+  readonly [adapterCapabilityBrand]: () => Service;
+}
+
+export type AdapterCapabilityService<Capability> =
+  Capability extends AdapterCapability<infer Service> ? Service : never;
+
+export type AdapterCapabilityResolver = (key: symbol) => unknown;
+
+export const adapterCapabilities: unique symbol = Symbol.for("@typed-sql/core.adapter-capabilities") as never;
+
+/** Structural host contract implemented by adapters that provide optional services. */
+export interface AdapterCapabilityHost {
+  readonly [adapterCapabilities]?: AdapterCapabilityResolver;
+}
+
+export class UnsupportedAdapterCapabilityError extends Error {
+  readonly code = "TSQL_UNSUPPORTED_ADAPTER_CAPABILITY";
+  readonly capability: string;
+
+  constructor(capability: string) {
+    super(`This database adapter does not provide the ${capability} capability`);
+    this.name = "UnsupportedAdapterCapabilityError";
+    this.capability = capability;
+  }
+}
+
+/** Defines a globally stable, namespaced adapter capability token. */
+export function defineAdapterCapability<Service>(id: string): AdapterCapability<Service> {
+  if (id.length === 0 || !id.includes(".")) {
+    throw new TypeError("Adapter capability ids must be non-empty and namespaced, for example vendor.feature");
+  }
+  return Object.freeze({
+    id,
+    key: Symbol.for(`@typed-sql/adapter-capability/${id}`),
+    [adapterCapabilityBrand]: (): Service => {
+      throw new TypeError("Adapter capability type brands are not callable");
+    },
+  });
+}
+
+/** Creates the immutable resolver installed on one adapter or transaction scope. */
+export function createAdapterCapabilityResolver(
+  entries: readonly (readonly [AdapterCapability<unknown>, unknown])[],
+): AdapterCapabilityResolver {
+  const services = new Map<symbol, unknown>();
+  for (const [capability, service] of entries) {
+    if (services.has(capability.key)) throw new TypeError(`Duplicate adapter capability: ${capability.id}`);
+    services.set(capability.key, service);
+  }
+  return (key: symbol): unknown => services.get(key);
+}
+
+/** Returns an optional adapter service without importing its driver or protocol package. */
+export function getAdapterCapability<Service>(
+  host: unknown,
+  capability: AdapterCapability<Service>,
+): Service | undefined {
+  if ((typeof host !== "object" && typeof host !== "function") || host === null) return undefined;
+  const resolver = (host as AdapterCapabilityHost)[adapterCapabilities];
+  return resolver?.(capability.key) as Service | undefined;
+}
+
+export function hasAdapterCapability<Service>(host: unknown, capability: AdapterCapability<Service>): boolean {
+  return getAdapterCapability(host, capability) !== undefined;
+}
+
+/** Resolves an adapter service or throws a stable fail-closed error. */
+export function requireAdapterCapability<Service>(host: unknown, capability: AdapterCapability<Service>): Service {
+  const service = getAdapterCapability(host, capability);
+  if (service === undefined) throw new UnsupportedAdapterCapabilityError(capability.id);
+  return service;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,18 @@
+export type {
+  AdapterCapability,
+  AdapterCapabilityHost,
+  AdapterCapabilityResolver,
+  AdapterCapabilityService,
+} from "./adapter-capabilities.js";
+export {
+  adapterCapabilities,
+  createAdapterCapabilityResolver,
+  defineAdapterCapability,
+  getAdapterCapability,
+  hasAdapterCapability,
+  requireAdapterCapability,
+  UnsupportedAdapterCapabilityError,
+} from "./adapter-capabilities.js";
 export type { TypedSqlDiagnosticCode } from "./diagnostics.js";
 export { diagnosticRegistry, isTypedSqlDiagnosticCode } from "./diagnostics.js";
 export type {

--- a/packages/core/test/adapter-capabilities.test.ts
+++ b/packages/core/test/adapter-capabilities.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, strict } from "poku";
+import {
+  adapterCapabilities,
+  createAdapterCapabilityResolver,
+  defineAdapterCapability,
+  getAdapterCapability,
+  hasAdapterCapability,
+  requireAdapterCapability,
+  UnsupportedAdapterCapabilityError,
+} from "../src/index.js";
+
+interface ExampleService {
+  readonly execute: () => string;
+}
+
+await describe("adapter capabilities", async () => {
+  const example = defineAdapterCapability<ExampleService>("example.bulk");
+  const service: ExampleService = Object.freeze({ execute: () => "available" });
+  const host = {
+    [adapterCapabilities]: createAdapterCapabilityResolver([[example, service]]),
+  };
+
+  await it("discovers optional services without widening their type", () => {
+    strict.strictEqual(getAdapterCapability(host, example), service);
+    strict.strictEqual(requireAdapterCapability(host, example).execute(), "available");
+    strict.strictEqual(hasAdapterCapability(host, example), true);
+  });
+
+  await it("uses globally stable keys for separately defined tokens", () => {
+    const secondCopy = defineAdapterCapability<ExampleService>("example.bulk");
+    strict.strictEqual(getAdapterCapability(host, secondCopy), service);
+  });
+
+  await it("fails closed for absent capabilities", () => {
+    const missing = defineAdapterCapability<ExampleService>("example.missing");
+    strict.strictEqual(getAdapterCapability(host, missing), undefined);
+    strict.strictEqual(hasAdapterCapability({}, missing), false);
+    strict.throws(
+      () => requireAdapterCapability(host, missing),
+      (error) =>
+        error instanceof UnsupportedAdapterCapabilityError &&
+        error.code === "TSQL_UNSUPPORTED_ADAPTER_CAPABILITY" &&
+        error.capability === "example.missing",
+    );
+  });
+
+  await it("rejects ambiguous capability declarations", () => {
+    strict.throws(() => defineAdapterCapability<ExampleService>("bulk"), /namespaced/u);
+    strict.throws(
+      () =>
+        createAdapterCapabilityResolver([
+          [example, service],
+          [example, service],
+        ]),
+      /Duplicate adapter capability/u,
+    );
+  });
+});

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -13,7 +13,8 @@ pnpm add -D @typed-sql/cli typescript@7.0.2
 of the grammar.
 
 ```ts
-import { sql, typePolicy } from "@typed-sql/mysql";
+import { requireAdapterCapability } from "@typed-sql/core";
+import { mysqlBulk, sql, typePolicy } from "@typed-sql/mysql";
 import { createMySql2Database } from "@typed-sql/mysql/mysql2";
 
 const query = sql`
@@ -41,6 +42,13 @@ const [selectedAccounts, allAccounts] = await database.batch([accountById(42n), 
 for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
   // account retains the query's inferred row type
 }
+
+const bulk = requireAdapterCapability(database, mysqlBulk);
+await bulk.loadData(
+  (account: { readonly id: bigint; readonly email: string }) =>
+    sql`INSERT INTO users (id, email) VALUES (${account.id}, ${account.email})`,
+  accounts,
+);
 ```
 
 The package root exports `sql`, `mysql`, and the MySQL type policy. The `/mysql2` entrypoint exports
@@ -53,6 +61,7 @@ creating `mysql2` pools.
 
 Read the [MySQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/mysql.md),
 [execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
+[bulk data guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/bulk-data.md),
 [observability guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/observability.md),
 [live verification guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/live-verification.md),
 [query plan governance guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-plan-governance.md),

--- a/packages/mysql/src/bulk.ts
+++ b/packages/mysql/src/bulk.ts
@@ -1,0 +1,248 @@
+import { parseStatement } from "@typed-sql/ast";
+import {
+  bindQueryRenderSkeleton,
+  compileQueryRenderSkeleton,
+  defineAdapterCapability,
+  type ExecutionOptions,
+  type Query,
+  QueryCancelledError,
+  type SqlRenderer,
+} from "@typed-sql/core";
+
+const mysqlRenderer: SqlRenderer = Object.freeze({
+  placeholder: () => "?",
+  quoteIdentifier: (name: string) => `\`${name.replaceAll("`", "``")}\``,
+});
+
+export interface MySqlBulkProgress {
+  readonly rows: number;
+  readonly bytes: number;
+}
+
+export interface MySqlBulkResult extends MySqlBulkProgress {}
+
+export interface MySqlLoadDataOptions extends ExecutionOptions {
+  /** Preferred encoded chunk size. One unusually wide row may exceed it. */
+  readonly chunkBytes?: number;
+  readonly onProgress?: (progress: MySqlBulkProgress) => void;
+}
+
+export interface MySqlBulkTransport {
+  loadData(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void>;
+}
+
+export interface MySqlBulkCapability {
+  /** Compiles one typed INSERT factory into a client-streamed LOAD DATA LOCAL INFILE operation. */
+  loadData<Input, Row, Params extends readonly unknown[]>(
+    rowQuery: (input: Input) => Query<Row, Params>,
+    rows: Iterable<Input> | AsyncIterable<Input>,
+    options?: MySqlLoadDataOptions,
+  ): Promise<MySqlBulkResult>;
+}
+
+export const mysqlBulk = defineAdapterCapability<MySqlBulkCapability>("mysql.load-data");
+
+const encoder = new TextEncoder();
+const DEFAULT_CHUNK_BYTES = 64 * 1_024;
+
+function mysqlTextValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "boolean") return value ? "1" : "0";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new RangeError("MySQL LOAD DATA cannot encode non-finite numbers");
+    return String(value);
+  }
+  if (value instanceof Date) {
+    throw new TypeError(
+      "MySQL LOAD DATA text mode does not accept Date values because mysql2 timezone encoding is connection-specific; use ordinary execution",
+    );
+  }
+  if (value instanceof Uint8Array) {
+    throw new TypeError("MySQL LOAD DATA text mode does not accept binary values; use ordinary execution");
+  }
+  if (typeof value === "object" && value !== null) {
+    throw new TypeError(
+      "MySQL LOAD DATA text mode does not accept structured values because mysql2 parameter encoding is type-specific; use ordinary execution",
+    );
+  }
+  throw new TypeError(`MySQL LOAD DATA cannot encode ${typeof value} values`);
+}
+
+function escapedField(value: unknown): string {
+  if (value === null || value === undefined) return "\\N";
+  return mysqlTextValue(value)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\0", "\\0")
+    .replaceAll("\t", "\\t")
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r");
+}
+
+function encodedRow(values: readonly unknown[]): Uint8Array {
+  return encoder.encode(`${values.map(escapedField).join("\t")}\n`);
+}
+
+function chunkSize(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_CHUNK_BYTES;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError("MySQL LOAD DATA chunkBytes must be a positive safe integer");
+  }
+  return resolved;
+}
+
+function loadDataStatement(text: string, parameterCount: number): string {
+  const statement = parseStatement(text, { syntax: "mysql" });
+  if (
+    statement.kind !== "insert" ||
+    statement.with !== undefined ||
+    statement.table.alias !== undefined ||
+    statement.source.kind !== "values" ||
+    statement.source.rows.length !== 1 ||
+    statement.returning.length !== 0 ||
+    statement.columns.length === 0
+  ) {
+    throw new TypeError(
+      "MySQL LOAD DATA requires a plain single-row INSERT with an explicit column list and one VALUES row",
+    );
+  }
+  const values = statement.source.rows[0]!;
+  if (
+    values.length !== statement.columns.length ||
+    values.length !== parameterCount ||
+    values.some((expression, index) => expression.kind !== "parameter" || expression.index !== index + 1)
+  ) {
+    throw new TypeError("MySQL LOAD DATA INSERT values must be one ordered parameter per target column");
+  }
+  const quote = mysqlRenderer.quoteIdentifier;
+  const table = `${statement.table.schema === undefined ? "" : `${quote(statement.table.schema.name)}.`}${quote(statement.table.name.name)}`;
+  const columns = statement.columns.map(({ name }) => quote(name)).join(", ");
+  return `LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE ${table} CHARACTER SET utf8mb4 FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (${columns})`;
+}
+
+function cancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) throw new QueryCancelledError("signal", { cause: signal.reason });
+}
+
+function asyncIterator<Value>(values: Iterable<Value> | AsyncIterable<Value>): AsyncIterator<Value> {
+  if (Symbol.asyncIterator in Object(values)) return (values as AsyncIterable<Value>)[Symbol.asyncIterator]();
+  const iterator = (values as Iterable<Value>)[Symbol.iterator]();
+  return {
+    next: async () => iterator.next(),
+    ...(iterator.return === undefined ? {} : { return: async () => iterator.return!() }),
+  };
+}
+
+function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!;
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+export function createMySqlBulkCapability(transport: MySqlBulkTransport): MySqlBulkCapability {
+  return Object.freeze({
+    async loadData<Input, Row, Params extends readonly unknown[]>(
+      rowQuery: (input: Input) => Query<Row, Params>,
+      rows: Iterable<Input> | AsyncIterable<Input>,
+      options: MySqlLoadDataOptions = {},
+    ): Promise<MySqlBulkResult> {
+      const preferredChunkBytes = chunkSize(options.chunkBytes);
+      cancelled(options.signal);
+      const iterator = asyncIterator(rows);
+      let iteratorClosed = false;
+      const closeIterator = async (): Promise<void> => {
+        if (iteratorClosed || iterator.return === undefined) return;
+        iteratorClosed = true;
+        await iterator.return();
+      };
+      let first: IteratorResult<Input>;
+      try {
+        first = await iterator.next();
+      } catch (error) {
+        try {
+          await closeIterator();
+        } catch {
+          /* Preserve the producer failure. */
+        }
+        throw error;
+      }
+      if (first.done === true) return Object.freeze({ rows: 0, bytes: 0 });
+
+      let firstQuery: Query<Row, Params>;
+      let compiled: ReturnType<typeof compileQueryRenderSkeleton<Row, Params>>;
+      let statement: string;
+      try {
+        firstQuery = rowQuery(first.value);
+        compiled = compileQueryRenderSkeleton(firstQuery, mysqlRenderer);
+        statement = loadDataStatement(compiled.rendered.text, compiled.rendered.values.length);
+      } catch (error) {
+        try {
+          await closeIterator();
+        } catch {
+          /* Preserve the query compilation failure. */
+        }
+        throw error;
+      }
+      let rowCount = 0;
+      let byteCount = 0;
+      let inputComplete = false;
+
+      const chunks = (async function* (): AsyncGenerator<Uint8Array> {
+        let pending: Uint8Array[] = [];
+        let pendingBytes = 0;
+        let current: IteratorResult<Input> = first;
+        try {
+          while (current.done !== true) {
+            cancelled(options.signal);
+            const query = rowCount === 0 ? firstQuery : rowQuery(current.value);
+            const rendered = rowCount === 0 ? compiled.rendered : bindQueryRenderSkeleton(query, compiled.skeleton);
+            if (rendered === undefined)
+              throw new TypeError("MySQL LOAD DATA row query changed its structural SQL shape");
+            const encoded = encodedRow(rendered.values);
+            if (pendingBytes > 0 && pendingBytes + encoded.byteLength > preferredChunkBytes) {
+              const chunk = concatenate(pending, pendingBytes);
+              byteCount += chunk.byteLength;
+              options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+              yield chunk;
+              pending = [];
+              pendingBytes = 0;
+            }
+            pending.push(encoded);
+            pendingBytes += encoded.byteLength;
+            rowCount += 1;
+            current = await iterator.next();
+          }
+          inputComplete = true;
+          if (pendingBytes > 0) {
+            const chunk = concatenate(pending, pendingBytes);
+            byteCount += chunk.byteLength;
+            options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+            yield chunk;
+          }
+        } finally {
+          if (current.done !== true) await closeIterator();
+        }
+      })();
+
+      try {
+        await transport.loadData(statement, chunks, options);
+      } catch (error) {
+        if (!inputComplete) {
+          try {
+            await closeIterator();
+          } catch {
+            /* Preserve the transport, producer, or database failure. */
+          }
+        }
+        throw error;
+      }
+      if (!inputComplete) await closeIterator();
+      return Object.freeze({ rows: rowCount, bytes: byteCount });
+    },
+  });
+}

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -6,6 +6,13 @@ import { analyzeMySqlSemantics } from "./semantics.js";
 import { defaultMySqlTypePolicy, type MySqlTypePolicy } from "./type-policy.js";
 import { MYSQL_DIALECT_VERSION } from "./version.js";
 
+export type {
+  MySqlBulkCapability,
+  MySqlBulkProgress,
+  MySqlBulkResult,
+  MySqlLoadDataOptions,
+} from "./bulk.js";
+export { mysqlBulk } from "./bulk.js";
 export { MYSQL_DIALECT_VERSION } from "./version.js";
 export type MySqlSchemaSnapshot = SchemaSnapshot & { readonly dialect: "mysql" };
 

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
 import type { DatabaseObserver, LiveQueryVerifier, QueryPlanEvidence, QueryPlanInspector } from "@typed-sql/core";
 import type { Connection as CallbackConnection, Query as CallbackQuery } from "mysql2";
 import type { FieldPacket, Pool, PoolConnection, PoolOptions } from "mysql2/promise";
@@ -106,6 +107,16 @@ export interface MySql2PlanInspectorOptions {
 interface Executable {
   execute(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, (readonly FieldPacket[])?]>;
   query(sql: string, values?: readonly unknown[]): Promise<readonly [unknown, (readonly FieldPacket[])?]>;
+}
+
+interface MySql2LoadDataConnection {
+  query(
+    options: {
+      readonly sql: string;
+      readonly infileStreamFactory: (path: string) => Readable;
+    },
+    callback: (error: Error | null) => void,
+  ): CallbackQuery;
 }
 
 export async function loadMySql2Driver(
@@ -455,12 +466,41 @@ function connectionAdapter(connection: PoolConnection): MySqlConnectionLike {
         options.batchSize,
       ),
     query: (sql) => execute(executable, "query", sql),
+    loadData: (statement, chunks) =>
+      loadData(connection.connection as unknown as CallbackConnection, statement, chunks),
     beginTransaction: () => connection.beginTransaction(),
     commit: () => connection.commit(),
     rollback: () => connection.rollback(),
     destroy: () => connection.destroy(),
     release: () => connection.release(),
   };
+}
+
+function loadData(connection: CallbackConnection, statement: string, chunks: AsyncIterable<Uint8Array>): Promise<void> {
+  const source = Readable.from(
+    (async function* (): AsyncGenerator<Buffer> {
+      for await (const chunk of chunks) yield Buffer.from(chunk);
+    })(),
+    { objectMode: false },
+  );
+  return new Promise((resolve, reject) => {
+    const native = connection as unknown as MySql2LoadDataConnection;
+    native.query(
+      {
+        sql: statement,
+        infileStreamFactory(path) {
+          if (path !== "typed-sql-stream") {
+            throw new Error(`MySQL requested an unexpected local infile path: ${path}`);
+          }
+          return source;
+        },
+      },
+      (error) => {
+        if (error === null) resolve();
+        else reject(error);
+      },
+    );
+  });
 }
 
 function createMySql2ProtocolStream(
@@ -576,6 +616,7 @@ export function adaptMySql2Pool(pool: Pool): MySqlPoolLike {
   const executable = pool as unknown as Executable;
   return {
     executionCapabilities: Object.freeze({ cancellation: true, deadlines: true }),
+    bulkLoad: true,
     execute: (sql, values) => execute(executable, "execute", sql, values),
     async getConnection(): Promise<MySqlConnectionLike> {
       return connectionAdapter(await pool.getConnection());

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import {
+  type AdapterCapabilityResolver,
+  adapterCapabilities,
   assertExecutionCapabilities,
+  createAdapterCapabilityResolver,
   type Database,
   type DatabaseObserver,
   databaseErrorCompletion,
@@ -20,6 +23,7 @@ import {
   startDatabaseObservation,
   UnsupportedExecutionCapabilityError,
 } from "@typed-sql/core";
+import { createMySqlBulkCapability, type MySqlBulkTransport, mysqlBulk } from "./bulk.js";
 import {
   decodeMySqlRows,
   encodeMySqlValue,
@@ -49,6 +53,7 @@ export interface MySqlExecutionResult {
 export interface MySqlConnectionLike extends MySqlStreamingConnection {
   execute(sql: string, values?: readonly unknown[]): Promise<MySqlExecutionResult>;
   query(sql: string): Promise<MySqlExecutionResult>;
+  loadData?(statement: string, chunks: AsyncIterable<Uint8Array>): Promise<void>;
   beginTransaction(): Promise<void>;
   commit(): Promise<void>;
   rollback(): Promise<void>;
@@ -58,6 +63,7 @@ export interface MySqlConnectionLike extends MySqlStreamingConnection {
 
 export interface MySqlPoolLike {
   readonly executionCapabilities?: ExecutionCapabilities;
+  readonly bulkLoad?: boolean;
   execute(sql: string, values?: readonly unknown[]): Promise<MySqlExecutionResult>;
   getConnection(): Promise<MySqlConnectionLike>;
   end(): Promise<void>;
@@ -123,6 +129,7 @@ export const mysqlRenderer: SqlRenderer = Object.freeze({
 interface MySqlTransactionConnectionState {
   active: QueryStream<unknown> | undefined;
   batch: MySqlConnectionOperation | undefined;
+  bulk: MySqlConnectionOperation | undefined;
   execute: MySqlConnectionOperation | undefined;
   discarded: boolean;
   usable: boolean;
@@ -154,6 +161,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   readonly #transactionState: MySqlTransactionConnectionState | undefined;
   #scopeOpen = true;
   readonly executionCapabilities: ExecutionCapabilities;
+  readonly [adapterCapabilities]: AdapterCapabilityResolver;
 
   constructor(
     pool: MySqlPoolLike,
@@ -179,6 +187,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       cancellation: pool.executionCapabilities?.cancellation ?? false,
       deadlines: pool.executionCapabilities?.deadlines ?? false,
     });
+    const bulkTransport: MySqlBulkTransport = {
+      loadData: (statement, chunks, options) => this.#loadData(statement, chunks, options),
+    };
+    this[adapterCapabilities] = createAdapterCapabilityResolver(
+      pool.bulkLoad === true ? [[mysqlBulk, createMySqlBulkCapability(bulkTransport)]] : [],
+    );
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
@@ -472,6 +486,42 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     return exposedStream;
   }
 
+  async #loadData(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {
+    assertExecutionCapabilities(this.executionCapabilities, options);
+    this.#assertScopeOpen();
+    this.#assertConnectionAvailable("start LOAD DATA");
+    const connection = this.#connection ?? (await this.#pool.getConnection());
+    if (connection.loadData === undefined) {
+      if (this.#connection === undefined) connection.release();
+      throw new Error(
+        "MySQL LOAD DATA requires an adapter with an application-owned local infile stream implementation",
+      );
+    }
+    const state = createMySqlConnectionOperation();
+    if (this.#connection !== undefined) this.#transactionState!.bulk = state;
+    let discarded = false;
+    const discard = (): void => {
+      if (discarded || connection.destroy === undefined) return;
+      discarded = true;
+      connection.destroy();
+      if (this.#transactionState !== undefined) {
+        this.#transactionState.usable = false;
+        this.#transactionState.discarded = true;
+      }
+    };
+    try {
+      await runControlledExecution(options, () => connection.loadData!(statement, chunks), discard);
+      if (this.#connection === undefined) connection.release();
+    } catch (error) {
+      discard();
+      if (!discarded && this.#connection === undefined) connection.release();
+      throw error;
+    } finally {
+      if (this.#transactionState?.bulk === state) this.#transactionState.bulk = undefined;
+      state.finish();
+    }
+  }
+
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
     statementName: string,
     factory: (...args: Arguments) => Query<Row, Params>,
@@ -515,7 +565,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         this.#prepared,
         this.#decoderPlans,
         this.#observation,
-        { active: undefined, batch: undefined, execute: undefined, discarded: false, usable: true },
+        { active: undefined, batch: undefined, bulk: undefined, execute: undefined, discarded: false, usable: true },
       );
       result = await fn(transaction);
       transaction.#scopeOpen = false;
@@ -604,12 +654,14 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     await this.#closeStreams();
     await this.#settleExecutes();
     await this.#settleBatch();
+    await this.#settleBulk();
   }
 
   async #assertTransactionReadyForFinalize(connectionFinalizing = false): Promise<void> {
     const leakedExecutes = new Set(this.#executes);
     if (this.#transactionState?.execute !== undefined) leakedExecutes.add(this.#transactionState.execute);
     const leakedBatch = this.#transactionState?.batch;
+    const leakedBulk = this.#transactionState?.bulk;
     await this.#rejectActiveStreams();
     const active = this.#transactionState?.active;
     if (active !== undefined) {
@@ -630,6 +682,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         "MySQL transaction callback returned while an ordered batch owned its connection; await the batch before returning",
       );
     }
+    if (leakedBulk !== undefined) {
+      await leakedBulk.completion;
+      throw new Error(
+        "MySQL transaction callback returned while LOAD DATA owned its connection; await LOAD DATA before returning",
+      );
+    }
     if (!connectionFinalizing && this.#transactionState?.usable === false)
       throw new Error("This MySQL transaction connection is no longer active");
   }
@@ -639,6 +697,8 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       throw new Error(`Cannot ${action} while a MySQL query stream owns the transaction connection`);
     if (this.#transactionState?.batch !== undefined)
       throw new Error(`Cannot ${action} while a MySQL ordered batch owns the transaction connection`);
+    if (this.#transactionState?.bulk !== undefined)
+      throw new Error(`Cannot ${action} while MySQL LOAD DATA owns the transaction connection`);
     if (this.#transactionState?.execute !== undefined)
       throw new Error(`Cannot ${action} while a MySQL execute operation owns the transaction connection`);
   }
@@ -652,6 +712,11 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   async #settleBatch(): Promise<void> {
     const batch = this.#transactionState?.batch;
     if (batch !== undefined) await batch.completion;
+  }
+
+  async #settleBulk(): Promise<void> {
+    const bulk = this.#transactionState?.bulk;
+    if (bulk !== undefined) await bulk.completion;
   }
 
   async #settleExecutes(): Promise<void> {

--- a/packages/mysql/test/bulk.test.ts
+++ b/packages/mysql/test/bulk.test.ts
@@ -1,0 +1,287 @@
+import { getAdapterCapability, requireAdapterCapability } from "@typed-sql/core";
+import { sql } from "@typed-sql/mysql";
+import { describe, it, strict } from "poku";
+import { createMySqlBulkCapability, type MySqlBulkTransport, mysqlBulk } from "../src/bulk.js";
+import {
+  createMySqlDatabase,
+  type MySqlConnectionLike,
+  type MySqlExecutionResult,
+  type MySqlPoolLike,
+} from "../src/runtime.js";
+
+function recorder() {
+  const statements: string[] = [];
+  const chunks: Uint8Array[] = [];
+  const transport: MySqlBulkTransport = {
+    async loadData(statement, source) {
+      statements.push(statement);
+      for await (const chunk of source) chunks.push(chunk);
+    },
+  };
+  return { capability: createMySqlBulkCapability(transport), chunks, statements };
+}
+
+class BulkConnection implements MySqlConnectionLike {
+  readonly loaded: Uint8Array[] = [];
+  readonly commands: string[] = [];
+  releaseCount = 0;
+  destroyCount = 0;
+  loadError: Error | undefined;
+  loadStarted = false;
+  hangLoad = false;
+  #rejectLoad: ((error: unknown) => void) | undefined;
+
+  async execute(): Promise<MySqlExecutionResult> {
+    return { rows: [] };
+  }
+  async query(sql: string): Promise<MySqlExecutionResult> {
+    this.commands.push(sql);
+    return { rows: [] };
+  }
+  async loadData(_statement: string, chunks: AsyncIterable<Uint8Array>): Promise<void> {
+    this.loadStarted = true;
+    if (this.loadError !== undefined) throw this.loadError;
+    if (this.hangLoad) {
+      await new Promise<void>((_resolve, reject) => {
+        this.#rejectLoad = reject;
+      });
+    }
+    for await (const chunk of chunks) this.loaded.push(chunk);
+  }
+  async beginTransaction(): Promise<void> {
+    this.commands.push("BEGIN");
+  }
+  async commit(): Promise<void> {
+    this.commands.push("COMMIT");
+  }
+  async rollback(): Promise<void> {
+    this.commands.push("ROLLBACK");
+  }
+  destroy(): void {
+    this.destroyCount += 1;
+    this.#rejectLoad?.(new Error("connection destroyed"));
+  }
+  release(): void {
+    this.releaseCount += 1;
+  }
+}
+
+class BulkPool implements MySqlPoolLike {
+  readonly executionCapabilities = { cancellation: true, deadlines: true } as const;
+  readonly bulkLoad = true;
+  readonly connection = new BulkConnection();
+  connections = 0;
+
+  async execute(): Promise<MySqlExecutionResult> {
+    return { rows: [] };
+  }
+  async getConnection(): Promise<MySqlConnectionLike> {
+    this.connections += 1;
+    return this.connection;
+  }
+  async end(): Promise<void> {}
+}
+
+const rowQuery = (row: { readonly id: bigint; readonly email: string; readonly note: string | null }) =>
+  sql`INSERT INTO app.account (id, email, note) VALUES (${row.id}, ${row.email}, ${row.note})`;
+
+await describe("MySQL LOAD DATA capability", async () => {
+  await it("derives a safe local-infile statement and escaped rows from a typed INSERT", async () => {
+    const { capability, chunks, statements } = recorder();
+    const result = await capability.loadData(rowQuery, [
+      { id: 1n, email: "one@example.com", note: null },
+      { id: 2n, email: "two\texample.com", note: "line\nbreak\\tail" },
+    ]);
+    strict.deepStrictEqual(statements, [
+      "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE `app`.`account` CHARACTER SET utf8mb4 FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (`id`, `email`, `note`)",
+    ]);
+    const encoded = new TextDecoder().decode(Buffer.concat(chunks));
+    strict.strictEqual(encoded, "1\tone@example.com\t\\N\n2\ttwo\\texample.com\tline\\nbreak\\\\tail\n");
+    strict.deepStrictEqual(result, { rows: 2, bytes: new TextEncoder().encode(encoded).byteLength });
+  });
+
+  await it("encodes stable scalar forms and performs no transport work for empty input", async () => {
+    const { capability, chunks, statements } = recorder();
+    const progress: { readonly rows: number; readonly bytes: number }[] = [];
+    await capability.loadData(
+      (row: {
+        readonly enabled: boolean;
+        readonly disabled: boolean;
+        readonly score: number;
+        readonly missing: undefined;
+        readonly text: string;
+      }) => sql`
+        INSERT INTO scalar_input (enabled, disabled, score, missing, text)
+        VALUES (${row.enabled}, ${row.disabled}, ${row.score}, ${row.missing}, ${row.text})
+      `,
+      [{ enabled: true, disabled: false, score: 1.5, missing: undefined, text: "nul\0carriage\r" }],
+      { chunkBytes: 1, onProgress: (value) => progress.push(value) },
+    );
+    const encoded = "1\t0\t1.5\t\\N\tnul\\0carriage\\r\n";
+    strict.strictEqual(new TextDecoder().decode(Buffer.concat(chunks)), encoded);
+    strict.deepStrictEqual(progress.at(-1), { rows: 1, bytes: new TextEncoder().encode(encoded).byteLength });
+
+    const empty = await capability.loadData((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, []);
+    strict.deepStrictEqual(empty, { rows: 0, bytes: 0 });
+    strict.strictEqual(statements.length, 1);
+  });
+
+  await it("rejects invalid chunk sizes and unstable primitive encodings", async () => {
+    const { capability } = recorder();
+    for (const chunkBytes of [0, 1.5]) {
+      await strict.rejects(
+        capability.loadData((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, [1n], { chunkBytes }),
+        /positive safe integer/u,
+      );
+    }
+    for (const value of [Number.NEGATIVE_INFINITY, Symbol("unsupported")]) {
+      await strict.rejects(
+        capability.loadData((input: unknown) => sql`INSERT INTO account (value) VALUES (${input})`, [value]),
+        /cannot encode/u,
+      );
+    }
+  });
+
+  await it("fails closed for structural drift, connection-specific text values, and invalid shapes", async () => {
+    const { capability } = recorder();
+    await strict.rejects(
+      capability.loadData(
+        (row: { readonly id: bigint; readonly alternate: boolean }) =>
+          row.alternate
+            ? sql`INSERT INTO archive (id) VALUES (${row.id})`
+            : sql`INSERT INTO account (id) VALUES (${row.id})`,
+        [
+          { id: 1n, alternate: false },
+          { id: 2n, alternate: true },
+        ],
+      ),
+      /changed its structural SQL shape/u,
+    );
+    await strict.rejects(
+      capability.loadData(
+        (value: Uint8Array) => sql`INSERT INTO account (payload) VALUES (${value})`,
+        [new Uint8Array([1])],
+      ),
+      /does not accept binary values/u,
+    );
+    await strict.rejects(
+      capability.loadData(
+        (value: Date) => sql`INSERT INTO account (created_at) VALUES (${value})`,
+        [new Date("2026-01-01T00:00:00.000Z")],
+      ),
+      /does not accept Date values/u,
+    );
+    await strict.rejects(
+      capability.loadData(
+        (value: { readonly enabled: boolean }) => sql`INSERT INTO account (settings) VALUES (${value})`,
+        [{ enabled: true }],
+      ),
+      /does not accept structured values/u,
+    );
+    await strict.rejects(
+      capability.loadData((id: bigint) => sql`UPDATE account SET id = ${id}`, [1n]),
+      /plain single-row INSERT/u,
+    );
+  });
+
+  await it("is discovered on capable adapters and owns root and transaction leases", async () => {
+    const pool = new BulkPool();
+    const database = createMySqlDatabase({ pool });
+    const bulk = requireAdapterCapability(database, mysqlBulk);
+    await bulk.loadData(rowQuery, [{ id: 1n, email: "one@example.com", note: null }]);
+    strict.strictEqual(pool.connections, 1);
+    strict.strictEqual(pool.connection.releaseCount, 1);
+
+    await database.transaction(async (transaction) => {
+      await requireAdapterCapability(transaction, mysqlBulk).loadData(rowQuery, [
+        { id: 2n, email: "two@example.com", note: null },
+      ]);
+      strict.strictEqual(pool.connection.releaseCount, 1);
+    });
+    strict.deepStrictEqual(pool.connection.commands, ["BEGIN", "COMMIT"]);
+    strict.strictEqual(pool.connection.releaseCount, 2);
+
+    const unsupported = createMySqlDatabase({
+      pool: {
+        execute: async () => ({ rows: [] }),
+        getConnection: async () => pool.connection,
+        end: async () => undefined,
+      },
+    });
+    strict.strictEqual(getAdapterCapability(unsupported, mysqlBulk), undefined);
+  });
+
+  await it("destroys a root lease after LOAD DATA or producer failure", async () => {
+    const pool = new BulkPool();
+    const bulk = requireAdapterCapability(createMySqlDatabase({ pool }), mysqlBulk);
+    const databaseFailure = new Error("LOAD DATA constraint failure");
+    pool.connection.loadError = databaseFailure;
+    await strict.rejects(
+      () => bulk.loadData(rowQuery, [{ id: 1n, email: "one@example.com", note: null }]),
+      databaseFailure,
+    );
+    strict.strictEqual(pool.connection.destroyCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 0);
+
+    const producerPool = new BulkPool();
+    const producerBulk = requireAdapterCapability(createMySqlDatabase({ pool: producerPool }), mysqlBulk);
+    const producerFailure = new Error("producer failed");
+    async function* failedRows() {
+      yield { id: 1n, email: "one@example.com", note: null };
+      throw producerFailure;
+    }
+    await strict.rejects(() => producerBulk.loadData(rowQuery, failedRows()), producerFailure);
+    strict.strictEqual(producerPool.connection.destroyCount, 1);
+    strict.strictEqual(producerPool.connection.releaseCount, 0);
+  });
+
+  await it("cancels LOAD DATA by destroying its application-owned connection", async () => {
+    const pool = new BulkPool();
+    pool.connection.hangLoad = true;
+    const controller = new AbortController();
+    const bulk = requireAdapterCapability(createMySqlDatabase({ pool }), mysqlBulk);
+    const running = bulk.loadData(rowQuery, [{ id: 1n, email: "one@example.com", note: null }], {
+      signal: controller.signal,
+    });
+    while (!pool.connection.loadStarted) await Promise.resolve();
+    controller.abort("request closed");
+    await strict.rejects(running, (error) => {
+      strict.strictEqual((error as { readonly code?: unknown }).code, "TSQL_CANCELLED");
+      strict.strictEqual((error as Error).cause, "request closed");
+      return true;
+    });
+    strict.strictEqual(pool.connection.destroyCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 0);
+  });
+
+  await it("closes a producer exactly once when the transport rejects before consuming", async () => {
+    let returns = 0;
+    const failure = new Error("transport unavailable");
+    const capability = createMySqlBulkCapability({
+      async loadData() {
+        throw failure;
+      },
+    });
+    const rows: AsyncIterable<bigint> = {
+      [Symbol.asyncIterator]() {
+        let delivered = false;
+        return {
+          async next() {
+            if (delivered) return { done: true, value: undefined };
+            delivered = true;
+            return { done: false, value: 1n };
+          },
+          async return() {
+            returns += 1;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    await strict.rejects(
+      () => capability.loadData((id) => sql`INSERT INTO account (id) VALUES (${id})`, rows),
+      failure,
+    );
+    strict.strictEqual(returns, 1);
+  });
+});

--- a/packages/mysql/test/mysql2.test.ts
+++ b/packages/mysql/test/mysql2.test.ts
@@ -20,11 +20,36 @@ class FakeCallbackCommand extends EventEmitter {
 class FakeCallbackConnection extends EventEmitter {
   readonly commands: FakeCallbackCommand[] = [];
   readonly calls: { readonly sql: string; readonly values: readonly unknown[] }[] = [];
+  readonly localInfileChunks: Buffer[] = [];
+  readonly localInfileStatements: string[] = [];
+  localInfilePath = "typed-sql-stream";
 
   execute(sql: string, values: readonly unknown[]): FakeCallbackCommand {
     const command = new FakeCallbackCommand();
     this.commands.push(command);
     this.calls.push({ sql, values });
+    return command;
+  }
+
+  query(
+    options: { readonly sql: string; readonly infileStreamFactory: (path: string) => Readable },
+    callback: (error: Error | null) => void,
+  ): FakeCallbackCommand {
+    const command = new FakeCallbackCommand();
+    this.localInfileStatements.push(options.sql);
+    try {
+      const source = options.infileStreamFactory(this.localInfilePath);
+      void (async () => {
+        try {
+          for await (const chunk of source) this.localInfileChunks.push(Buffer.from(chunk));
+          callback(null);
+        } catch (error) {
+          callback(error instanceof Error ? error : new Error(String(error)));
+        }
+      })();
+    } catch (error) {
+      callback(error instanceof Error ? error : new Error(String(error)));
+    }
     return command;
   }
 }
@@ -167,6 +192,36 @@ await describe("application-owned mysql2 integration", async () => {
     await pool.end();
     strict.strictEqual(raw.pooledConnection.released, true);
     strict.strictEqual(raw.ended, true);
+  });
+
+  await it("streams LOAD DATA only through the exact application-owned infile sentinel", async () => {
+    const raw = new FakeRawPool();
+    const connection = await adaptMySql2Pool(raw as unknown as Pool).getConnection();
+    await connection.loadData!(
+      "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE account",
+      (async function* () {
+        yield new TextEncoder().encode("1\tone@example.com\n");
+      })(),
+    );
+    strict.deepStrictEqual(raw.pooledConnection.connection.localInfileStatements, [
+      "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE account",
+    ]);
+    strict.strictEqual(
+      Buffer.concat(raw.pooledConnection.connection.localInfileChunks).toString("utf8"),
+      "1\tone@example.com\n",
+    );
+
+    raw.pooledConnection.connection.localInfilePath = "/tmp/untrusted.csv";
+    await strict.rejects(
+      () =>
+        connection.loadData!(
+          "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE account",
+          (async function* () {
+            yield new Uint8Array([1]);
+          })(),
+        ),
+      /unexpected local infile path/u,
+    );
   });
 
   await it("normalizes native mysql2 DML metadata in an ordered batch", async () => {

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -16,8 +16,15 @@ the grammar. Applications that stream rows also install the optional application
 pnpm add pg-cursor
 ```
 
+Applications that use PostgreSQL COPY also install its optional application-owned stream:
+
+```sh
+pnpm add pg-copy-streams
+```
+
 ```ts
-import { sql, typePolicy } from "@typed-sql/postgres";
+import { requireAdapterCapability } from "@typed-sql/core";
+import { postgresCopy, sql, typePolicy } from "@typed-sql/postgres";
 import { createPgDatabase } from "@typed-sql/postgres/pg";
 
 const query = sql`
@@ -30,6 +37,7 @@ const database = await createPgDatabase({
   connectionString: process.env.DATABASE_URL!,
   poolConfig: { pipeline: true },
   typePolicy,
+  copyStreamsImporter: () => import("pg-copy-streams"),
   // observer: createOpenTelemetryObserver(),
 });
 
@@ -49,6 +57,13 @@ const [pipelinedAccount, pipelinedAll] = await database.pipeline([accountById(42
 for await (const account of database.stream(accountById(42n), { batchSize: 500 })) {
   // account retains the query's inferred row type
 }
+
+const copy = requireAdapterCapability(database, postgresCopy);
+await copy.copyFrom(
+  (account: { readonly id: bigint; readonly email: string }) =>
+    sql`INSERT INTO users (id, email) VALUES (${account.id}, ${account.email})`,
+  accounts,
+);
 ```
 
 The package root exports `sql`, `postgres`, and the PostgreSQL type policy. The `/pg` entrypoint
@@ -61,6 +76,7 @@ creating `pg` pools.
 
 Read the [PostgreSQL grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/dialects/postgresql.md),
 [execution guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/execution.md),
+[bulk data guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/bulk-data.md),
 [observability guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/observability.md),
 [live verification guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/live-verification.md),
 [query plan governance guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/query-plan-governance.md),

--- a/packages/postgres/src/bulk.ts
+++ b/packages/postgres/src/bulk.ts
@@ -1,0 +1,277 @@
+import { parseStatement } from "@typed-sql/ast";
+import {
+  bindQueryRenderSkeleton,
+  compileQueryRenderSkeleton,
+  defineAdapterCapability,
+  type ExecutionOptions,
+  type Query,
+  QueryCancelledError,
+  type QueryStream,
+  type SqlRenderer,
+} from "@typed-sql/core";
+
+const postgresRenderer: SqlRenderer = Object.freeze({
+  placeholder: (index: number) => `$${index}`,
+  quoteIdentifier: (name: string) => `"${name.replaceAll('"', '""')}"`,
+});
+
+export interface PostgresCopyProgress {
+  readonly rows: number;
+  readonly bytes: number;
+}
+
+export interface PostgresCopyResult extends PostgresCopyProgress {}
+
+export interface PostgresCopyFromOptions extends ExecutionOptions {
+  /** Preferred encoded chunk size. One unusually wide row may exceed it. */
+  readonly chunkBytes?: number;
+  readonly onProgress?: (progress: PostgresCopyProgress) => void;
+}
+
+export interface PostgresCopyToOptions extends ExecutionOptions {}
+
+export interface PostgresCopyTransport {
+  copyFrom(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void>;
+  copyTo(statement: string, options: ExecutionOptions): QueryStream<Uint8Array>;
+}
+
+export interface PostgresCopyCapability {
+  /**
+   * Compiles one ordinary typed single-row INSERT factory into COPY FROM STDIN.
+   * Every later row must preserve the first query's exact structural shape.
+   */
+  copyFrom<Input, Row, Params extends readonly unknown[]>(
+    rowQuery: (input: Input) => Query<Row, Params>,
+    rows: Iterable<Input> | AsyncIterable<Input>,
+    options?: PostgresCopyFromOptions,
+  ): Promise<PostgresCopyResult>;
+
+  /** Streams raw PostgreSQL CSV bytes for a static typed SELECT query. */
+  copyTo<Row>(query: Query<Row, readonly []>, options?: PostgresCopyToOptions): QueryStream<Uint8Array>;
+}
+
+export const postgresCopy = defineAdapterCapability<PostgresCopyCapability>("postgres.copy");
+
+const encoder = new TextEncoder();
+const DEFAULT_CHUNK_BYTES = 64 * 1_024;
+
+function quoteIdentifier(value: string): string {
+  return postgresRenderer.quoteIdentifier(value);
+}
+
+function postgresArrayElement(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (Array.isArray(value)) return postgresArray(value);
+  const encoded = postgresTextValue(value);
+  return `"${encoded.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function postgresArray(value: readonly unknown[]): string {
+  return `{${value.map(postgresArrayElement).join(",")}}`;
+}
+
+function postgresTextValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint" || typeof value === "boolean") return String(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new RangeError("PostgreSQL COPY cannot encode non-finite numbers");
+    return String(value);
+  }
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) throw new RangeError("PostgreSQL COPY cannot encode an invalid Date");
+    return value.toISOString();
+  }
+  if (value instanceof Uint8Array) return `\\x${Buffer.from(value).toString("hex")}`;
+  if (Array.isArray(value)) return postgresArray(value);
+  if (typeof value === "object" && value !== null) return JSON.stringify(value);
+  throw new TypeError(`PostgreSQL COPY cannot encode ${typeof value} values`);
+}
+
+function csvField(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return `"${postgresTextValue(value).replaceAll('"', '""')}"`;
+}
+
+function csvRow(values: readonly unknown[]): Uint8Array {
+  return encoder.encode(`${values.map(csvField).join(",")}\n`);
+}
+
+function chunkSize(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_CHUNK_BYTES;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError("PostgreSQL COPY chunkBytes must be a positive safe integer");
+  }
+  return resolved;
+}
+
+function copyFromStatement(text: string, parameterCount: number): string {
+  const statement = parseStatement(text);
+  if (
+    statement.kind !== "insert" ||
+    statement.with !== undefined ||
+    statement.table.alias !== undefined ||
+    statement.source.kind !== "values" ||
+    statement.source.rows.length !== 1 ||
+    statement.returning.length !== 0 ||
+    statement.columns.length === 0
+  ) {
+    throw new TypeError(
+      "PostgreSQL COPY requires a plain single-row INSERT with an explicit column list, one VALUES row, and no RETURNING clause",
+    );
+  }
+  const values = statement.source.rows[0]!;
+  if (
+    values.length !== statement.columns.length ||
+    values.length !== parameterCount ||
+    values.some((expression, index) => expression.kind !== "parameter" || expression.index !== index + 1)
+  ) {
+    throw new TypeError("PostgreSQL COPY INSERT values must be one ordered parameter per target column");
+  }
+  const table = `${statement.table.schema === undefined ? "" : `${quoteIdentifier(statement.table.schema.name)}.`}${quoteIdentifier(statement.table.name.name)}`;
+  const columns = statement.columns.map(({ name }) => quoteIdentifier(name)).join(", ");
+  return `COPY ${table} (${columns}) FROM STDIN WITH (FORMAT csv)`;
+}
+
+function copyToStatement<Row>(query: Query<Row, readonly []>): string {
+  const { rendered } = compileQueryRenderSkeleton(query, postgresRenderer);
+  if (rendered.values.length !== 0)
+    throw new TypeError("PostgreSQL COPY TO accepts only static queries without parameters");
+  const text = rendered.text.trim().replace(/;\s*$/u, "");
+  if (parseStatement(text).kind !== "select") {
+    throw new TypeError("PostgreSQL COPY TO requires a SELECT query");
+  }
+  return `COPY (${text}) TO STDOUT WITH (FORMAT csv)`;
+}
+
+function cancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) throw new QueryCancelledError("signal", { cause: signal.reason });
+}
+
+function asyncIterator<Value>(values: Iterable<Value> | AsyncIterable<Value>): AsyncIterator<Value> {
+  if (Symbol.asyncIterator in Object(values)) return (values as AsyncIterable<Value>)[Symbol.asyncIterator]();
+  const iterator = (values as Iterable<Value>)[Symbol.iterator]();
+  return {
+    next: async () => iterator.next(),
+    ...(iterator.return === undefined ? {} : { return: async () => iterator.return!() }),
+  };
+}
+
+function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!;
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+export function createPostgresCopyCapability(transport: PostgresCopyTransport): PostgresCopyCapability {
+  return Object.freeze({
+    async copyFrom<Input, Row, Params extends readonly unknown[]>(
+      rowQuery: (input: Input) => Query<Row, Params>,
+      rows: Iterable<Input> | AsyncIterable<Input>,
+      options: PostgresCopyFromOptions = {},
+    ): Promise<PostgresCopyResult> {
+      const preferredChunkBytes = chunkSize(options.chunkBytes);
+      cancelled(options.signal);
+      const iterator = asyncIterator(rows);
+      let iteratorClosed = false;
+      const closeIterator = async (): Promise<void> => {
+        if (iteratorClosed || iterator.return === undefined) return;
+        iteratorClosed = true;
+        await iterator.return();
+      };
+      let first: IteratorResult<Input>;
+      try {
+        first = await iterator.next();
+      } catch (error) {
+        try {
+          await closeIterator();
+        } catch {
+          /* Preserve the producer failure. */
+        }
+        throw error;
+      }
+      if (first.done === true) return Object.freeze({ rows: 0, bytes: 0 });
+
+      let firstQuery: Query<Row, Params>;
+      let compiled: ReturnType<typeof compileQueryRenderSkeleton<Row, Params>>;
+      let statement: string;
+      try {
+        firstQuery = rowQuery(first.value);
+        compiled = compileQueryRenderSkeleton(firstQuery, postgresRenderer);
+        statement = copyFromStatement(compiled.rendered.text, compiled.rendered.values.length);
+      } catch (error) {
+        try {
+          await closeIterator();
+        } catch {
+          /* Preserve the query compilation failure. */
+        }
+        throw error;
+      }
+      let rowCount = 0;
+      let byteCount = 0;
+      let inputComplete = false;
+
+      const chunks = (async function* (): AsyncGenerator<Uint8Array> {
+        let pending: Uint8Array[] = [];
+        let pendingBytes = 0;
+        let current: IteratorResult<Input> = first;
+        try {
+          while (current.done !== true) {
+            cancelled(options.signal);
+            const query = rowCount === 0 ? firstQuery : rowQuery(current.value);
+            const rendered = rowCount === 0 ? compiled.rendered : bindQueryRenderSkeleton(query, compiled.skeleton);
+            if (rendered === undefined) {
+              throw new TypeError("PostgreSQL COPY row query changed its structural SQL shape");
+            }
+            const encoded = csvRow(rendered.values);
+            if (pendingBytes > 0 && pendingBytes + encoded.byteLength > preferredChunkBytes) {
+              const chunk = concatenate(pending, pendingBytes);
+              byteCount += chunk.byteLength;
+              options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+              yield chunk;
+              pending = [];
+              pendingBytes = 0;
+            }
+            pending.push(encoded);
+            pendingBytes += encoded.byteLength;
+            rowCount += 1;
+            current = await iterator.next();
+          }
+          inputComplete = true;
+          if (pendingBytes > 0) {
+            const chunk = concatenate(pending, pendingBytes);
+            byteCount += chunk.byteLength;
+            options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+            yield chunk;
+          }
+        } finally {
+          if (current.done !== true) await closeIterator();
+        }
+      })();
+
+      try {
+        await transport.copyFrom(statement, chunks, options);
+      } catch (error) {
+        if (!inputComplete) {
+          try {
+            await closeIterator();
+          } catch {
+            /* Preserve the transport, producer, or database failure. */
+          }
+        }
+        throw error;
+      }
+      if (!inputComplete) await closeIterator();
+      return Object.freeze({ rows: rowCount, bytes: byteCount });
+    },
+
+    copyTo<Row>(query: Query<Row, readonly []>, options: PostgresCopyToOptions = {}): QueryStream<Uint8Array> {
+      cancelled(options.signal);
+      return transport.copyTo(copyToStatement(query), options);
+    },
+  });
+}

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -6,6 +6,14 @@ import { analyzePostgresSemantics } from "./semantics.js";
 import { defaultPostgresTypePolicy, type PostgresTypePolicy } from "./type-policy.js";
 import { POSTGRES_DIALECT_VERSION } from "./version.js";
 
+export type {
+  PostgresCopyCapability,
+  PostgresCopyFromOptions,
+  PostgresCopyProgress,
+  PostgresCopyResult,
+  PostgresCopyToOptions,
+} from "./bulk.js";
+export { postgresCopy } from "./bulk.js";
 export { POSTGRES_DIALECT_VERSION } from "./version.js";
 
 export type PostgresSchemaSnapshot = SchemaSnapshot & { readonly dialect: "postgres" };

--- a/packages/postgres/src/pg.ts
+++ b/packages/postgres/src/pg.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { once } from "node:events";
+import type { Readable, Writable } from "node:stream";
+import { finished } from "node:stream/promises";
 import type { DatabaseObserver, LiveQueryVerifier, QueryPlanEvidence, QueryPlanInspector } from "@typed-sql/core";
 import type { Pool as PgPool, PoolClient, PoolConfig, QueryConfig } from "pg";
 import type { PostgresSchemaSnapshot } from "./index.js";
@@ -6,6 +9,8 @@ import { type PostgresQueryable, PostgresSchemaProvider } from "./provider.js";
 import {
   createPostgresDatabase,
   type PostgresClientLike,
+  type PostgresCopyFromSink,
+  type PostgresCopyToSource,
   type PostgresCursorLike,
   type PostgresDatabase,
   type PostgresPoolLike,
@@ -31,12 +36,24 @@ export interface PgCursorConstructor {
 
 export type PgCursorImporter = () => Promise<unknown>;
 
+export interface PgCopyStreamsModule {
+  readonly from: (statement: string) => unknown;
+  readonly to: (statement: string) => unknown;
+}
+
+export type PgCopyStreamsImporter = () => Promise<unknown>;
+
 const pgCursorPackage = "pg-cursor";
+const pgCopyStreamsPackage = "pg-copy-streams";
 const queryTimeoutError =
   "@typed-sql/postgres/pg does not accept pg query_timeout because pg can reject before the connection is ready for reuse; use PostgreSQL statement_timeout instead";
 
 async function defaultPgCursorImporter(): Promise<unknown> {
   return import(pgCursorPackage);
+}
+
+async function defaultPgCopyStreamsImporter(): Promise<unknown> {
+  return import(pgCopyStreamsPackage);
 }
 
 function pgCursorConstructor(module: unknown): PgCursorConstructor {
@@ -66,6 +83,31 @@ export async function loadPgCursorDriver(
   }
 }
 
+export async function loadPgCopyStreams(
+  importer: PgCopyStreamsImporter = defaultPgCopyStreamsImporter,
+): Promise<PgCopyStreamsModule> {
+  try {
+    const module = await importer();
+    if (
+      typeof module !== "object" ||
+      module === null ||
+      typeof (module as Partial<PgCopyStreamsModule>).from !== "function" ||
+      typeof (module as Partial<PgCopyStreamsModule>).to !== "function"
+    ) {
+      throw new TypeError("The application-owned pg-copy-streams package must export from() and to() factories");
+    }
+    return module as PgCopyStreamsModule;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "@typed-sql/postgres/pg COPY requires the application-owned pg-copy-streams package. Install it with: pnpm add pg-copy-streams",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 export interface PgOptions {
   readonly connectionString: string | (() => string | Promise<string>);
   readonly poolConfig?: Omit<PoolConfig, "connectionString" | "query_timeout" | "types">;
@@ -73,6 +115,8 @@ export interface PgOptions {
   readonly decimal?: (value: string) => unknown;
   /** Host-injected loader for workspaces or runtimes with nonstandard package resolution. */
   readonly cursorImporter?: PgCursorImporter;
+  /** Host-injected loader for the optional pg-copy-streams bulk protocol package. */
+  readonly copyStreamsImporter?: PgCopyStreamsImporter;
   readonly observer?: DatabaseObserver;
 }
 
@@ -437,6 +481,7 @@ function queryConfig(config: PostgresQueryConfig): QueryConfig<unknown[]> {
 export function adaptPgPool(
   pool: PgPool,
   cursorImporter: PgCursorImporter = defaultPgCursorImporter,
+  copyStreamsImporter: PgCopyStreamsImporter = defaultPgCopyStreamsImporter,
 ): PostgresPoolLike {
   const options = (
     pool as PgPool & {
@@ -449,6 +494,11 @@ export function adaptPgPool(
   const loadCursor = (): Promise<PgCursorConstructor> => {
     cursorConstructorPromise ??= loadPgCursorDriver(cursorImporter);
     return cursorConstructorPromise;
+  };
+  let copyStreamsPromise: Promise<PgCopyStreamsModule> | undefined;
+  const loadCopyStreams = (): Promise<PgCopyStreamsModule> => {
+    copyStreamsPromise ??= loadPgCopyStreams(copyStreamsImporter);
+    return copyStreamsPromise;
   };
   const wrapClient = (client: PoolClient): PostgresClientLike => {
     let fatalError: Error | undefined;
@@ -497,6 +547,73 @@ export function adaptPgPool(
           },
         };
       },
+      async openCopyFrom(statement: string): Promise<PostgresCopyFromSink> {
+        const copy = await loadCopyStreams();
+        const nativeQuery = client.query.bind(client) as unknown as (query: unknown) => Writable;
+        const writable = nativeQuery(copy.from(statement));
+        const terminal = finished(writable);
+        void terminal.catch(() => undefined);
+        return {
+          async write(chunk): Promise<void> {
+            if (!writable.write(chunk)) await once(writable, "drain");
+          },
+          async finish(): Promise<void> {
+            writable.end();
+            await terminal;
+          },
+          async abort(error): Promise<void> {
+            writable.destroy(error instanceof Error ? error : new Error("PostgreSQL COPY FROM aborted"));
+            await terminal.catch(() => undefined);
+          },
+        };
+      },
+      async openCopyTo(statement: string): Promise<PostgresCopyToSource> {
+        const copy = await loadCopyStreams();
+        const nativeQuery = client.query.bind(client) as unknown as (query: unknown) => Readable;
+        const readable = nativeQuery(copy.to(statement));
+        const terminal = finished(readable);
+        void terminal.catch(() => undefined);
+        const iterator = readable[Symbol.asyncIterator]();
+        let complete = false;
+        const close = async (): Promise<void> => {
+          const early = !complete;
+          complete = true;
+          if (early) readable.destroy();
+          if (early) await terminal.catch(() => undefined);
+          else await terminal;
+        };
+        const source: PostgresCopyToSource = {
+          [Symbol.asyncIterator](): PostgresCopyToSource {
+            return source;
+          },
+          async next(): Promise<IteratorResult<Uint8Array, undefined>> {
+            const result = await iterator.next();
+            if (result.done === true) {
+              complete = true;
+              return { done: true, value: undefined };
+            }
+            const value = result.value;
+            return {
+              done: false,
+              value: value instanceof Uint8Array ? value : Buffer.from(value as string),
+            };
+          },
+          async return(): Promise<IteratorResult<Uint8Array, undefined>> {
+            await close();
+            return { done: true, value: undefined };
+          },
+          close,
+          async abort(error): Promise<void> {
+            readable.destroy(error instanceof Error ? error : new Error("PostgreSQL COPY TO aborted"));
+            await terminal.catch(() => undefined);
+            complete = true;
+          },
+          async [Symbol.asyncDispose](): Promise<void> {
+            await close();
+          },
+        };
+        return source;
+      },
       release(error?: Error | boolean): void {
         client.removeListener("error", onError);
         client.removeListener("end", onEnd);
@@ -516,6 +633,9 @@ export function adaptPgPool(
     async ensureCursor(): Promise<void> {
       await loadCursor();
     },
+    async ensureCopy(): Promise<void> {
+      await loadCopyStreams();
+    },
     async connect(): Promise<PostgresClientLike> {
       return wrapClient(await pool.connect());
     },
@@ -533,7 +653,7 @@ export async function createPgDatabase(options: PgOptions): Promise<PostgresData
   const { Pool } = driver;
   const pool = new Pool({ ...options.poolConfig, connectionString: resolvedConnectionString });
   return createPostgresDatabase({
-    pool: adaptPgPool(pool, options.cursorImporter),
+    pool: adaptPgPool(pool, options.cursorImporter, options.copyStreamsImporter),
     ownsPool: true,
     fallbackTypeParsers: driver.types,
     ...(options.typePolicy === undefined ? {} : { typePolicy: options.typePolicy }),

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import {
+  type AdapterCapabilityResolver,
+  adapterCapabilities,
   assertExecutionCapabilities,
+  createAdapterCapabilityResolver,
   type Database,
   type DatabaseObserver,
   databaseErrorCompletion,
@@ -19,6 +22,7 @@ import {
   type StreamOptions,
   startDatabaseObservation,
 } from "@typed-sql/core";
+import { createPostgresCopyCapability, type PostgresCopyTransport, postgresCopy } from "./bulk.js";
 import {
   createPostgresPreparedQueryState,
   type PostgresPreparedQueryFactory,
@@ -54,10 +58,22 @@ export interface PostgresQueryResult {
   readonly rows: readonly Record<string, unknown>[];
 }
 
+export interface PostgresCopyFromSink {
+  write(chunk: Uint8Array): Promise<void>;
+  finish(): Promise<void>;
+  abort(error: unknown): Promise<void>;
+}
+
+export interface PostgresCopyToSource extends QueryStream<Uint8Array> {
+  abort(error: unknown): Promise<void>;
+}
+
 export interface PostgresClientLike {
   readonly pipeline?: boolean;
   query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult>;
   openCursor?(config: PostgresQueryConfig): PostgresCursorLike | Promise<PostgresCursorLike>;
+  openCopyFrom?(statement: string): Promise<PostgresCopyFromSink>;
+  openCopyTo?(statement: string): Promise<PostgresCopyToSource>;
   release(error?: Error | boolean): void;
 }
 
@@ -65,6 +81,7 @@ export interface PostgresPoolLike {
   readonly executionCapabilities?: ExecutionCapabilities;
   query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult>;
   ensureCursor?(): Promise<void>;
+  ensureCopy?(): Promise<void>;
   connect(): Promise<PostgresClientLike>;
   end(): Promise<void>;
 }
@@ -249,6 +266,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   #transactionOperationError: unknown;
   readonly #transactionState: {
     activeBatch: Promise<unknown> | undefined;
+    activeCopy: Promise<unknown> | undefined;
     readonly activeExecutes: Set<Promise<unknown>>;
     activePipeline: Promise<unknown> | undefined;
     readonly activeStreams: Set<QueryStream<unknown>>;
@@ -263,6 +281,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   readonly #transactionExecutes = new Set<Promise<unknown>>();
   readonly #transactionStreams = new Set<QueryStream<unknown>>();
   readonly executionCapabilities: ExecutionCapabilities;
+  readonly [adapterCapabilities]: AdapterCapabilityResolver;
 
   constructor(
     pool: PostgresPoolLike,
@@ -274,6 +293,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     observation: PostgresObservationState,
     transactionState = {
       activeBatch: undefined as Promise<unknown> | undefined,
+      activeCopy: undefined as Promise<unknown> | undefined,
       activeExecutes: new Set<Promise<unknown>>(),
       activePipeline: undefined as Promise<unknown> | undefined,
       activeStreams: new Set<QueryStream<unknown>>(),
@@ -298,6 +318,13 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       cancellation: pool.executionCapabilities?.cancellation ?? false,
       deadlines: pool.executionCapabilities?.deadlines ?? false,
     });
+    const copyTransport: PostgresCopyTransport = {
+      copyFrom: (statement, chunks, options) => this.#copyFrom(statement, chunks, options),
+      copyTo: (statement, options) => this.#copyTo(statement, options),
+    };
+    this[adapterCapabilities] = createAdapterCapabilityResolver(
+      pool.ensureCopy === undefined ? [] : [[postgresCopy, createPostgresCopyCapability(copyTransport)]],
+    );
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
@@ -309,6 +336,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute another query");
     this.#rejectOperationDuringTransactionBatch("execute another query");
+    this.#rejectOperationDuringTransactionCopy("execute another query");
     this.#rejectOperationDuringTransactionPipeline("execute another query");
     const config = this.#queryConfig(query);
     let operation: Promise<PostgresQueryResult>;
@@ -352,6 +380,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute another query");
     this.#rejectOperationDuringTransactionBatch("execute another query");
+    this.#rejectOperationDuringTransactionCopy("execute another query");
     this.#rejectOperationDuringTransactionPipeline("execute another query");
 
     if (options.signal?.aborted || (options.deadline !== undefined && Number(options.deadline) <= Date.now())) {
@@ -480,6 +509,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute a query batch");
     this.#rejectOperationDuringTransactionBatch("execute another query batch");
+    this.#rejectOperationDuringTransactionCopy("execute a query batch");
     this.#rejectOperationDuringTransactionPipeline("execute a query batch");
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
     const querySnapshot = [...queries] as unknown as QueryBatch<Queries>;
@@ -526,6 +556,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("execute a query pipeline");
     this.#rejectOperationDuringTransactionBatch("execute a query pipeline");
+    this.#rejectOperationDuringTransactionCopy("execute a query pipeline");
     this.#rejectOperationDuringTransactionExecute("execute a query pipeline");
     this.#rejectOperationDuringTransactionPipeline("execute another query pipeline");
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
@@ -608,6 +639,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("start another query stream");
     this.#rejectOperationDuringTransactionBatch("start a query stream");
+    this.#rejectOperationDuringTransactionCopy("start a query stream");
     this.#rejectOperationDuringTransactionPipeline("start a query stream");
     const batchSize = validatePostgresStreamBatchSize(options.batchSize);
     const config = this.#queryConfig(query);
@@ -636,7 +668,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
         }
         try {
           const cursor = await client.openCursor(config);
-          return { cursor, ...(release === undefined ? {} : { release }) };
+          return { cursor: cursor as PostgresCursorLike<Row>, ...(release === undefined ? {} : { release }) };
         } catch (error) {
           this.#recordTransactionOperationFailure(error);
           try {
@@ -654,6 +686,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
               this.#assertTransactionScopeOpen();
               this.#rejectOperationDuringTransactionStream("start another query stream");
               this.#rejectOperationDuringTransactionBatch("start a query stream");
+              this.#rejectOperationDuringTransactionCopy("start a query stream");
               this.#rejectOperationDuringTransactionPipeline("start a query stream");
               this.#transactionState.activeStreams.add(exposedStream as QueryStream<unknown>);
             },
@@ -675,6 +708,142 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
             fingerprint: postgresQueryFingerprint(this.#observation, query),
             prepared: this.#prepared.queries.has(query),
           });
+    if (this.#client !== undefined) this.#transactionStreams.add(exposedStream as QueryStream<unknown>);
+    return exposedStream;
+  }
+
+  async #copyFrom(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {
+    assertExecutionCapabilities(this.executionCapabilities, options);
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("start COPY FROM");
+    this.#rejectOperationDuringTransactionBatch("start COPY FROM");
+    this.#rejectOperationDuringTransactionCopy("start another COPY operation");
+    this.#rejectOperationDuringTransactionExecute("start COPY FROM");
+    this.#rejectOperationDuringTransactionPipeline("start COPY FROM");
+    await this.#pool.ensureCopy?.();
+    const client = this.#client ?? (await this.#pool.connect());
+    let sink: PostgresCopyFromSink | undefined;
+    const operation = runControlledExecution(
+      options,
+      async () => {
+        if (client.openCopyFrom === undefined) {
+          throw new Error(
+            "PostgreSQL COPY requires the application-owned pg-copy-streams package. Install it with: pnpm add pg-copy-streams",
+          );
+        }
+        sink = await client.openCopyFrom(statement);
+        try {
+          for await (const chunk of chunks) await sink.write(chunk);
+          await sink.finish();
+        } catch (error) {
+          try {
+            await sink.abort(error);
+          } catch {
+            /* Preserve the producer or database failure. */
+          }
+          throw error;
+        }
+      },
+      (error) => {
+        void sink?.abort(error).catch(() => undefined);
+      },
+    );
+    if (this.#client !== undefined) this.#transactionState.activeCopy = operation;
+    try {
+      await operation;
+      if (this.#client === undefined) client.release();
+    } catch (error) {
+      this.#recordTransactionOperationFailure(error);
+      if (this.#client === undefined) {
+        try {
+          client.release(error instanceof Error ? error : true);
+        } catch {
+          /* Preserve the COPY failure. */
+        }
+      }
+      throw error;
+    } finally {
+      if (this.#transactionState.activeCopy === operation) this.#transactionState.activeCopy = undefined;
+    }
+  }
+
+  #copyTo(statement: string, options: ExecutionOptions): QueryStream<Uint8Array> {
+    assertExecutionCapabilities(this.executionCapabilities, options);
+    this.#assertTransactionScopeOpen();
+    this.#rejectOperationDuringTransactionStream("start COPY TO");
+    this.#rejectOperationDuringTransactionBatch("start COPY TO");
+    this.#rejectOperationDuringTransactionCopy("start COPY TO");
+    this.#rejectOperationDuringTransactionPipeline("start COPY TO");
+    let exposedStream: QueryStream<Uint8Array>;
+    const stream = new PostgresQueryStream<Uint8Array>({
+      batchSize: 1,
+      start: async () => {
+        await this.#pool.ensureCopy?.();
+        const client = this.#client ?? (await this.#pool.connect());
+        const release =
+          this.#client === undefined
+            ? (cleanupError?: unknown): void =>
+                client.release(
+                  cleanupError === undefined ? undefined : cleanupError instanceof Error ? cleanupError : true,
+                )
+            : undefined;
+        if (client.openCopyTo === undefined) {
+          try {
+            release?.();
+          } catch {
+            /* The missing optional dependency remains primary. */
+          }
+          throw new Error(
+            "PostgreSQL COPY requires the application-owned pg-copy-streams package. Install it with: pnpm add pg-copy-streams",
+          );
+        }
+        try {
+          const source = await client.openCopyTo(statement);
+          return {
+            cursor: {
+              async read(): Promise<readonly Uint8Array[]> {
+                const result = await runControlledExecution(
+                  options,
+                  () => source.next(),
+                  (error) => {
+                    void source.abort(error).catch(() => undefined);
+                  },
+                );
+                return result.done === true ? [] : [result.value];
+              },
+              close: () => source.close(),
+            },
+            ...(release === undefined ? {} : { release }),
+          };
+        } catch (error) {
+          this.#recordTransactionOperationFailure(error);
+          try {
+            release?.(error);
+          } catch {
+            /* Preserve source creation or optional-dependency failures. */
+          }
+          throw error;
+        }
+      },
+      ...(this.#client === undefined
+        ? {}
+        : {
+            onStart: () => {
+              this.#assertTransactionScopeOpen();
+              this.#rejectOperationDuringTransactionStream("start COPY TO");
+              this.#rejectOperationDuringTransactionBatch("start COPY TO");
+              this.#rejectOperationDuringTransactionCopy("start COPY TO");
+              this.#rejectOperationDuringTransactionPipeline("start COPY TO");
+              this.#transactionState.activeStreams.add(exposedStream as QueryStream<unknown>);
+            },
+            onClose: () => {
+              this.#transactionState.activeStreams.delete(exposedStream as QueryStream<unknown>);
+              this.#transactionStreams.delete(exposedStream as QueryStream<unknown>);
+            },
+            onError: (error: unknown) => this.#recordTransactionOperationFailure(error),
+          }),
+    });
+    exposedStream = stream;
     if (this.#client !== undefined) this.#transactionStreams.add(exposedStream as QueryStream<unknown>);
     return exposedStream;
   }
@@ -710,6 +879,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     this.#assertTransactionScopeOpen();
     this.#rejectOperationDuringTransactionStream("start a nested transaction");
     this.#rejectOperationDuringTransactionBatch("start a nested transaction");
+    this.#rejectOperationDuringTransactionCopy("start a nested transaction");
     this.#rejectOperationDuringTransactionPipeline("start a nested transaction");
     if (this.#client !== undefined) return this.#nestedTransaction(fn);
     const client = await this.#pool.connect();
@@ -723,6 +893,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       this.#observation,
       {
         activeBatch: undefined,
+        activeCopy: undefined,
         activeExecutes: new Set(),
         activePipeline: undefined,
         activeStreams: new Set(),
@@ -764,6 +935,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       await scope.#closeTransactionStreamsPreservingError();
       await scope.#settleTransactionPipelinePreservingError();
       await scope.#settleTransactionBatchPreservingError();
+      await scope.#settleTransactionCopyPreservingError();
       if (!scope.#transactionState.leaseReleased) {
         try {
           await client.query("ROLLBACK");
@@ -827,6 +999,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       await scope.#closeTransactionStreamsPreservingError();
       await scope.#settleTransactionPipelinePreservingError();
       await scope.#settleTransactionBatchPreservingError();
+      await scope.#settleTransactionCopyPreservingError();
       if (scope.#transactionState.valid && !scope.#transactionState.leaseReleased) {
         try {
           await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
@@ -904,11 +1077,13 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     const leakedExecutes = this.#transactionExecutes.size > 0 || this.#transactionState.activeExecutes.size > 0;
     const leakedPipeline = this.#transactionState.activePipeline !== undefined;
     const leakedBatch = this.#transactionState.activeBatch !== undefined;
-    if (!leakedStreams && !leakedExecutes && !leakedPipeline && !leakedBatch) return;
+    const leakedCopy = this.#transactionState.activeCopy !== undefined;
+    if (!leakedStreams && !leakedExecutes && !leakedPipeline && !leakedBatch && !leakedCopy) return;
     await this.#settleTransactionExecutesPreservingError();
     await this.#closeTransactionStreamsPreservingError();
     await this.#settleTransactionPipelinePreservingError();
     await this.#settleTransactionBatchPreservingError();
+    await this.#settleTransactionCopyPreservingError();
     if (leakedExecutes) {
       throw new Error(
         "A PostgreSQL transaction callback returned before an execute operation completed; await execute before returning",
@@ -922,6 +1097,11 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     if (leakedPipeline) {
       throw new Error(
         "A PostgreSQL transaction callback returned before its query pipeline completed; await the pipeline before returning",
+      );
+    }
+    if (leakedCopy) {
+      throw new Error(
+        "A PostgreSQL transaction callback returned before its COPY operation completed; await COPY before returning",
       );
     }
     throw new Error("A PostgreSQL transaction callback returned before all query streams were completed or closed");
@@ -969,6 +1149,16 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     }
   }
 
+  async #settleTransactionCopyPreservingError(): Promise<void> {
+    const operation = this.#transactionState.activeCopy;
+    if (operation === undefined) return;
+    try {
+      await operation;
+    } catch {
+      /* The callback or transaction misuse error remains primary. */
+    }
+  }
+
   #rejectOperationDuringTransactionStream(operation: string): void {
     if (this.#client !== undefined && this.#transactionState.activeStreams.size > 0) {
       throw new Error(
@@ -981,6 +1171,14 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     if (this.#client !== undefined && this.#transactionState.activeBatch !== undefined) {
       throw new Error(
         `Cannot ${operation} while a PostgreSQL transaction query batch is still running; await the batch first`,
+      );
+    }
+  }
+
+  #rejectOperationDuringTransactionCopy(operation: string): void {
+    if (this.#client !== undefined && this.#transactionState.activeCopy !== undefined) {
+      throw new Error(
+        `Cannot ${operation} while a PostgreSQL transaction COPY operation is still running; await COPY first`,
       );
     }
   }

--- a/packages/postgres/src/stream.ts
+++ b/packages/postgres/src/stream.ts
@@ -1,18 +1,18 @@
 import type { QueryStream } from "@typed-sql/core";
 
-export interface PostgresCursorLike {
-  read(rowCount: number): Promise<readonly Record<string, unknown>[]>;
+export interface PostgresCursorLike<Row = Record<string, unknown>> {
+  read(rowCount: number): Promise<readonly Row[]>;
   close(): Promise<void>;
 }
 
-export interface PostgresCursorLease {
-  readonly cursor: PostgresCursorLike;
+export interface PostgresCursorLease<Row = Record<string, unknown>> {
+  readonly cursor: PostgresCursorLike<Row>;
   release?(cleanupError?: unknown): void | Promise<void>;
 }
 
-export interface PostgresQueryStreamOptions {
+export interface PostgresQueryStreamOptions<Row = Record<string, unknown>> {
   readonly batchSize: number;
-  readonly start: () => Promise<PostgresCursorLease>;
+  readonly start: () => Promise<PostgresCursorLease<Row>>;
   readonly onError?: (error: unknown) => void;
   readonly onStart?: () => void;
   readonly onClose?: () => void;
@@ -31,17 +31,17 @@ function done(): IteratorReturnResult<undefined> {
  */
 export class PostgresQueryStream<Row> implements QueryStream<Row> {
   readonly #batchSize: number;
-  readonly #start: () => Promise<PostgresCursorLease>;
+  readonly #start: () => Promise<PostgresCursorLease<Row>>;
   readonly #onClose: (() => void) | undefined;
   readonly #onError: ((error: unknown) => void) | undefined;
   readonly #onStart: (() => void) | undefined;
   #buffer: readonly Row[] = [];
   #bufferIndex = 0;
-  #lease: PostgresCursorLease | undefined;
+  #lease: PostgresCursorLease<Row> | undefined;
   #operation: Promise<void> = Promise.resolve();
   #terminal = false;
 
-  constructor(options: PostgresQueryStreamOptions) {
+  constructor(options: PostgresQueryStreamOptions<Row>) {
     this.#batchSize = options.batchSize;
     this.#start = options.start;
     this.#onStart = options.onStart;

--- a/packages/postgres/test/bulk-runtime.test.ts
+++ b/packages/postgres/test/bulk-runtime.test.ts
@@ -1,0 +1,214 @@
+import { getAdapterCapability, type QueryStream, requireAdapterCapability, sql } from "@typed-sql/core";
+import { describe, it, strict } from "poku";
+import { postgresCopy } from "../src/bulk.js";
+import {
+  createPostgresDatabase,
+  type PostgresClientLike,
+  type PostgresCopyFromSink,
+  type PostgresCopyToSource,
+  type PostgresPoolLike,
+  type PostgresQueryConfig,
+  type PostgresQueryResult,
+} from "../src/runtime.js";
+
+class ByteSource implements PostgresCopyToSource {
+  readonly chunks: Uint8Array[];
+  closeCount = 0;
+  abortCount = 0;
+
+  constructor(chunks: readonly string[]) {
+    this.chunks = chunks.map((value) => new TextEncoder().encode(value));
+  }
+
+  [Symbol.asyncIterator](): this {
+    return this;
+  }
+  async next(): Promise<IteratorResult<Uint8Array, undefined>> {
+    const value = this.chunks.shift();
+    return value === undefined ? { done: true, value: undefined } : { done: false, value };
+  }
+  async return(): Promise<IteratorResult<Uint8Array, undefined>> {
+    await this.close();
+    return { done: true, value: undefined };
+  }
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+  async abort(): Promise<void> {
+    this.abortCount += 1;
+  }
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+}
+
+class CopyClient implements PostgresClientLike {
+  readonly commands: string[] = [];
+  readonly written: Uint8Array[] = [];
+  readonly copyToStatements: string[] = [];
+  readonly copyFromStatements: string[] = [];
+  readonly source = new ByteSource(["1,one@example.com\n", "2,two@example.com\n"]);
+  releaseArguments: (Error | boolean | undefined)[] = [];
+  finishCount = 0;
+  abortCount = 0;
+  writeError: Error | undefined;
+  #rejectWrite: ((error: unknown) => void) | undefined;
+  hangWrites = false;
+  writeStarted = false;
+
+  async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
+    this.commands.push(typeof config === "string" ? config : config.text);
+    return { rows: [] };
+  }
+  async openCopyFrom(statement: string): Promise<PostgresCopyFromSink> {
+    this.copyFromStatements.push(statement);
+    return {
+      write: async (chunk) => {
+        this.writeStarted = true;
+        if (this.writeError !== undefined) throw this.writeError;
+        if (this.hangWrites) {
+          await new Promise<void>((_resolve, reject) => {
+            this.#rejectWrite = reject;
+          });
+        }
+        this.written.push(chunk);
+      },
+      finish: async () => {
+        this.finishCount += 1;
+      },
+      abort: async () => {
+        this.abortCount += 1;
+        this.#rejectWrite?.(new Error("COPY sink aborted"));
+      },
+    };
+  }
+  async openCopyTo(statement: string): Promise<PostgresCopyToSource> {
+    this.copyToStatements.push(statement);
+    return this.source;
+  }
+  release(error?: Error | boolean): void {
+    this.releaseArguments.push(error);
+  }
+}
+
+class CopyPool implements PostgresPoolLike {
+  readonly executionCapabilities = { cancellation: true, deadlines: true } as const;
+  readonly client = new CopyClient();
+  connectCount = 0;
+  ensureCount = 0;
+
+  async query(): Promise<PostgresQueryResult> {
+    return { rows: [] };
+  }
+  async ensureCopy(): Promise<void> {
+    this.ensureCount += 1;
+  }
+  async connect(): Promise<PostgresClientLike> {
+    this.connectCount += 1;
+    return this.client;
+  }
+  async end(): Promise<void> {}
+}
+
+const insert = (row: { readonly id: bigint; readonly email: string }) =>
+  sql`INSERT INTO account (id, email) VALUES (${row.id}, ${row.email})`;
+
+await describe("PostgreSQL COPY runtime lifecycle", async () => {
+  await it("discovers COPY only on capable pools and releases a root import lease", async () => {
+    const pool = new CopyPool();
+    const database = createPostgresDatabase({ pool });
+    const copy = requireAdapterCapability(database, postgresCopy);
+    const result = await copy.copyFrom(insert, [
+      { id: 1n, email: "one@example.com" },
+      { id: 2n, email: "two@example.com" },
+    ]);
+
+    strict.deepStrictEqual(result.rows, 2);
+    strict.strictEqual(pool.connectCount, 1);
+    strict.strictEqual(pool.ensureCount, 1);
+    strict.strictEqual(pool.client.finishCount, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+    strict.strictEqual(
+      new TextDecoder().decode(Buffer.concat(pool.client.written)),
+      '"1","one@example.com"\n"2","two@example.com"\n',
+    );
+
+    const unsupported = createPostgresDatabase({
+      pool: {
+        query: async () => ({ rows: [] }),
+        connect: async () => pool.client,
+        end: async () => undefined,
+      },
+    });
+    strict.strictEqual(getAdapterCapability(unsupported, postgresCopy), undefined);
+  });
+
+  await it("uses the transaction lease and commits only after COPY finishes", async () => {
+    const pool = new CopyPool();
+    await createPostgresDatabase({ pool }).transaction(async (transaction) => {
+      const copy = requireAdapterCapability(transaction, postgresCopy);
+      await copy.copyFrom(insert, [{ id: 1n, email: "one@example.com" }]);
+      strict.deepStrictEqual(pool.client.releaseArguments, []);
+    });
+    strict.deepStrictEqual(pool.client.commands, ["BEGIN", "COMMIT"]);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("keeps COPY TO lazy, streams bounded native chunks, and releases on completion", async () => {
+    const pool = new CopyPool();
+    const copy = requireAdapterCapability(createPostgresDatabase({ pool }), postgresCopy);
+    const stream: QueryStream<Uint8Array> = copy.copyTo(
+      sql.__typed<{ readonly id: bigint; readonly email: string }, readonly []>()`
+        SELECT id, email FROM account ORDER BY id
+      `,
+    );
+    strict.strictEqual(pool.connectCount, 0);
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    strict.strictEqual(new TextDecoder().decode(Buffer.concat(chunks)), "1,one@example.com\n2,two@example.com\n");
+    strict.strictEqual(pool.connectCount, 1);
+    strict.strictEqual(pool.client.source.closeCount, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("closes COPY TO and releases its lease when the consumer stops early", async () => {
+    const pool = new CopyPool();
+    const copy = requireAdapterCapability(createPostgresDatabase({ pool }), postgresCopy);
+    const stream = copy.copyTo(sql.__typed<{ readonly id: bigint }, readonly []>()`SELECT id FROM account`);
+    strict.deepStrictEqual(await stream.next(), {
+      done: false,
+      value: new TextEncoder().encode("1,one@example.com\n"),
+    });
+    await stream.close();
+    strict.strictEqual(pool.client.source.closeCount, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [undefined]);
+  });
+
+  await it("aborts COPY FROM and discards a root lease after database failure", async () => {
+    const pool = new CopyPool();
+    const failure = new Error("COPY constraint failure");
+    pool.client.writeError = failure;
+    const copy = requireAdapterCapability(createPostgresDatabase({ pool }), postgresCopy);
+    await strict.rejects(() => copy.copyFrom(insert, [{ id: 1n, email: "one@example.com" }]), failure);
+    strict.strictEqual(pool.client.abortCount, 1);
+    strict.deepStrictEqual(pool.client.releaseArguments, [failure]);
+  });
+
+  await it("cancels an in-flight COPY FROM, aborts native work, and discards the lease", async () => {
+    const pool = new CopyPool();
+    pool.client.hangWrites = true;
+    const controller = new AbortController();
+    const copy = requireAdapterCapability(createPostgresDatabase({ pool }), postgresCopy);
+    const running = copy.copyFrom(insert, [{ id: 1n, email: "one@example.com" }], {
+      signal: controller.signal,
+    });
+    while (!pool.client.writeStarted) await Promise.resolve();
+    controller.abort("request closed");
+    await strict.rejects(running, (error) => {
+      strict.strictEqual((error as { readonly code?: unknown }).code, "TSQL_CANCELLED");
+      return true;
+    });
+    strict.ok(pool.client.abortCount >= 1);
+    strict.ok(pool.client.releaseArguments[0] instanceof Error);
+  });
+});

--- a/packages/postgres/test/bulk.test.ts
+++ b/packages/postgres/test/bulk.test.ts
@@ -1,0 +1,228 @@
+import type { Query, QueryStream } from "@typed-sql/core";
+import { sql } from "@typed-sql/postgres";
+import { describe, it, strict } from "poku";
+import { createPostgresCopyCapability, type PostgresCopyTransport } from "../src/bulk.js";
+
+class EmptyByteStream implements QueryStream<Uint8Array> {
+  [Symbol.asyncIterator](): this {
+    return this;
+  }
+  async next(): Promise<IteratorResult<Uint8Array, undefined>> {
+    return { done: true, value: undefined };
+  }
+  async return(): Promise<IteratorResult<Uint8Array, undefined>> {
+    return { done: true, value: undefined };
+  }
+  async close(): Promise<void> {}
+  async [Symbol.asyncDispose](): Promise<void> {}
+}
+
+function recorder() {
+  const statements: string[] = [];
+  const chunks: Uint8Array[] = [];
+  const transport: PostgresCopyTransport = {
+    async copyFrom(statement, source) {
+      statements.push(statement);
+      for await (const chunk of source) chunks.push(chunk);
+    },
+    copyTo(statement) {
+      statements.push(statement);
+      return new EmptyByteStream();
+    },
+  };
+  return { capability: createPostgresCopyCapability(transport), chunks, statements };
+}
+
+const decode = (chunks: readonly Uint8Array[]): string => new TextDecoder().decode(Buffer.concat(chunks));
+
+await describe("PostgreSQL COPY capability", async () => {
+  await it("derives COPY columns and ordered CSV values from a typed INSERT factory", async () => {
+    const { capability, chunks, statements } = recorder();
+    const progress: { readonly rows: number; readonly bytes: number }[] = [];
+    const result = await capability.copyFrom(
+      (row: { readonly id: bigint; readonly email: string; readonly active: boolean; readonly note: string | null }) =>
+        sql`INSERT INTO public.account (id, email, active, note) VALUES (${row.id}, ${row.email}, ${row.active}, ${row.note})`,
+      [
+        { id: 1n, email: "one@example.com", active: true, note: null },
+        { id: 2n, email: 'two,"quoted"@example.com', active: false, note: "line\nbreak" },
+      ],
+      { chunkBytes: 16, onProgress: (value) => progress.push(value) },
+    );
+
+    strict.deepStrictEqual(statements, [
+      'COPY "public"."account" ("id", "email", "active", "note") FROM STDIN WITH (FORMAT csv)',
+    ]);
+    strict.strictEqual(
+      decode(chunks),
+      '"1","one@example.com","true",\n"2","two,""quoted""@example.com","false","line\nbreak"\n',
+    );
+    strict.deepStrictEqual(result, { rows: 2, bytes: 84 });
+    strict.deepStrictEqual(progress.at(-1), result);
+  });
+
+  await it("does no driver work for an empty input", async () => {
+    const { capability, statements } = recorder();
+    const result = await capability.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, []);
+    strict.deepStrictEqual(result, { rows: 0, bytes: 0 });
+    strict.deepStrictEqual(statements, []);
+  });
+
+  await it("uses PostgreSQL-compatible text input for dates, JSON, bytea, and arrays", async () => {
+    const { capability, chunks } = recorder();
+    await capability.copyFrom(
+      (row: {
+        readonly createdAt: Date;
+        readonly payload: { readonly enabled: boolean };
+        readonly bytes: Uint8Array;
+        readonly tags: readonly string[];
+      }) => sql`
+        INSERT INTO event (created_at, payload, bytes, tags)
+        VALUES (${row.createdAt}, ${row.payload}, ${row.bytes}, ${row.tags})
+      `,
+      [
+        {
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          payload: { enabled: true },
+          bytes: new Uint8Array([0, 255]),
+          tags: ["one", "two"],
+        },
+      ],
+    );
+    strict.strictEqual(
+      decode(chunks),
+      '"2026-01-01T00:00:00.000Z","{""enabled"":true}","\\x00ff","{""one"",""two""}"\n',
+    );
+  });
+
+  await it("encodes nested arrays and PostgreSQL null array elements", async () => {
+    const { capability, chunks } = recorder();
+    await capability.copyFrom(
+      (row: { readonly values: readonly unknown[]; readonly optional: undefined }) =>
+        sql`INSERT INTO array_input (array_values, optional) VALUES (${row.values}, ${row.optional})`,
+      [{ values: [null, undefined, ["nested"]], optional: undefined }],
+    );
+    const output = decode(chunks);
+    strict.ok(output.includes("NULL,NULL"));
+    strict.ok(output.endsWith(",\n"));
+  });
+
+  await it("fails closed when a later row changes structural SQL", async () => {
+    const { capability } = recorder();
+    await strict.rejects(
+      capability.copyFrom(
+        (row: { readonly id: bigint; readonly alternate: boolean }) =>
+          row.alternate
+            ? sql`INSERT INTO archive (id) VALUES (${row.id})`
+            : sql`INSERT INTO account (id) VALUES (${row.id})`,
+        [
+          { id: 1n, alternate: false },
+          { id: 2n, alternate: true },
+        ],
+      ),
+      /changed its structural SQL shape/u,
+    );
+  });
+
+  await it("rejects statements that cannot soundly map one input row", async () => {
+    const { capability } = recorder();
+    await strict.rejects(
+      capability.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id}) RETURNING id`, [1n]),
+      /plain single-row INSERT/u,
+    );
+    await strict.rejects(
+      capability.copyFrom((id: bigint) => sql`UPDATE account SET id = ${id}`, [1n]),
+      /plain single-row INSERT/u,
+    );
+    await strict.rejects(
+      capability.copyFrom((id: bigint) => sql`INSERT INTO account VALUES (${id})`, [1n]),
+      /plain single-row INSERT/u,
+    );
+    await strict.rejects(
+      capability.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id} + 1)`, [1n]),
+      /one ordered parameter/u,
+    );
+  });
+
+  await it("rejects invalid chunk sizes and values without driver work", async () => {
+    const { capability, statements } = recorder();
+    for (const chunkBytes of [0, 1.5]) {
+      await strict.rejects(
+        capability.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, [1n], { chunkBytes }),
+        /positive safe integer/u,
+      );
+    }
+    for (const value of [Number.POSITIVE_INFINITY, new Date(Number.NaN), Symbol("unsupported")]) {
+      await strict.rejects(
+        capability.copyFrom((input: unknown) => sql`INSERT INTO account (value) VALUES (${input})`, [value]),
+        /cannot encode/u,
+      );
+    }
+    strict.strictEqual(statements.length, 3);
+  });
+
+  await it("wraps a static typed SELECT for COPY TO STDOUT", async () => {
+    const { capability, statements } = recorder();
+    await capability
+      .copyTo(sql.__typed<{ readonly id: bigint }, readonly []>()`SELECT account.id FROM account ORDER BY account.id`)
+      .close();
+    strict.deepStrictEqual(statements, [
+      "COPY (SELECT account.id FROM account ORDER BY account.id) TO STDOUT WITH (FORMAT csv)",
+    ]);
+
+    const parameterized = sql.__typed<{ readonly id: bigint }, readonly [bigint]>()`
+      SELECT account.id FROM account WHERE account.id = ${1n}
+    ` as unknown as Query<{ readonly id: bigint }, readonly []>;
+    strict.throws(() => capability.copyTo(parameterized), /only static queries/u);
+    strict.throws(
+      () => capability.copyTo(sql.__typed<never, readonly []>()`UPDATE account SET active = true`),
+      /requires a SELECT/u,
+    );
+  });
+
+  await it("honors cancellation before acquiring a transport", async () => {
+    const { capability, statements } = recorder();
+    const controller = new AbortController();
+    controller.abort("stop");
+    await strict.rejects(
+      capability.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, [1n], {
+        signal: controller.signal,
+      }),
+      (error) => error instanceof Error && error.name === "QueryCancelledError",
+    );
+    strict.deepStrictEqual(statements, []);
+  });
+
+  await it("closes a producer exactly once when the transport rejects before consuming", async () => {
+    let returns = 0;
+    const failure = new Error("transport unavailable");
+    const capability = createPostgresCopyCapability({
+      async copyFrom() {
+        throw failure;
+      },
+      copyTo() {
+        return new EmptyByteStream();
+      },
+    });
+    const rows: AsyncIterable<bigint> = {
+      [Symbol.asyncIterator]() {
+        let delivered = false;
+        return {
+          async next() {
+            if (delivered) return { done: true, value: undefined };
+            delivered = true;
+            return { done: false, value: 1n };
+          },
+          async return() {
+            returns += 1;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    await strict.rejects(
+      () => capability.copyFrom((id) => sql`INSERT INTO account (id) VALUES (${id})`, rows),
+      failure,
+    );
+    strict.strictEqual(returns, 1);
+  });
+});

--- a/packages/postgres/test/pg.test.ts
+++ b/packages/postgres/test/pg.test.ts
@@ -1,8 +1,18 @@
 import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
 import type { Pool as PgPool } from "pg";
 import { describe, it, strict } from "poku";
-import { type DatabaseOperationEnd, sql } from "../../core/src/index.js";
-import { adaptPgPool, createPgDatabase, loadPgCursorDriver, loadPgDriver, type PgOptions, pg } from "../src/pg.js";
+import { type DatabaseOperationEnd, requireAdapterCapability, sql } from "../../core/src/index.js";
+import { postgresCopy } from "../src/index.js";
+import {
+  adaptPgPool,
+  createPgDatabase,
+  loadPgCopyStreams,
+  loadPgCursorDriver,
+  loadPgDriver,
+  type PgOptions,
+  pg,
+} from "../src/pg.js";
 import type { PostgresQueryable, PostgresQueryResult } from "../src/provider.js";
 import { createPostgresDatabase, type PostgresQueryConfig } from "../src/runtime.js";
 
@@ -50,8 +60,27 @@ class FakePgClient extends EventEmitter {
   releaseError: Error | boolean | undefined;
   queryError: Error | undefined;
   readonly calls: unknown[] = [];
-  query(config: unknown): Promise<{ rows: readonly Record<string, unknown>[] }> | FakeNativeCursor {
+  readonly copyInput: Buffer[] = [];
+  readonly copyStatements: string[] = [];
+  query(
+    config: unknown,
+  ): Promise<{ rows: readonly Record<string, unknown>[] }> | FakeNativeCursor | Readable | Writable {
     this.calls.push(config);
+    if (typeof config === "object" && config !== null && "copy" in config && "statement" in config) {
+      const marker = config as { readonly copy: "from" | "to"; readonly statement: string };
+      this.copyStatements.push(marker.statement);
+      if (marker.copy === "to") {
+        return marker.statement.includes("string")
+          ? Readable.from(["1,one@example.com\n"])
+          : Readable.from([Buffer.from("1,one@example.com\n")]);
+      }
+      return new Writable({
+        write: (chunk, _encoding, callback) => {
+          this.copyInput.push(Buffer.from(chunk));
+          callback();
+        },
+      });
+    }
     if (
       typeof config === "object" &&
       config !== null &&
@@ -275,6 +304,62 @@ await describe("application-owned pg integration", async () => {
     strict.strictEqual(cursor?.closeCount, 1);
   });
 
+  await it("bridges application-owned COPY streams and makes early export close successful", async () => {
+    const original = new FakePgPool();
+    let imports = 0;
+    const pool = adaptPgPool(
+      original as unknown as PgPool,
+      async () => ({ default: FakePgCursor }),
+      async () => {
+        imports += 1;
+        return {
+          from: (statement: string) => ({ copy: "from", statement }),
+          to: (statement: string) => ({ copy: "to", statement }),
+        };
+      },
+    );
+    await pool.ensureCopy!();
+    const client = await pool.connect();
+    const sink = await client.openCopyFrom!("COPY account FROM STDIN");
+    await sink.write(new TextEncoder().encode("1\tone@example.com\n"));
+    await sink.finish();
+    strict.strictEqual(Buffer.concat(original.client.copyInput).toString("utf8"), "1\tone@example.com\n");
+
+    const source = await client.openCopyTo!("COPY account TO STDOUT");
+    strict.deepStrictEqual(await source.next(), {
+      done: false,
+      value: Buffer.from("1,one@example.com\n"),
+    });
+    await source.close();
+
+    const completed = await client.openCopyTo!("COPY complete TO STDOUT");
+    await completed.next();
+    strict.deepStrictEqual(await completed.next(), { done: true, value: undefined });
+    await completed.close();
+
+    const returned = await client.openCopyTo!("COPY returned TO STDOUT");
+    await returned.return!();
+    const disposed = await client.openCopyTo!("COPY disposed TO STDOUT");
+    await disposed[Symbol.asyncDispose]();
+    const stringSource = await client.openCopyTo!("COPY string TO STDOUT");
+    strict.deepStrictEqual((await stringSource.next()).value, Buffer.from("1,one@example.com\n"));
+    await stringSource.close();
+
+    const abortedSink = await client.openCopyFrom!("COPY aborted FROM STDIN");
+    await abortedSink.abort("stop");
+    strict.deepStrictEqual(original.client.copyStatements, [
+      "COPY account FROM STDIN",
+      "COPY account TO STDOUT",
+      "COPY complete TO STDOUT",
+      "COPY returned TO STDOUT",
+      "COPY disposed TO STDOUT",
+      "COPY string TO STDOUT",
+      "COPY aborted FROM STDIN",
+    ]);
+    strict.strictEqual(imports, 1);
+    client.release();
+  });
+
   await it("discards the client with the primary cursor SQL error", async () => {
     const sqlError = new Error("invalid input syntax");
     let closeCount = 0;
@@ -426,6 +511,20 @@ await describe("application-owned pg integration", async () => {
     strict.strictEqual(await loadPgCursorDriver(async () => ({ default: FakePgCursor })), FakePgCursor);
   });
 
+  await it("normalizes missing or invalid application-owned pg-copy-streams failures", async () => {
+    const missing = Object.assign(new Error("missing"), { code: "ERR_MODULE_NOT_FOUND" });
+    await strict.rejects(
+      () =>
+        loadPgCopyStreams(async () => {
+          throw missing;
+        }),
+      /pnpm add pg-copy-streams/,
+    );
+    await strict.rejects(() => loadPgCopyStreams(async () => ({ from: () => undefined })), /from\(\).*to\(\)/);
+    const module = { from: () => ({}), to: () => ({}) };
+    strict.strictEqual(await loadPgCopyStreams(async () => module), module);
+  });
+
   await it("does not lease a pg client when the lazy cursor dependency is missing", async () => {
     const original = new FakePgPool();
     const missing = Object.assign(new Error("missing"), { code: "ERR_MODULE_NOT_FOUND" });
@@ -437,6 +536,22 @@ await describe("application-owned pg integration", async () => {
     const stream = database.stream(sql`SELECT 1`);
     strict.strictEqual(original.connectCount, 0);
     await strict.rejects(() => stream.next(), /pnpm add pg-cursor/);
+    strict.strictEqual(original.connectCount, 0);
+  });
+
+  await it("does not lease a pg client when the lazy COPY dependency is missing", async () => {
+    const original = new FakePgPool();
+    const missing = Object.assign(new Error("missing"), { code: "ERR_MODULE_NOT_FOUND" });
+    const database = createPostgresDatabase({
+      pool: adaptPgPool(original as unknown as PgPool, undefined, async () => {
+        throw missing;
+      }),
+    });
+    const copy = requireAdapterCapability(database, postgresCopy);
+    await strict.rejects(
+      () => copy.copyFrom((id: bigint) => sql`INSERT INTO account (id) VALUES (${id})`, [1n]),
+      /pnpm add pg-copy-streams/,
+    );
     strict.strictEqual(original.connectCount, 0);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       pg:
         specifier: 8.23.0
         version: 8.23.0
+      pg-copy-streams:
+        specifier: 7.0.0
+        version: 7.0.0
       pg-cursor:
         specifier: 2.22.0
         version: 2.22.0(pg@8.23.0)
@@ -2443,6 +2446,9 @@ packages:
 
   pg-connection-string@2.14.0:
     resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-copy-streams@7.0.0:
+    resolution: {integrity: sha512-zBvnY6wtaBRE2ae2xXWOOGMaNVPkXh1vhypAkNSKgMdciJeTyIQAHZaEeRAxUjs/p1El5jgzYmwG5u871Zj3dQ==}
 
   pg-cursor@2.22.0:
     resolution: {integrity: sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==}
@@ -5170,6 +5176,8 @@ snapshots:
     optional: true
 
   pg-connection-string@2.14.0: {}
+
+  pg-copy-streams@7.0.0: {}
 
   pg-cursor@2.22.0(pg@8.23.0):
     dependencies:

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -16,6 +16,7 @@ const expectedPublicDocs = [
   "docs/getting-started/configuration.md",
   "docs/getting-started/first-query.md",
   "docs/getting-started/installation.md",
+  "docs/guides/bulk-data.md",
   "docs/guides/composition.md",
   "docs/guides/editors.md",
   "docs/guides/execution.md",

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -23,7 +23,7 @@ interface PackageManifest {
 
 const directory = dirname(fileURLToPath(import.meta.url));
 const workspace = resolve(directory, "../..");
-const forbiddenDrivers = new Set(["pg", "mysql2", "better-sqlite3", "sqlite3"]);
+const forbiddenDrivers = new Set(["pg", "pg-copy-streams", "mysql2", "better-sqlite3", "sqlite3"]);
 const publicPackages = [
   "ast",
   "core",
@@ -122,8 +122,11 @@ await describe("public package graph", async () => {
   await it("keeps pg entirely application-owned instead of declaring a peer", async () => {
     const packageManifest = await manifest("postgres");
     strict.strictEqual(packageManifest.dependencies?.pg, undefined);
+    strict.strictEqual(packageManifest.dependencies?.["pg-copy-streams"], undefined);
     strict.strictEqual(packageManifest.optionalDependencies?.pg, undefined);
+    strict.strictEqual(packageManifest.optionalDependencies?.["pg-copy-streams"], undefined);
     strict.strictEqual(packageManifest.peerDependencies?.pg, undefined);
+    strict.strictEqual(packageManifest.peerDependencies?.["pg-copy-streams"], undefined);
     strict.strictEqual(packageManifest.dependencies?.["@types/pg"], "8.23.1");
   });
 

--- a/test/contracts/performance-policy.test.ts
+++ b/test/contracts/performance-policy.test.ts
@@ -112,6 +112,7 @@ await describe("performance regression policy", async () => {
       "kysely",
       "mysql2",
       "pg",
+      "pg-copy-streams",
       "typeorm",
     ]) {
       strict.ok(manifest.dependencies[dependency] !== undefined, `comparison does not pin ${dependency}`);
@@ -120,6 +121,19 @@ await describe("performance regression policy", async () => {
     strict.ok(compose.includes("postgres:18.0-alpine"));
     strict.ok(compose.includes("mysql:9.5"));
     strict.ok(compose.includes("healthcheck:"));
+    strict.ok(compose.includes("--local-infile=ON"));
+    const bulk = await readFile(join(benchmark, "src", "bulk.ts"), "utf8");
+    for (const evidence of [
+      "typed-sql COPY FROM",
+      "typed-sql LOAD DATA",
+      "typed-sql ordered batch",
+      "typed-sql native pipeline",
+      "raw pg-copy-streams",
+      "raw mysql2 LOAD DATA",
+    ]) {
+      strict.ok(bulk.includes(evidence), `bulk comparison does not include ${evidence}`);
+    }
+    strict.ok(bulk.includes("BULK_BENCHMARK_ROW_COUNTS"));
     const documentation = await readFile(join(benchmark, "README.md"), "utf8");
     strict.ok(documentation.includes("not a universal leaderboard"));
     strict.ok(documentation.includes("generated numbers are intentionally ignored"));

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -77,6 +77,10 @@ import type {
 import * as conformanceApi from "../../packages/conformance/src/index.js";
 import type {
   ActiveDatabaseObservation,
+  AdapterCapability,
+  AdapterCapabilityHost,
+  AdapterCapabilityResolver,
+  AdapterCapabilityService,
   BatchOperationStart,
   ControlledQueryExecutor,
   Database,
@@ -150,7 +154,14 @@ import type {
   TypedSqlConfig,
 } from "../../packages/core/src/index.js";
 import * as coreApi from "../../packages/core/src/index.js";
-import type { MySqlQuerySemanticResolverOptions, MySqlRoutedDatabaseOptions } from "../../packages/mysql/src/index.js";
+import type {
+  MySqlBulkCapability,
+  MySqlBulkProgress,
+  MySqlBulkResult,
+  MySqlLoadDataOptions,
+  MySqlQuerySemanticResolverOptions,
+  MySqlRoutedDatabaseOptions,
+} from "../../packages/mysql/src/index.js";
 import * as mysqlApi from "../../packages/mysql/src/index.js";
 import * as mysql2Api from "../../packages/mysql/src/mysql2.js";
 import type { MySqlDatabase, MySqlPreparedQueryFactory, MySqlTransaction } from "../../packages/mysql/src/runtime.js";
@@ -158,6 +169,11 @@ import * as mysqlRuntimeApi from "../../packages/mysql/src/runtime.js";
 import type { OpenTelemetryObserverOptions } from "../../packages/opentelemetry/src/index.js";
 import * as openTelemetryApi from "../../packages/opentelemetry/src/index.js";
 import type {
+  PostgresCopyCapability,
+  PostgresCopyFromOptions,
+  PostgresCopyProgress,
+  PostgresCopyResult,
+  PostgresCopyToOptions,
   PostgresQuerySemanticResolverOptions,
   PostgresRoutedDatabaseOptions,
 } from "../../packages/postgres/src/index.js";
@@ -188,6 +204,17 @@ const queryResults: Assert<
 const rowInvariant: Assert<Equal<Assignable<ExactQuery, Query<{ readonly id: bigint }, readonly [bigint]>>, false>> =
   true;
 const parametersInvariant: Assert<Equal<Assignable<ExactQuery, Query<Account, readonly [unknown]>>, false>> = true;
+
+type CapabilityService = { readonly execute: (value: bigint) => Promise<void> };
+const capability = coreApi.defineAdapterCapability<CapabilityService>("contract.execute");
+const capabilityService: Assert<Equal<AdapterCapabilityService<typeof capability>, CapabilityService>> = true;
+const capabilityResolver: AdapterCapabilityResolver = coreApi.createAdapterCapabilityResolver([
+  [capability, { execute: async () => undefined }],
+]);
+const capabilityHost: AdapterCapabilityHost = { [coreApi.adapterCapabilities]: capabilityResolver };
+const optionalCapability: CapabilityService | undefined = coreApi.getAdapterCapability(capabilityHost, capability);
+const requiredCapability: CapabilityService = coreApi.requireAdapterCapability(capabilityHost, capability);
+const hasCapability: boolean = coreApi.hasAdapterCapability(capabilityHost, capability);
 
 const base = coreApi.sql<Account, readonly []>`SELECT account.id, account.status FROM account`;
 const predicate = coreApi.sql.fragment`account.id >= ${1n}`;
@@ -284,6 +311,34 @@ function mysqlPreparedContract(database: MySqlDatabase): ExactQuery {
     true;
   void exact;
   return prepared(1n);
+}
+
+interface BulkAccountInput {
+  readonly id: bigint;
+  readonly email: string;
+  readonly note: string | null;
+}
+
+const bulkAccountQuery = (row: BulkAccountInput) =>
+  coreApi.sql.__typed<never, readonly [bigint, string, string | null]>()`
+    INSERT INTO account (id, email, note) VALUES (${row.id}, ${row.email}, ${row.note})
+  `;
+
+function postgresCopyContract(database: PostgresDatabase): Promise<PostgresCopyResult> {
+  const copy = coreApi.requireAdapterCapability(database, postgresApi.postgresCopy);
+  void copy.copyTo(coreApi.sql.__typed<Account, readonly []>()`SELECT id, status FROM account`);
+  // @ts-expect-error COPY input rows retain the INSERT factory's scalar and nullability contract
+  void copy.copyFrom(bulkAccountQuery, [{ id: "1", email: "wrong@example.com", note: undefined }]);
+  // @ts-expect-error COPY TO cannot turn a parameterized query into a static export
+  void copy.copyTo(coreApi.sql.__typed<Account, readonly [bigint]>()`SELECT id, status FROM account WHERE id = ${1n}`);
+  return copy.copyFrom(bulkAccountQuery, [{ id: 1n, email: "one@example.com", note: null }]);
+}
+
+function mysqlBulkContract(database: MySqlDatabase): Promise<MySqlBulkResult> {
+  const bulk = coreApi.requireAdapterCapability(database, mysqlApi.mysqlBulk);
+  // @ts-expect-error LOAD DATA input rows retain the INSERT factory's scalar and nullability contract
+  void bulk.loadData(bulkAccountQuery, [{ id: 1n, email: 42, note: undefined }]);
+  return bulk.loadData(bulkAccountQuery, [{ id: 1n, email: "one@example.com", note: null }]);
 }
 
 function postgresStreamingContract(database: PostgresDatabase, query: ExactQuery): QueryStream<Account> {
@@ -423,6 +478,10 @@ type ReferencedStableTypes =
   | RuntimeAdapterConformanceFixture<Account, readonly [bigint]>
   | ControlledQueryExecutor
   | ActiveDatabaseObservation
+  | AdapterCapability<CapabilityService>
+  | AdapterCapabilityHost
+  | AdapterCapabilityResolver
+  | AdapterCapabilityService<typeof capability>
   | BatchOperationStart
   | DatabaseObservation
   | DatabaseObservationStatus
@@ -492,8 +551,17 @@ type ReferencedStableTypes =
   | TypedSqlConfig
   | PostgresQuerySemanticResolverOptions
   | PostgresRoutedDatabaseOptions
+  | PostgresCopyCapability
+  | PostgresCopyFromOptions
+  | PostgresCopyProgress
+  | PostgresCopyResult
+  | PostgresCopyToOptions
   | MySqlQuerySemanticResolverOptions
-  | MySqlRoutedDatabaseOptions;
+  | MySqlRoutedDatabaseOptions
+  | MySqlBulkCapability
+  | MySqlBulkProgress
+  | MySqlBulkResult
+  | MySqlLoadDataOptions;
 
 void queryRow;
 void queryParameters;
@@ -501,6 +569,10 @@ void queryResult;
 void queryResults;
 void rowInvariant;
 void parametersInvariant;
+void capabilityService;
+void optionalCapability;
+void requiredCapability;
+void hasCapability;
 void composedParameters;
 void emptyParameters;
 void executionContract;
@@ -516,6 +588,8 @@ void postgresTransactionOmitsClose;
 void mysqlTransactionOmitsClose;
 void postgresPreparedContract;
 void mysqlPreparedContract;
+void postgresCopyContract;
+void mysqlBulkContract;
 void postgresStreamingContract;
 void mysqlStreamingContract;
 void transactionStreamingContract;
@@ -583,11 +657,13 @@ const expectedRuntimeExports = {
   ],
   config: ["discoverConfig", "fromConfig", "loadConfig"],
   core: [
+    "UnsupportedAdapterCapabilityError",
     "QueryCancelledError",
     "QueryCardinalityError",
     "UnsupportedExecutionCapabilityError",
     "assertDialectPlugin",
     "assertExecutionCapabilities",
+    "adapterCapabilities",
     "bindQueryRenderSkeleton",
     "compileQueryRenderSkeleton",
     "DIALECT_CONTRACT_VERSION",
@@ -595,12 +671,16 @@ const expectedRuntimeExports = {
     "ResolverSchemaIndex",
     "closestName",
     "createDatabase",
+    "createAdapterCapabilityResolver",
     "createRoutedDatabase",
+    "defineAdapterCapability",
     "defineConfig",
     "defineQuerySemantics",
     "databaseErrorCompletion",
     "diagnosticRegistry",
     "executionDeadline",
+    "getAdapterCapability",
+    "hasAdapterCapability",
     "isTypedSqlDiagnosticCode",
     "mapQuerySemanticRanges",
     "mergeQuerySemantics",
@@ -609,6 +689,7 @@ const expectedRuntimeExports = {
     "queryRoute",
     "QUERY_SEMANTICS_VERSION",
     "renderQuery",
+    "requireAdapterCapability",
     "rowTypeLiteral",
     "runControlledExecution",
     "sql",
@@ -628,6 +709,7 @@ const expectedRuntimeExports = {
     "isMySqlRetryableTransactionError",
     "mapMySqlType",
     "mysql",
+    "mysqlBulk",
     "mysqlCatalogQueries",
     "parseSchemaSnapshot",
     "sql",
@@ -656,6 +738,7 @@ const expectedRuntimeExports = {
     "mapPostgresType",
     "parseSchemaSnapshot",
     "postgres",
+    "postgresCopy",
     "postgresCatalogQueries",
     "sql",
     "typePolicy",
@@ -666,6 +749,7 @@ const expectedRuntimeExports = {
     "createPgLiveVerifier",
     "createPgPlanInspector",
     "loadPgCursorDriver",
+    "loadPgCopyStreams",
     "loadPgDriver",
     "pg",
   ],

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Execute queries", link: "/guides/execution" },
+          { text: "Transfer bulk data", link: "/guides/bulk-data" },
           { text: "Observe database work", link: "/guides/observability" },
           { text: "Route reads and retry transactions", link: "/guides/routing-and-retries" },
           { text: "Emit query manifests", link: "/guides/query-manifests" },


### PR DESCRIPTION
Closes #56

## Summary

- add grammar-neutral optional adapter capability discovery without protocol or driver dependencies in core
- add typed PostgreSQL COPY FROM/TO through application-owned `pg-copy-streams`
- add typed MySQL `LOAD DATA LOCAL INFILE` through mysql2 with an exact application-owned sentinel stream
- enforce structural INSERT stability, bounded backpressure, cancellation, transaction ownership, and conservative lease cleanup
- add real-database E2E coverage, direct-driver/batch/pipeline benchmarks, public API contracts, and durable docs

## Verification

- `pnpm verify` on Node 24.10.0
- `TYPED_SQL_CONTAINER_ENGINE=podman TYPED_SQL_E2E_PORT=55439 pnpm e2e:postgres`
- `TYPED_SQL_CONTAINER_ENGINE=podman TYPED_SQL_MYSQL_E2E_PORT=53309 pnpm e2e:mysql`
- full PostgreSQL/MySQL bulk benchmark at 100, 1,000, and 5,000 rows

The Node 22.5.1 shell is below the repository engine requirement and lacks `node:sqlite`; the canonical gate was therefore run with the supported installed Node 24.10.0 toolchain.