### PR TITLE
feat: add Standard Schema result validation

### DIFF
--- a/.changeset/warm-results-validate.md
+++ b/.changeset/warm-results-validate.md
@@ -1,0 +1,10 @@
+---
+"@typed-sql/core": major
+"@typed-sql/postgres": major
+"@typed-sql/mysql": major
+"@typed-sql/sqlite": minor
+---
+
+Add opt-in Standard Schema V1 result validation with compile-time output compatibility, immutable
+query attachment, sync and async validators, redacted fingerprinted errors, and consistent decoded-row
+handling across buffered cardinality methods, batches, PostgreSQL pipelines, streams, and transactions.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ codecs. The interpolation is also checked as `bigint` because it is compared wit
   application-owned replicas and support bounded retries for explicit transactions.
 - **Use native bulk protocols without losing SQL.** Optional PostgreSQL COPY and MySQL LOAD DATA
   capabilities compile ordinary typed `INSERT` factories into backpressured application streams.
+- **Validate only where runtime proof matters.** Attach any Standard Schema V1 validator to decoded
+  results without adding a validator dependency or changing the unvalidated query path.
 
 ## Install
 
@@ -162,6 +164,7 @@ the structural-variant bound.
 - [Documentation site](https://lojhan.github.io/typed-sql/)
 - [Documentation source](./docs/index.md)
 - [Execution adapters](./docs/guides/execution.md)
+- [Standard Schema result validation](./docs/guides/result-validation.md)
 - [Bulk data transfer](./docs/guides/bulk-data.md)
 - [Database observability](./docs/guides/observability.md)
 - [Query manifests](./docs/guides/query-manifests.md)

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -23,6 +23,7 @@ The production performance suite covers:
 - rejecting structural expansion before grammar work exceeds its bound;
 - core template construction, fragment composition, rendering, and prepared-skeleton binding;
 - adapter render, encode, decode, decoder-plan compilation and cache-hit throughput, 100-row stream, 25-query batch, and PostgreSQL pipeline overhead with deterministic fake drivers;
+- disabled and enabled Standard Schema result-validation overhead at adapter boundaries;
 - cold, unchanged, incrementally edited, and schema-reloaded language-service analysis;
 - cancellation before expensive analysis;
 - retained heap under cache pressure.

--- a/docs/concepts/type-safety.md
+++ b/docs/concepts/type-safety.md
@@ -52,7 +52,7 @@ Use `sql.dynamic()` for SQL whose structure cannot be represented statically. It
 
 ## Runtime trust boundaries
 
-Static types describe the configured schema and adapter policy. They do not validate untrusted request payloads, data written outside database constraints, or serialized responses. Add runtime validation wherever application trust boundaries require it.
+Static types describe the configured schema and adapter policy. They do not validate untrusted request payloads, data written outside database constraints, or serialized responses. At a database result boundary, `sql.validateResult(query, schema)` can attach an application-owned Standard Schema validator whose output agrees with the inferred row. See [Validate query results](../guides/result-validation.md) for the decoding order, execution behavior, and redaction policy.
 
 ## Resource limits
 

--- a/docs/guides/execution.md
+++ b/docs/guides/execution.md
@@ -109,6 +109,7 @@ All three retain the query's inferred row type. Cardinality is checked after the
 | `QueryCardinalityError` | `TSQL_CARDINALITY` | `expected`, `actual` |
 | `QueryCancelledError` | `TSQL_CANCELLED` | `reason` (`signal` or `deadline`) |
 | `UnsupportedExecutionCapabilityError` | `TSQL_UNSUPPORTED_EXECUTION_CAPABILITY` | `capability` |
+| `QueryResultValidationError` | `TSQL_RESULT_VALIDATION` | `fingerprint`, `rowIndex`, `vendor`, `failure`, `issues` |
 
 `deadline` is absolute, expressed as Unix milliseconds or a `Date`. A pre-aborted signal or expired deadline fails before leasing a connection. For an in-flight operation, the pg and mysql2 adapters interrupt conservatively by discarding the checked-out connection, then wait for driver settlement before rejecting. Inside a transaction, cancellation invalidates that transaction and discards its lease; do not catch the cancellation and continue using the scope.
 
@@ -230,6 +231,8 @@ try {
 ```
 
 `QueryStream` also implements `AsyncDisposable`, so runtimes that support explicit resource management can use `await using`.
+
+An attached [Standard Schema result validator](./result-validation.md) runs immediately before each decoded row is yielded. The first invalid row closes the native stream through the same idempotent cleanup path.
 
 PostgreSQL streaming requires the application-owned `pg-cursor` package in addition to `pg`. It is loaded only when iteration begins. MySQL streaming uses mysql2 itself and needs no additional package. See the [PostgreSQL](../dialects/postgresql.md#streaming) and [MySQL](../dialects/mysql.md#streaming) adapter details.
 

--- a/docs/guides/result-validation.md
+++ b/docs/guides/result-validation.md
@@ -1,0 +1,103 @@
+---
+title: Validate query results
+description: Add opt-in Standard Schema validation to inferred query results without coupling typed-sql to a validator library.
+---
+
+# Validate query results
+
+Compile-time inference proves the contract described by the configured database snapshot and codec policy. At an application trust boundary, you can additionally validate the decoded rows returned by the database.
+
+typed-sql accepts [Standard Schema V1](https://standardschema.dev/schema). The interface is implemented by Zod, Valibot, ArkType, Yup, Joi, and other validators, so neither `@typed-sql/core` nor a grammar package depends on a validator library.
+
+## Attach a validator
+
+Create an ordinary inferred query, then use `sql.validateResult(query, schema)`:
+
+```ts
+import { sql } from "@typed-sql/postgres";
+import { z } from "zod";
+
+const accountSchema = z.object({
+  id: z.bigint(),
+  email: z.string().email(),
+  status: z.enum(["active", "suspended"]),
+});
+
+const accountQuery = sql`
+  SELECT account.id, account.email, account.status
+  FROM accounts AS account
+  WHERE account.id = ${accountId}
+`;
+
+const validatedAccountQuery = sql.validateResult(accountQuery, accountSchema);
+const account = await database.maybeOne(validatedAccountQuery);
+```
+
+The returned query keeps the original ordered parameter tuple and uses the validator output as its row type. TypeScript rejects a schema whose output is not assignable to the compiler-inferred row. A schema with `any` output is also rejected because it cannot establish a sound boundary.
+
+The operation is immutable: attaching validation creates a new query value. Executing `accountQuery` remains unvalidated; executing `validatedAccountQuery` validates.
+
+Valibot uses the same API without an adapter:
+
+```ts
+import * as v from "valibot";
+
+const accountSchema = v.object({
+  id: v.bigint(),
+  email: v.pipe(v.string(), v.email()),
+  status: v.picklist(["active", "suspended"]),
+});
+
+const validatedAccountQuery = sql.validateResult(accountQuery, accountSchema);
+```
+
+## Understand the boundary
+
+The row passes through three separate layers:
+
+1. The compiler infers a static `Query<Row, Parameters>` from SQL, schema metadata, and the selected type policy.
+2. The runtime adapter decodes native driver values according to that type policy.
+3. The attached Standard Schema validates or transforms each decoded row before it reaches application code.
+
+PostgreSQL and MySQL therefore present the same decoded values to a validator that their unvalidated execution APIs would return. Validation does not inspect raw protocol values and does not replace snapshot generation, live verification, or database constraints.
+
+Standard Schema permits synchronous and asynchronous validators. Both are accepted. Rows are validated in result order, which keeps row indexes deterministic and prevents unbounded concurrent validator work.
+
+## Execution behavior
+
+Validation applies consistently to every official adapter:
+
+- `execute()` and `all()` validate every decoded row.
+- `one()` and `maybeOne()` validate rows before checking cardinality.
+- `batch()` and PostgreSQL `pipeline()` validate each result against its own attached schema.
+- `stream()` validates lazily immediately before yielding each row.
+- transaction-scoped operations use the same rules; an uncaught validation failure rejects the callback and rolls back the transaction.
+
+On a stream failure, typed-sql closes the native stream and releases or retires its connection through the adapter's normal cleanup path. Rows yielded before the invalid row remain consumed; validation cannot undo application work already performed for them.
+
+## Handle failures safely
+
+`QueryResultValidationError` has code `TSQL_RESULT_VALIDATION` and exposes:
+
+- `fingerprint`: the dialect- and grammar-version-scoped query identity;
+- `rowIndex`: the zero-based position in the individual result;
+- `vendor`: the validator's Standard Schema vendor name;
+- `failure`: `issues`, `validator-exception`, or `invalid-result`;
+- `issues`: normalized property paths.
+
+Actual rows and parameter values are never attached to the error. Vendor issue messages may contain values, so they are redacted by default. Enable them only for a controlled diagnostic boundary:
+
+```ts
+const query = sql.validateResult(accountQuery, accountSchema, {
+  includeIssueMessages: true,
+  libraryOptions: { locale: "en" },
+});
+```
+
+`libraryOptions` is passed through the Standard Schema options object. Its meaning belongs to the selected validator.
+
+## Performance policy
+
+Validation is opt-in per query. An unvalidated query performs one constant-time attachment lookup at the adapter boundary; it does not hash a fingerprint, allocate validation state, or call validator code. Enabled cost is proportional to the returned rows and the validator selected by the application.
+
+Use runtime validation where the additional runtime proof is worth that cost—for example, external databases, tenant-controlled schemas, custom codecs, or security-sensitive response boundaries. Ordinary internal queries can retain the raw-driver-oriented unvalidated path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ It is not an ORM or a query builder. SQL remains visible, database drivers remai
 ## Guides
 
 - [Compose conditional SQL](./guides/composition.md) without creating a parallel query-builder API.
+- [Validate decoded query results](./guides/result-validation.md) with any Standard Schema implementation.
 - [Generate snapshots and detect drift](./guides/schema-snapshots.md).
 - [Trace database work safely](./guides/observability.md) through the neutral observer contract.
 - [Route safe reads and retry explicit transactions](./guides/routing-and-retries.md) with application-owned topology.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -37,10 +37,13 @@ Applications import `sql` from their selected dialect root.
 | `sql.or(parts)` | `SqlFragment` | Join present predicates with parenthesized `OR`. |
 | `sql.where(query, predicate)` | `Query` | Preserve the base row and append predicate parameters. |
 | `sql.append(query, ...parts)` | `Query` | Append present fragments while preserving ordered parameters. |
+| `sql.validateResult(query, schema, options?)` | `Query` | Attach an application-owned Standard Schema validator to decoded rows. |
 | `sql.raw(text)` | `SqlFragment<readonly []>` | Insert trusted static SQL unchanged. |
 | `sql.dynamic(text)` | `Query<unknown>` | Opt out of static row inference for dynamic SQL. |
 
 `sql.raw()` is not an escaping function. Do not pass untrusted values to it.
+
+`sql.validateResult()` accepts the dependency-free Standard Schema V1 structural contract. The schema output must be assignable to the query's inferred row, and the returned query retains the original parameter tuple. `QueryResultValidationOptions` controls optional vendor messages and `libraryOptions`; `QueryResultValidationError` exposes a redacted, fingerprinted failure. See [Validate query results](../guides/result-validation.md).
 
 The declarations contain an internal `sql.__typed` member used by compiler overlays. Application code must use the ordinary `sql` tag.
 

--- a/e2e/packed/package.json
+++ b/e2e/packed/package.json
@@ -10,6 +10,8 @@
   "devDependencies": {
     "poku": "4.5.0",
     "tsx": "4.23.12",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "valibot": "^1.4.2",
+    "zod": "^4.5.2"
   }
 }

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -129,6 +129,8 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         ? {
             pg: "8.23.0",
             mysql2: "3.24.1",
+            valibot: "1.4.2",
+            zod: "4.5.2",
             tsx: "4.23.12",
             typescript: "7.0.2",
             "@types/node": "24.13.3",
@@ -136,6 +138,8 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         : {
             pg: `link:${join(workspace, "node_modules", "pg")}`,
             mysql2: `link:${join(workspace, "node_modules", "mysql2")}`,
+            valibot: `link:${join(packageDirectory, "node_modules", "valibot")}`,
+            zod: `link:${join(packageDirectory, "node_modules", "zod")}`,
             tsx: `link:${join(workspace, "node_modules", "tsx")}`,
             typescript: `link:${join(workspace, "node_modules", "typescript")}`,
             "@types/node": `link:${join(workspace, "node_modules", "@types", "node")}`,
@@ -333,6 +337,7 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         import { sql, typePolicy } from "@typed-sql/postgres";
         import { createPgDatabase } from "@typed-sql/postgres/pg";
         import type { QueryParameters, QueryRow } from "@typed-sql/core";
+        import { z } from "zod";
         type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
         type Assert<T extends true> = T;
         export const query = sql\`
@@ -344,6 +349,12 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         \`;
         const queryParameters: Assert<Equal<QueryParameters<typeof query>, readonly [bigint]>> = true;
         void queryParameters;
+        const querySchema = z.object({
+          id: z.bigint(), email: z.string(), status: z.enum(["active", "suspended"]), budget: z.string().nullable(),
+        });
+        export const validatedQuery = sql.validateResult(query, querySchema);
+        const validatedRow: Assert<Equal<QueryRow<typeof validatedQuery>, z.output<typeof querySchema>>> = true;
+        void validatedRow;
 
         export const cteQuery = sql\`
           WITH project_totals AS (
@@ -406,6 +417,7 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         import { sql, typePolicy } from "@typed-sql/mysql";
         import { createMySql2Database } from "@typed-sql/mysql/mysql2";
         import type { QueryParameters, QueryRow } from "@typed-sql/core";
+        import * as v from "valibot";
         type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
         type Assert<T extends true> = T;
         export const query = sql\`
@@ -417,6 +429,12 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         \`;
         const queryParameters: Assert<Equal<QueryParameters<typeof query>, readonly [bigint]>> = true;
         void queryParameters;
+        const querySchema = v.object({
+          id: v.bigint(), email: v.string(), status: v.picklist(["active", "suspended"]), budget: v.nullable(v.string()),
+        });
+        export const validatedQuery = sql.validateResult(query, querySchema);
+        const validatedRow: Assert<Equal<QueryRow<typeof validatedQuery>, v.InferOutput<typeof querySchema>>> = true;
+        void validatedRow;
 
         export const cteQuery = sql\`
           WITH project_totals AS (
@@ -629,11 +647,19 @@ await describe(`${consumerSource} real-database consumers`, async () => {
         import { sql as mysqlSql, typePolicy as mysqlTypePolicy } from "@typed-sql/mysql";
         import { createMySql2Database } from "@typed-sql/mysql/mysql2";
         import { createDashboardServer } from "./postgres/src/server.js";
+        import { z } from "zod";
+        import * as v from "valibot";
         const postgres = await createPgDatabase({ connectionString: "postgresql://typed_sql:typed_sql_e2e@127.0.0.1:${postgresPort}/typed_sql_e2e", typePolicy: postgresTypePolicy });
         const mysql = await createMySql2Database({ connectionUri: "mysql://typed_sql:typed_sql_e2e@127.0.0.1:${mysqlPort}/typed_sql_e2e", typePolicy: mysqlTypePolicy });
         try {
-          const pgRows = await postgres.execute(postgresSql<{ id: bigint; email: string }>\`SELECT id, email FROM users ORDER BY id\`);
-          const myRows = await mysql.execute(mysqlSql<{ id: bigint; status: string }>\`SELECT id, status FROM users ORDER BY id\`);
+          const pgRows = await postgres.execute(postgresSql.validateResult(
+            postgresSql<{ id: bigint; email: string }>\`SELECT id, email FROM users ORDER BY id\`,
+            z.object({ id: z.bigint(), email: z.string() }),
+          ));
+          const myRows = await mysql.execute(mysqlSql.validateResult(
+            mysqlSql<{ id: bigint; status: "active" | "suspended" }>\`SELECT id, status FROM users ORDER BY id\`,
+            v.object({ id: v.bigint(), status: v.picklist(["active", "suspended"]) }),
+          ));
           if (pgRows[0]?.id !== 1n || pgRows[0]?.email !== "alice@example.com") throw new Error("packed pg execution failed");
           if (myRows[0]?.id !== 1n || myRows[0]?.status !== "active") throw new Error("packed mysql2 execution failed");
         } finally { await postgres.close(); await mysql.close(); }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -38,6 +38,10 @@ type without adding a protocol or driver dependency to core.
 `DatabaseObserver` provides redacted query, batch, pipeline, stream, cancellation, and nested
 transaction lifecycles. It is disabled by default and does not add a telemetry dependency to core.
 
+`sql.validateResult(query, schema)` optionally validates decoded rows through the structural
+Standard Schema V1 interface. Validator output must agree with the inferred row; core does not
+install Zod, Valibot, or another validator package.
+
 `createRoutedDatabase` provides conservative, grammar-neutral primary/replica selection and bounded
 explicit-transaction retries from semantic evidence. Dialect packages supply the semantic resolver;
 applications continue owning every database adapter and topology decision.
@@ -50,7 +54,8 @@ database driver, TypeScript compiler, or editor dependency.
 Read the [query API](https://github.com/Lojhan/typed-sql/blob/main/docs/reference/api.md),
 [architecture](https://github.com/Lojhan/typed-sql/blob/main/docs/concepts/architecture.md),
 [routing and retry guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/routing-and-retries.md),
-[bulk data guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/bulk-data.md), and
+[bulk data guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/bulk-data.md),
+[result validation guide](https://github.com/Lojhan/typed-sql/blob/main/docs/guides/result-validation.md), and
 [custom grammar guide](https://github.com/Lojhan/typed-sql/blob/main/docs/extending/custom-grammars.md).
 
 MIT © typed-sql contributors

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,21 @@ export {
 export type { ResolverType } from "./resolver.js";
 export { closestName, ParameterCollector, ResolverSchemaIndex, unionTypeLiterals } from "./resolver.js";
 export type {
+  CompatibleResultSchema,
+  QueryResultValidationFailure,
+  QueryResultValidationIssue,
+  QueryResultValidationOptions,
+  StandardSchemaV1,
+  StandardTypedV1,
+} from "./result-validation.js";
+export {
+  hasQueryResultValidator,
+  QueryResultValidationError,
+  queryResultValidationSource,
+  validateQueryResultRows,
+  validateQueryResultStream,
+} from "./result-validation.js";
+export type {
   QueryRoute,
   QueryRoutePreference,
   QueryRouteSelection,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -4,6 +4,14 @@ import {
   type ExecutionOptions,
   QueryCardinalityError,
 } from "./execution.js";
+import {
+  type CompatibleResultSchema,
+  type QueryResultValidationOptions,
+  queryResultValidationSource,
+  type StandardSchemaV1,
+  setQueryResultValidator,
+  validateQueryResultRows,
+} from "./result-validation.js";
 
 const fragmentBrand: unique symbol = Symbol.for("@typed-sql/core.fragment") as never;
 const queryBrand: unique symbol = Symbol.for("@typed-sql/core.query") as never;
@@ -99,6 +107,11 @@ export interface SqlTag {
     query: Query<Row, QueryParams>,
     ...parts: Parts
   ) => Query<Row, readonly [...QueryParams, ...FragmentListParameters<Parts>]>;
+  readonly validateResult: <Row, Params extends readonly unknown[], const Schema extends StandardSchemaV1>(
+    query: Query<Row, Params>,
+    schema: Schema & CompatibleResultSchema<Row, Schema>,
+    options?: QueryResultValidationOptions,
+  ) => Query<StandardSchemaV1.InferOutput<Schema>, Params>;
   readonly raw: (text: string) => SqlFragment<readonly []>;
   readonly dynamic: (text: string) => Query<unknown>;
 }
@@ -322,6 +335,25 @@ export const sql: SqlTag = Object.assign(tag, {
     }
     return query<Row, readonly [...QueryParams, ...FragmentListParameters<Parts>]>(segments);
   },
+  validateResult<Row, Params extends readonly unknown[], const Schema extends StandardSchemaV1>(
+    queryValue: Query<Row, Params>,
+    schema: Schema,
+    options: QueryResultValidationOptions = {},
+  ): Query<StandardSchemaV1.InferOutput<Schema>, Params> {
+    const standard = schema?.["~standard"];
+    if (
+      typeof standard !== "object" ||
+      standard === null ||
+      standard.version !== 1 ||
+      typeof standard.vendor !== "string" ||
+      typeof standard.validate !== "function"
+    ) {
+      throw new TypeError("sql.validateResult() expects a Standard Schema V1 validator");
+    }
+    const validated = query<StandardSchemaV1.InferOutput<Schema>, Params>([...queryValue.segments]);
+    setQueryResultValidator(validated, queryResultValidationSource(queryValue), schema, options);
+    return validated;
+  },
   raw(sqlText: string): SqlFragment<readonly []> {
     return fragment<readonly []>([text(sqlText)]);
   },
@@ -428,7 +460,8 @@ class DatabaseImplementation implements Database {
 
   async execute<Row, Params extends readonly unknown[]>(queryValue: Query<Row, Params>): Promise<readonly Row[]> {
     const rendered = renderQuery(queryValue, this.#renderer);
-    return (await this.#executor.execute(rendered.text, rendered.values)) as readonly Row[];
+    const rows = await this.#executor.execute(rendered.text, rendered.values);
+    return validateQueryResultRows(queryValue, rows, "generic-adapter");
   }
 
   async all<Row, Params extends readonly unknown[]>(
@@ -441,7 +474,8 @@ class DatabaseImplementation implements Database {
     assertExecutionCapabilities(this.executionCapabilities, options);
     const controlled = this.#executor as ControlledQueryExecutor;
     const rendered = renderQuery(queryValue, this.#renderer);
-    return (await controlled.executeControlled(rendered.text, rendered.values, options)) as readonly Row[];
+    const rows = await controlled.executeControlled(rendered.text, rendered.values, options);
+    return validateQueryResultRows(queryValue, rows, "generic-adapter");
   }
 
   async one<Row, Params extends readonly unknown[]>(

--- a/packages/core/src/result-validation.ts
+++ b/packages/core/src/result-validation.ts
@@ -1,0 +1,300 @@
+import type { QueryStream } from "./execution.js";
+import type { Query } from "./query.js";
+
+/** Structural Standard Typed V1 contract, copied from the dependency-free specification. */
+export interface StandardTypedV1<Input = unknown, Output = Input> {
+  readonly "~standard": StandardTypedV1.Props<Input, Output>;
+}
+
+export namespace StandardTypedV1 {
+  export interface Props<Input = unknown, Output = Input> {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly types?: Types<Input, Output>;
+  }
+
+  export interface Types<Input = unknown, Output = Input> {
+    readonly input: Input;
+    readonly output: Output;
+  }
+
+  export type InferInput<Schema extends StandardTypedV1> = NonNullable<Schema["~standard"]["types"]>["input"];
+  export type InferOutput<Schema extends StandardTypedV1> = NonNullable<Schema["~standard"]["types"]>["output"];
+}
+
+/** Dependency-free Standard Schema V1 contract implemented by ecosystem validators. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export namespace StandardSchemaV1 {
+  export interface Props<Input = unknown, Output = Input> extends StandardTypedV1.Props<Input, Output> {
+    readonly validate: (value: unknown, options?: Options) => Result<Output> | Promise<Result<Output>>;
+  }
+
+  export interface Options {
+    readonly libraryOptions?: Record<string, unknown>;
+  }
+
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  export interface SuccessResult<Output> {
+    readonly value: Output;
+    readonly issues?: undefined;
+  }
+
+  export interface FailureResult {
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  export interface Issue {
+    readonly message: string;
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment>;
+  }
+
+  export interface PathSegment {
+    readonly key: PropertyKey;
+  }
+
+  export interface Types<Input = unknown, Output = Input> extends StandardTypedV1.Types<Input, Output> {}
+
+  export type InferInput<Schema extends StandardTypedV1> = StandardTypedV1.InferInput<Schema>;
+  export type InferOutput<Schema extends StandardTypedV1> = StandardTypedV1.InferOutput<Schema>;
+}
+
+type IsAny<Value> = 0 extends 1 & Value ? true : false;
+
+/** A validator is compatible only when its non-`any` output is assignable to the inferred row. */
+export type CompatibleResultSchema<Row, Schema extends StandardSchemaV1> =
+  IsAny<StandardSchemaV1.InferOutput<Schema>> extends true
+    ? never
+    : [StandardSchemaV1.InferOutput<Schema>] extends [Row]
+      ? Schema
+      : never;
+
+export interface QueryResultValidationOptions {
+  /** Vendor messages may echo values, so they are excluded unless explicitly requested. */
+  readonly includeIssueMessages?: boolean;
+  readonly libraryOptions?: Record<string, unknown>;
+}
+
+export interface QueryResultValidationIssue {
+  readonly path: readonly PropertyKey[];
+  readonly message?: string;
+}
+
+export type QueryResultValidationFailure = "issues" | "validator-exception" | "invalid-result";
+
+export class QueryResultValidationError extends Error {
+  readonly code = "TSQL_RESULT_VALIDATION";
+  readonly fingerprint: string;
+  readonly rowIndex: number;
+  readonly vendor: string;
+  readonly failure: QueryResultValidationFailure;
+  readonly issues: readonly QueryResultValidationIssue[];
+
+  constructor(options: {
+    readonly fingerprint: string;
+    readonly rowIndex: number;
+    readonly vendor: string;
+    readonly failure: QueryResultValidationFailure;
+    readonly issues: readonly QueryResultValidationIssue[];
+  }) {
+    const locations = options.issues
+      .map(({ path }) => path.map(String).join("."))
+      .filter(Boolean)
+      .join(", ");
+    super(
+      `Query result validation failed for ${options.fingerprint} at row ${options.rowIndex}${
+        locations.length === 0 ? "" : ` (${locations})`
+      }`,
+    );
+    this.name = "QueryResultValidationError";
+    this.fingerprint = options.fingerprint;
+    this.rowIndex = options.rowIndex;
+    this.vendor = options.vendor;
+    this.failure = options.failure;
+    this.issues = options.issues;
+  }
+}
+
+interface ValidatorBinding {
+  readonly source: object;
+  readonly schema: StandardSchemaV1;
+  readonly options: QueryResultValidationOptions;
+}
+
+const validators = new WeakMap<object, ValidatorBinding>();
+const emptyIssues = Object.freeze([]);
+
+/** @internal Used by `sql.validateResult()` after it creates a separate immutable query. */
+export function setQueryResultValidator(
+  query: object,
+  source: object,
+  schema: StandardSchemaV1,
+  options: QueryResultValidationOptions,
+): void {
+  validators.set(query, Object.freeze({ source, schema, options: Object.freeze({ ...options }) }));
+}
+
+export function hasQueryResultValidator(query: object): boolean {
+  return validators.has(query);
+}
+
+/** Returns the original query identity so adapter-owned metadata survives validation attachment. */
+export function queryResultValidationSource<Row, Params extends readonly unknown[]>(
+  query: Query<Row, Params>,
+): Query<unknown, Params> {
+  return (validators.get(query)?.source ?? query) as Query<unknown, Params>;
+}
+
+function normalizePath(path: StandardSchemaV1.Issue["path"]): readonly PropertyKey[] {
+  if (path === undefined) return emptyIssues;
+  const normalized: PropertyKey[] = [];
+  for (const segment of path) {
+    normalized.push(typeof segment === "object" && segment !== null ? segment.key : segment);
+  }
+  return Object.freeze(normalized);
+}
+
+function normalizeIssues(
+  issues: ReadonlyArray<StandardSchemaV1.Issue>,
+  messages: boolean,
+): readonly QueryResultValidationIssue[] {
+  const normalized: QueryResultValidationIssue[] = [];
+  // Do not call Array methods: Standard Schema implementations may return richer array subclasses.
+  for (const issue of issues) {
+    normalized.push(
+      Object.freeze({ path: normalizePath(issue.path), ...(messages ? { message: String(issue.message) } : {}) }),
+    );
+  }
+  return Object.freeze(normalized);
+}
+
+async function validateValue<Row>(
+  binding: ValidatorBinding,
+  value: unknown,
+  fingerprint: string,
+  rowIndex: number,
+): Promise<Row> {
+  const standard = binding.schema["~standard"];
+  let result: StandardSchemaV1.Result<unknown>;
+  try {
+    result = await standard.validate(
+      value,
+      binding.options.libraryOptions === undefined ? undefined : { libraryOptions: binding.options.libraryOptions },
+    );
+  } catch (error) {
+    const issues =
+      binding.options.includeIssueMessages === true && error instanceof Error
+        ? Object.freeze([Object.freeze({ path: emptyIssues, message: error.message })])
+        : emptyIssues;
+    throw new QueryResultValidationError({
+      fingerprint,
+      rowIndex,
+      vendor: standard.vendor,
+      failure: "validator-exception",
+      issues,
+    });
+  }
+  if (typeof result !== "object" || result === null) {
+    throw new QueryResultValidationError({
+      fingerprint,
+      rowIndex,
+      vendor: standard.vendor,
+      failure: "invalid-result",
+      issues: emptyIssues,
+    });
+  }
+  if (result.issues) {
+    let issues: readonly QueryResultValidationIssue[];
+    try {
+      issues = normalizeIssues(result.issues, binding.options.includeIssueMessages === true);
+    } catch {
+      throw new QueryResultValidationError({
+        fingerprint,
+        rowIndex,
+        vendor: standard.vendor,
+        failure: "invalid-result",
+        issues: emptyIssues,
+      });
+    }
+    throw new QueryResultValidationError({
+      fingerprint,
+      rowIndex,
+      vendor: standard.vendor,
+      failure: "issues",
+      issues,
+    });
+  }
+  if (!("value" in result)) {
+    throw new QueryResultValidationError({
+      fingerprint,
+      rowIndex,
+      vendor: standard.vendor,
+      failure: "invalid-result",
+      issues: emptyIssues,
+    });
+  }
+  return result.value as Row;
+}
+
+export async function validateQueryResultRows<Row, Params extends readonly unknown[]>(
+  query: Query<Row, Params>,
+  rows: readonly unknown[],
+  fingerprint: string,
+): Promise<readonly Row[]> {
+  const binding = validators.get(query);
+  if (binding === undefined) return rows as readonly Row[];
+  const validated: Row[] = [];
+  for (let index = 0; index < rows.length; index += 1) {
+    validated.push(await validateValue<Row>(binding, rows[index], fingerprint, index));
+  }
+  return Object.freeze(validated);
+}
+
+export function validateQueryResultStream<Row, Params extends readonly unknown[]>(
+  query: Query<Row, Params>,
+  stream: QueryStream<unknown>,
+  fingerprint: string,
+): QueryStream<Row> {
+  const binding = validators.get(query);
+  if (binding === undefined) return stream as QueryStream<Row>;
+  let rowIndex = 0;
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await stream.close();
+  };
+  const validated: QueryStream<Row> = {
+    [Symbol.asyncIterator]: () => validated,
+    async next() {
+      if (closed) return { done: true, value: undefined };
+      const result = await stream.next();
+      if (result.done) {
+        closed = true;
+        return { done: true, value: undefined };
+      }
+      try {
+        const value = await validateValue<Row>(binding, result.value, fingerprint, rowIndex);
+        rowIndex += 1;
+        return { done: false, value };
+      } catch (error) {
+        await close().catch(() => undefined);
+        throw error;
+      }
+    },
+    async return(value?: unknown) {
+      await close();
+      return { done: true, value: value as Row };
+    },
+    async throw(error?: unknown) {
+      await close();
+      throw error;
+    },
+    close,
+    [Symbol.asyncDispose]: close,
+  };
+  return validated;
+}

--- a/packages/core/test/result-validation.test.ts
+++ b/packages/core/test/result-validation.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, strict } from "poku";
+import {
+  createDatabase,
+  type QueryResultValidationError,
+  type QueryStream,
+  QueryResultValidationError as ResultValidationError,
+  type StandardSchemaV1,
+  sql,
+  validateQueryResultStream,
+} from "../src/index.js";
+
+type Account = { readonly id: bigint; readonly email: string };
+
+function accountSchema(
+  validate: StandardSchemaV1<unknown, Account>["~standard"]["validate"],
+): StandardSchemaV1<unknown, Account> {
+  return { "~standard": { version: 1, vendor: "test-validator", validate } };
+}
+
+const renderer = { placeholder: () => "?", quoteIdentifier: (name: string) => `"${name}"` };
+
+async function captureValidationError(operation: Promise<unknown>): Promise<QueryResultValidationError> {
+  try {
+    await operation;
+  } catch (error) {
+    if (!(error instanceof ResultValidationError)) throw error;
+    return error;
+  }
+  throw new Error("Expected query result validation to fail");
+}
+
+await describe("Standard Schema result validation", async () => {
+  await it("validates and transforms decoded rows without changing the base query", async () => {
+    const base = sql<Account>`SELECT id, email FROM account`;
+    const validated = sql.validateResult(
+      base,
+      accountSchema((value) => {
+        const row = value as { readonly id: string; readonly email: string };
+        return { value: { id: BigInt(row.id), email: row.email.trim() } };
+      }),
+    );
+    const database = createDatabase({ execute: async () => [{ id: "7", email: " a@example.test " }] }, renderer);
+
+    strict.deepStrictEqual(await database.execute(base), [{ id: "7", email: " a@example.test " }]);
+    strict.deepStrictEqual(await database.execute(validated), [{ id: 7n, email: "a@example.test" }]);
+    strict.notStrictEqual(validated, base);
+  });
+
+  await it("supports asynchronous validators", async () => {
+    const query = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema(async (value) => {
+        await Promise.resolve();
+        return { value: value as Account };
+      }),
+    );
+    const database = createDatabase({ execute: async () => [{ id: 1n, email: "a@example.test" }] }, renderer);
+    strict.deepStrictEqual(await database.one(query), { id: 1n, email: "a@example.test" });
+  });
+
+  await it("redacts issue messages and values by default while retaining safe locations", async () => {
+    const query = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema(() => ({
+        issues: [{ message: "secret@example.test is invalid", path: ["email", { key: 0 }] }],
+      })),
+    );
+    const database = createDatabase({ execute: async () => [{ id: 1n, email: "secret@example.test" }] }, renderer);
+
+    const validationError = await captureValidationError(database.execute(query));
+    strict.strictEqual(validationError.code, "TSQL_RESULT_VALIDATION");
+    strict.strictEqual(validationError.fingerprint, "generic-adapter");
+    strict.strictEqual(validationError.rowIndex, 0);
+    strict.strictEqual(validationError.vendor, "test-validator");
+    strict.deepStrictEqual(validationError.issues, [{ path: ["email", 0] }]);
+    strict.ok(!validationError.message.includes("secret@example.test"));
+  });
+
+  await it("includes validator messages only through an explicit diagnostic opt-in", async () => {
+    const query = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema(() => ({ issues: [{ message: "email is invalid", path: ["email"] }] })),
+      { includeIssueMessages: true, libraryOptions: { locale: "en" } },
+    );
+    const database = createDatabase({ execute: async () => [{ id: 1n, email: "bad" }] }, renderer);
+    const error = await captureValidationError(database.execute(query));
+    strict.deepStrictEqual(error.issues, [{ path: ["email"], message: "email is invalid" }]);
+  });
+
+  await it("normalizes validator exceptions and malformed results", async () => {
+    const thrown = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema(() => {
+        throw new Error("row contained a secret");
+      }),
+    );
+    const malformed = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema(() => undefined as never),
+    );
+    const database = createDatabase({ execute: async () => [{}] }, renderer);
+
+    const thrownError = await captureValidationError(database.execute(thrown));
+    const malformedError = await captureValidationError(database.execute(malformed));
+    strict.strictEqual(thrownError.failure, "validator-exception");
+    strict.strictEqual(thrownError.issues.length, 0);
+    strict.strictEqual(malformedError.failure, "invalid-result");
+  });
+
+  await it("validates streams lazily and closes the source at the first invalid row", async () => {
+    const query = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema((value) => {
+        const row = value as Account;
+        return row.email.includes("@") ? { value: row } : { issues: [{ message: "invalid", path: ["email"] }] };
+      }),
+    );
+    let index = 0;
+    let closes = 0;
+    const rows: readonly Account[] = [
+      { id: 1n, email: "valid@example.test" },
+      { id: 2n, email: "invalid" },
+    ];
+    const source: QueryStream<Account> = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async next() {
+        const value = rows[index++];
+        return value === undefined ? { done: true, value: undefined } : { done: false, value };
+      },
+      async close() {
+        closes += 1;
+      },
+      async [Symbol.asyncDispose]() {
+        await this.close();
+      },
+    };
+    const stream = validateQueryResultStream(query, source, "sha256:test");
+
+    strict.deepStrictEqual(await stream.next(), { done: false, value: rows[0] });
+    const error = await captureValidationError(stream.next());
+    strict.strictEqual(error.rowIndex, 1);
+    strict.strictEqual(closes, 1);
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+  });
+
+  await it("supports iterator return, throw, natural completion, and async disposal", async () => {
+    const query = sql.validateResult(
+      sql<Account>`SELECT id, email FROM account`,
+      accountSchema((value) => ({ value: value as Account })),
+    );
+    let closes = 0;
+    const source = (): QueryStream<Account> => ({
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async next() {
+        return { done: true, value: undefined };
+      },
+      async close() {
+        closes += 1;
+      },
+      async [Symbol.asyncDispose]() {
+        await this.close();
+      },
+    });
+
+    const completed = validateQueryResultStream(query, source(), "sha256:completed");
+    strict.deepStrictEqual(await completed.next(), { done: true, value: undefined });
+    await completed.close();
+
+    const returned = validateQueryResultStream(query, source(), "sha256:returned");
+    strict.deepStrictEqual(await returned.return?.(), { done: true, value: undefined });
+
+    const thrown = validateQueryResultStream(query, source(), "sha256:thrown");
+    await strict.rejects(thrown.throw?.(new Error("stop")) ?? Promise.resolve(), /stop/);
+
+    const disposed = validateQueryResultStream(query, source(), "sha256:disposed");
+    await disposed[Symbol.asyncDispose]();
+    strict.strictEqual(closes, 3);
+  });
+
+  await it("rejects non-Standard-Schema values at the attachment boundary", () => {
+    strict.throws(
+      () => sql.validateResult(sql<Account>`SELECT id, email FROM account`, {} as never),
+      /Standard Schema V1/,
+    );
+  });
+});

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   databaseErrorCompletion,
   type ExecutionCapabilities,
   type ExecutionOptions,
+  hasQueryResultValidator,
   observeQueryStream,
   type Query,
   type QueryBatch,
@@ -16,12 +17,15 @@ import {
   QueryCardinalityError,
   type QueryResults,
   type QueryStream,
+  queryResultValidationSource,
   renderQuery,
   runControlledExecution,
   type SqlRenderer,
   type StreamOptions,
   startDatabaseObservation,
   UnsupportedExecutionCapabilityError,
+  validateQueryResultRows,
+  validateQueryResultStream,
 } from "@typed-sql/core";
 import { createMySqlBulkCapability, type MySqlBulkTransport, mysqlBulk } from "./bulk.js";
 import {
@@ -113,11 +117,11 @@ function mysqlQueryFingerprint<Row, Params extends readonly unknown[]>(
   query: Query<Row, Params>,
 ): string {
   const key = query as unknown as Query<unknown, readonly unknown[]>;
-  const cached = state.fingerprints!.get(key);
+  const cached = state.fingerprints?.get(key);
   if (cached !== undefined) return cached;
   const text = renderQuery(query, mysqlRenderer).text;
   const fingerprint = `sha256:${createHash("sha256").update(`mysql\0${MYSQL_DIALECT_VERSION}\0${text}`).digest("hex")}`;
-  state.fingerprints!.set(key, fingerprint);
+  state.fingerprints?.set(key, fingerprint);
   return fingerprint;
 }
 
@@ -196,8 +200,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
-    if (this.#observation.observer === undefined) return this.#executeUnobserved(query);
-    return this.#observeQuery(query, "many", () => this.#executeUnobserved(query));
+    if (this.#observation.observer === undefined) {
+      return this.#validateRows(query, await this.#executeUnobserved(query));
+    }
+    return this.#observeQuery(query, "many", async () =>
+      this.#validateRows(query, await this.#executeUnobserved(query)),
+    );
   }
 
   async #executeUnobserved<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
@@ -220,8 +228,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<readonly Row[]> {
-    if (this.#observation.observer === undefined) return this.#allUnobserved(query, options);
-    return this.#observeQuery(query, "many", () => this.#allUnobserved(query, options));
+    if (this.#observation.observer === undefined) {
+      return this.#validateRows(query, await this.#allUnobserved(query, options));
+    }
+    return this.#observeQuery(query, "many", async () =>
+      this.#validateRows(query, await this.#allUnobserved(query, options)),
+    );
   }
 
   async #allUnobserved<Row, Params extends readonly unknown[]>(
@@ -292,12 +304,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     options?: ExecutionOptions,
   ): Promise<Row> {
     if (this.#observation.observer === undefined) {
-      const rows = await this.#allUnobserved(query, options);
+      const rows = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
       return rows[0]!;
     }
     const rows = await this.#observeQuery(query, "one", async () => {
-      const result = await this.#allUnobserved(query, options);
+      const result = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (result.length !== 1) throw new QueryCardinalityError("one", result.length);
       return result;
     });
@@ -309,12 +321,12 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     options?: ExecutionOptions,
   ): Promise<Row | undefined> {
     if (this.#observation.observer === undefined) {
-      const rows = await this.#allUnobserved(query, options);
+      const rows = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
       return rows[0];
     }
     const rows = await this.#observeQuery(query, "maybeOne", async () => {
-      const result = await this.#allUnobserved(query, options);
+      const result = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (result.length > 1) throw new QueryCardinalityError("maybeOne", result.length);
       return result;
     });
@@ -334,7 +346,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
       transactionDepth: this.#depth,
       fingerprint: mysqlQueryFingerprint(this.#observation, query),
       cardinality,
-      prepared: this.#prepared.queries.has(query),
+      prepared: this.#prepared.queries.has(queryResultValidationSource(query)),
     });
     if (observation === undefined) return operation();
     try {
@@ -351,7 +363,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     executor: Pick<MySqlConnectionLike, "execute">,
     query: Query<Row, Params>,
   ): Promise<readonly Row[]> {
-    const prepared = this.#prepared.queries.get(query);
+    const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
     const result = await executor.execute(rendered.text, rendered.values.map(encodeMySqlValue));
     if (!Array.isArray(result.rows)) return [];
@@ -361,8 +373,10 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
 
   async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
-    if (this.#observation.observer === undefined) return this.#batchUnobserved(queries);
-    return this.#observeBatch(queries, () => this.#batchUnobserved(queries));
+    if (this.#observation.observer === undefined) {
+      return this.#validateBatch(queries, await this.#batchUnobserved(queries));
+    }
+    return this.#observeBatch(queries, async () => this.#validateBatch(queries, await this.#batchUnobserved(queries)));
   }
 
   async #batchUnobserved<const Queries extends readonly unknown[]>(
@@ -448,7 +462,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     options: StreamOptions = {},
   ): QueryStream<Row> {
     this.#assertScopeOpen();
-    const prepared = this.#prepared.queries.get(query);
+    const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, mysqlRenderer);
     const batchSize = validateMySqlStreamBatchSize(options.batchSize);
     let exposedStream: QueryStream<Row>;
@@ -471,10 +485,13 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         if (this.#transactionState?.active === exposedStream) this.#transactionState.active = undefined;
       },
     });
+    const validatedStream = hasQueryResultValidator(query)
+      ? validateQueryResultStream(query, queryStream, mysqlQueryFingerprint(this.#observation, query))
+      : queryStream;
     exposedStream =
       this.#observation.observer === undefined
-        ? queryStream
-        : observeQueryStream(queryStream, this.#observation.observer, {
+        ? validatedStream
+        : observeQueryStream(validatedStream, this.#observation.observer, {
             kind: "stream",
             dialect: "mysql",
             grammarVersion: MYSQL_DIALECT_VERSION,
@@ -484,6 +501,34 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
           });
     this.#streams?.add(exposedStream as QueryStream<unknown>);
     return exposedStream;
+  }
+
+  async #validateRows<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    rows: readonly unknown[],
+  ): Promise<readonly Row[]> {
+    if (!hasQueryResultValidator(query)) return rows as readonly Row[];
+    return validateQueryResultRows(query, rows, mysqlQueryFingerprint(this.#observation, query));
+  }
+
+  async #validateBatch<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+    results: QueryResults<Queries>,
+  ): Promise<QueryResults<Queries>> {
+    let validated: unknown[] | undefined;
+    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
+    const resultList = results as readonly (readonly unknown[])[];
+    for (let index = 0; index < queryList.length; index += 1) {
+      const query = queryList[index]!;
+      if (!hasQueryResultValidator(query)) continue;
+      validated ??= [...resultList];
+      validated[index] = await validateQueryResultRows(
+        query,
+        resultList[index]!,
+        mysqlQueryFingerprint(this.#observation, query),
+      );
+    }
+    return (validated ?? results) as QueryResults<Queries>;
   }
 
   async #loadData(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {

--- a/packages/mysql/test/execute-lifecycle.test.ts
+++ b/packages/mysql/test/execute-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart } from "@typed-sql/core";
+import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart, StandardSchemaV1 } from "@typed-sql/core";
 import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import {
@@ -118,6 +118,21 @@ class ExecutePool implements MySqlPoolLike {
 const nextTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 await describe("MySQL transaction execute ownership", async () => {
+  await it("validates after MySQL codec decoding", async () => {
+    const schema: StandardSchemaV1<unknown, { readonly id: bigint }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate(value) {
+          const row = value as { readonly id: unknown };
+          return typeof row.id === "bigint" ? { value: { id: row.id } } : { issues: [{ message: "not bigint" }] };
+        },
+      },
+    };
+    const database = createMySqlDatabase({ pool: new ExecutePool() });
+    strict.deepStrictEqual(await database.one(sql.validateResult(accountQuery, schema)), { id: 1n });
+  });
+
   await it("emits redacted fingerprinted query, batch, and transaction lifecycles", async () => {
     const starts: DatabaseOperationStart[] = [];
     const ends: DatabaseOperationEnd[] = [];

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   databaseErrorCompletion,
   type ExecutionCapabilities,
   type ExecutionOptions,
+  hasQueryResultValidator,
   observeQueryStream,
   type Query,
   type QueryBatch,
@@ -16,11 +17,14 @@ import {
   QueryCardinalityError,
   type QueryResults,
   type QueryStream,
+  queryResultValidationSource,
   renderQuery,
   runControlledExecution,
   type SqlRenderer,
   type StreamOptions,
   startDatabaseObservation,
+  validateQueryResultRows,
+  validateQueryResultStream,
 } from "@typed-sql/core";
 import { createPostgresCopyCapability, type PostgresCopyTransport, postgresCopy } from "./bulk.js";
 import {
@@ -134,13 +138,13 @@ function postgresQueryFingerprint<Row, Params extends readonly unknown[]>(
   query: Query<Row, Params>,
 ): string {
   const key = query as unknown as Query<unknown, readonly unknown[]>;
-  const cached = state.fingerprints!.get(key);
+  const cached = state.fingerprints?.get(key);
   if (cached !== undefined) return cached;
   const text = renderQuery(query, postgresRenderer).text;
   const fingerprint = `sha256:${createHash("sha256")
     .update(`postgres\0${POSTGRES_DIALECT_VERSION}\0${text}`)
     .digest("hex")}`;
-  state.fingerprints!.set(key, fingerprint);
+  state.fingerprints?.set(key, fingerprint);
   return fingerprint;
 }
 
@@ -328,8 +332,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
-    if (this.#observation.observer === undefined) return this.#executeUnobserved(query);
-    return this.#observeQuery(query, "many", () => this.#executeUnobserved(query));
+    if (this.#observation.observer === undefined) {
+      return this.#validateRows(query, await this.#executeUnobserved(query));
+    }
+    return this.#observeQuery(query, "many", async () =>
+      this.#validateRows(query, await this.#executeUnobserved(query)),
+    );
   }
 
   async #executeUnobserved<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
@@ -366,8 +374,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     query: Query<Row, Params>,
     options?: ExecutionOptions,
   ): Promise<readonly Row[]> {
-    if (this.#observation.observer === undefined) return this.#allUnobserved(query, options);
-    return this.#observeQuery(query, "many", () => this.#allUnobserved(query, options));
+    if (this.#observation.observer === undefined) {
+      return this.#validateRows(query, await this.#allUnobserved(query, options));
+    }
+    return this.#observeQuery(query, "many", async () =>
+      this.#validateRows(query, await this.#allUnobserved(query, options)),
+    );
   }
 
   async #allUnobserved<Row, Params extends readonly unknown[]>(
@@ -442,12 +454,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     options?: ExecutionOptions,
   ): Promise<Row> {
     if (this.#observation.observer === undefined) {
-      const rows = await this.#allUnobserved(query, options);
+      const rows = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (rows.length !== 1) throw new QueryCardinalityError("one", rows.length);
       return rows[0]!;
     }
     const rows = await this.#observeQuery(query, "one", async () => {
-      const result = await this.#allUnobserved(query, options);
+      const result = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (result.length !== 1) throw new QueryCardinalityError("one", result.length);
       return result;
     });
@@ -459,12 +471,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     options?: ExecutionOptions,
   ): Promise<Row | undefined> {
     if (this.#observation.observer === undefined) {
-      const rows = await this.#allUnobserved(query, options);
+      const rows = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (rows.length > 1) throw new QueryCardinalityError("maybeOne", rows.length);
       return rows[0];
     }
     const rows = await this.#observeQuery(query, "maybeOne", async () => {
-      const result = await this.#allUnobserved(query, options);
+      const result = await this.#validateRows(query, await this.#allUnobserved(query, options));
       if (result.length > 1) throw new QueryCardinalityError("maybeOne", result.length);
       return result;
     });
@@ -484,7 +496,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
       transactionDepth: this.#transactionDepth,
       fingerprint: postgresQueryFingerprint(this.#observation, query),
       cardinality,
-      prepared: this.#prepared.queries.has(query),
+      prepared: this.#prepared.queries.has(queryResultValidationSource(query)),
     });
     if (observation === undefined) return operation();
     try {
@@ -499,8 +511,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
 
   async batch<const Queries extends readonly unknown[]>(queries: QueryBatch<Queries>): Promise<QueryResults<Queries>> {
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
-    if (this.#observation.observer === undefined) return this.#batchUnobserved(queries);
-    return this.#observeGroup("batch", queries, () => this.#batchUnobserved(queries));
+    if (this.#observation.observer === undefined) {
+      return this.#validateBatch(queries, await this.#batchUnobserved(queries));
+    }
+    return this.#observeGroup("batch", queries, async () =>
+      this.#validateBatch(queries, await this.#batchUnobserved(queries)),
+    );
   }
 
   async #batchUnobserved<const Queries extends readonly unknown[]>(
@@ -546,8 +562,12 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     queries: QueryBatch<Queries>,
   ): Promise<QueryResults<Queries>> {
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
-    if (this.#observation.observer === undefined) return this.#pipelineUnobserved(queries);
-    return this.#observeGroup("pipeline", queries, () => this.#pipelineUnobserved(queries));
+    if (this.#observation.observer === undefined) {
+      return this.#validateBatch(queries, await this.#pipelineUnobserved(queries));
+    }
+    return this.#observeGroup("pipeline", queries, async () =>
+      this.#validateBatch(queries, await this.#pipelineUnobserved(queries)),
+    );
   }
 
   async #pipelineUnobserved<const Queries extends readonly unknown[]>(
@@ -697,19 +717,50 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
             onError: (error: unknown) => this.#recordTransactionOperationFailure(error),
           }),
     });
+    const validatedStream = hasQueryResultValidator(query)
+      ? validateQueryResultStream(query, stream, postgresQueryFingerprint(this.#observation, query))
+      : stream;
     exposedStream =
       this.#observation.observer === undefined
-        ? stream
-        : observeQueryStream(stream, this.#observation.observer, {
+        ? validatedStream
+        : observeQueryStream(validatedStream, this.#observation.observer, {
             kind: "stream",
             dialect: "postgres",
             grammarVersion: POSTGRES_DIALECT_VERSION,
             transactionDepth: this.#transactionDepth,
             fingerprint: postgresQueryFingerprint(this.#observation, query),
-            prepared: this.#prepared.queries.has(query),
+            prepared: this.#prepared.queries.has(queryResultValidationSource(query)),
           });
     if (this.#client !== undefined) this.#transactionStreams.add(exposedStream as QueryStream<unknown>);
     return exposedStream;
+  }
+
+  async #validateRows<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    rows: readonly unknown[],
+  ): Promise<readonly Row[]> {
+    if (!hasQueryResultValidator(query)) return rows as readonly Row[];
+    return validateQueryResultRows(query, rows, postgresQueryFingerprint(this.#observation, query));
+  }
+
+  async #validateBatch<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+    results: QueryResults<Queries>,
+  ): Promise<QueryResults<Queries>> {
+    let validated: unknown[] | undefined;
+    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
+    const resultList = results as readonly (readonly unknown[])[];
+    for (let index = 0; index < queryList.length; index += 1) {
+      const query = queryList[index]!;
+      if (!hasQueryResultValidator(query)) continue;
+      validated ??= [...resultList];
+      validated[index] = await validateQueryResultRows(
+        query,
+        resultList[index]!,
+        postgresQueryFingerprint(this.#observation, query),
+      );
+    }
+    return (validated ?? results) as QueryResults<Queries>;
   }
 
   async #copyFrom(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {
@@ -1014,7 +1065,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
   }
 
   #queryConfig<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): PostgresQueryConfig {
-    const prepared = this.#prepared.queries.get(query);
+    const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, postgresRenderer);
     return {
       ...(prepared === undefined ? {} : { name: prepared.statementName }),

--- a/packages/postgres/test/pipeline.test.ts
+++ b/packages/postgres/test/pipeline.test.ts
@@ -1,12 +1,13 @@
-import type {
-  DatabaseObserver,
-  DatabaseOperationEnd,
-  DatabaseOperationStart,
-  Query,
-  QueryResults,
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  type DatabaseOperationStart,
+  type Query,
+  type QueryResults,
+  type StandardSchemaV1,
+  sql,
 } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
 import {
   createPostgresDatabase,
   type PostgresClientLike,
@@ -110,6 +111,30 @@ const accountQuery = sql<{ id: bigint; email: string }>`SELECT id, email FROM ac
 const projectQuery = sql<{ id: bigint; budget: string | null }>`SELECT id, budget FROM project`;
 
 await describe("PostgreSQL query pipelines", async () => {
+  await it("validates selected pipeline results without changing ordinary members", async () => {
+    const pool = new PipelinePool();
+    pool.client.rows.set("SELECT validated", [{ id: 1 }]);
+    pool.client.rows.set("SELECT ordinary", [{ id: 2 }]);
+    const schema: StandardSchemaV1<unknown, { readonly id: number }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate(value) {
+          const row = value as { readonly id: unknown };
+          return typeof row.id === "number" ? { value: { id: row.id } } : { issues: [{ message: "not number" }] };
+        },
+      },
+    };
+    const validated = sql.validateResult(sql<{ id: number }>`SELECT validated`, schema);
+    const results = await createPostgresDatabase({ pool }).pipeline([
+      validated,
+      sql<{ id: number }>`SELECT ordinary`,
+      validated,
+    ]);
+
+    strict.deepStrictEqual(results, [[{ id: 1 }], [{ id: 2 }], [{ id: 1 }]]);
+  });
+
   await it("preserves exact tuple and homogeneous-array result types", async () => {
     const database = createPostgresDatabase({ pool: new PipelinePool() });
     const tuple = database.pipeline([accountQuery, projectQuery]);

--- a/packages/postgres/test/provider.test.ts
+++ b/packages/postgres/test/provider.test.ts
@@ -97,6 +97,14 @@ class CatalogClient implements PostgresIntrospectionClient {
           set_returning: false,
           volatility: "s",
         },
+        {
+          schema_name: "analytics",
+          function_name: "user_count",
+          argument_types: [],
+          database_return_type: "bigint",
+          set_returning: false,
+          volatility: "s",
+        },
       ];
     else throw new Error("Unexpected catalog query");
     return { rows: rows as readonly Row[] };
@@ -138,6 +146,7 @@ await describe("PostgreSQL schema provider", async () => {
     strict.strictEqual(snapshot.tables.users?.columns.display_name?.tsType, "string");
     strict.strictEqual(snapshot.functions?.["user_count()"]?.returnType, "bigint");
     strict.strictEqual(snapshot.functions?.["user_count()"]?.volatility, "stable");
+    strict.strictEqual(snapshot.functions?.["analytics.user_count()"]?.returnType, "bigint");
     strict.ok(client.filters.every((filter) => JSON.stringify(filter) === '["public"]'));
   });
 
@@ -166,6 +175,13 @@ await describe("PostgreSQL schema provider", async () => {
     strict.strictEqual(pool.client.commands.at(-1), "COMMIT");
     strict.strictEqual(pool.client.released, true);
     strict.strictEqual(pool.ended, true);
+
+    const rollbackPool = new CatalogPool();
+    rollbackPool.client.failCatalog = true;
+    await strict.rejects(() => new PostgresSchemaProvider({ pool: rollbackPool }).introspect({ url: "postgres://db" }));
+    strict.ok(rollbackPool.client.commands.includes("ROLLBACK"));
+    strict.strictEqual(rollbackPool.client.released, true);
+    strict.strictEqual(rollbackPool.ended, true);
     strict.ok(pool.client.filters.every((filter) => JSON.stringify(filter) === "[]"));
   });
 
@@ -184,6 +200,21 @@ await describe("PostgreSQL schema provider", async () => {
     strict.ok(pool.client.commands.includes("ROLLBACK"));
     strict.strictEqual(pool.client.released, true);
     strict.strictEqual(pool.ended, true);
+
+    const nonErrorPool: PostgresIntrospectionPool & { ended: boolean } = {
+      ended: false,
+      async connect(): Promise<PostgresIntrospectionClient> {
+        throw "connection unavailable";
+      },
+      async end(): Promise<void> {
+        this.ended = true;
+      },
+    };
+    await strict.rejects(
+      () => introspectPostgres({ url: "postgres://secret@localhost/db" }, { pool: nonErrorPool }),
+      /connection unavailable/,
+    );
+    strict.strictEqual(nonErrorPool.ended, true);
   });
 
   await it("closes pools and redacts connection failures", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -146,6 +146,10 @@ await describe("PostgreSQL runtime adapter", async () => {
     strict.deepStrictEqual(validatedRows, [{ id: 1 }]);
     strict.deepStrictEqual(ordinaryRows, [{ id: 1 }]);
 
+    const [firstValidatedRows, secondValidatedRows] = await database.batch([validated, validated]);
+    strict.deepStrictEqual(firstValidatedRows, [{ id: 1 }]);
+    strict.deepStrictEqual(secondValidatedRows, [{ id: 1 }]);
+
     const invalidSchema: StandardSchemaV1<unknown, { readonly id: number }> = {
       "~standard": {
         version: 1,
@@ -157,6 +161,14 @@ await describe("PostgreSQL runtime adapter", async () => {
       database.execute(sql.validateResult(sql<{ id: number }>`SELECT id FROM users`, invalidSchema)),
       /result validation failed/,
     );
+
+    const unobserved = createPostgresDatabase({ pool: new MockPool() });
+    const unobservedValidated = sql.validateResult(sql<{ id: number }>`SELECT id FROM users`, schema);
+    strict.deepStrictEqual(await unobserved.execute(unobservedValidated), [{ id: 1 }]);
+    strict.deepStrictEqual(await unobserved.all(unobservedValidated), [{ id: 1 }]);
+    strict.deepStrictEqual(await unobserved.one(unobservedValidated), { id: 1 });
+    strict.deepStrictEqual(await unobserved.maybeOne(unobservedValidated), { id: 1 });
+    strict.deepStrictEqual(await unobserved.batch([unobservedValidated]), [[{ id: 1 }]]);
   });
 
   await it("emits redacted fingerprinted query, batch, and transaction lifecycles", async () => {

--- a/packages/postgres/test/runtime.test.ts
+++ b/packages/postgres/test/runtime.test.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { describe, it, strict } from "poku";
 import {
   type DatabaseObserver,
   type DatabaseOperationEnd,
@@ -7,8 +6,10 @@ import {
   type Query,
   type QueryParameters,
   type QueryRow,
+  type StandardSchemaV1,
   sql,
-} from "../../core/src/index.js";
+} from "@typed-sql/core";
+import { describe, it, strict } from "poku";
 import {
   createPostgresDatabase,
   createPostgresTypeParsers,
@@ -113,6 +114,51 @@ class MockPool implements PostgresPoolLike {
 }
 
 await describe("PostgreSQL runtime adapter", async () => {
+  await it("validates decoded PostgreSQL rows and retains prepared metadata", async () => {
+    const schema: StandardSchemaV1<unknown, { readonly id: number }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate(value) {
+          const row = value as { readonly id: unknown };
+          return typeof row.id === "number" ? { value: { id: row.id } } : { issues: [{ message: "not number" }] };
+        },
+      },
+    };
+    const starts: DatabaseOperationStart[] = [];
+    const database = createPostgresDatabase({
+      pool: new MockPool(),
+      observer: {
+        start(operation) {
+          starts.push(operation);
+          return { end() {} };
+        },
+      },
+    });
+    const prepared = database.prepare("validated-account", () => sql<{ id: number }>`SELECT id FROM users`);
+    const validated = sql.validateResult(prepared(), schema);
+    strict.deepStrictEqual(await database.one(validated), { id: 1 });
+    const start = starts[0];
+    if (start?.kind !== "query") strict.fail("Expected a query observation");
+    strict.strictEqual(start.prepared, true);
+
+    const [validatedRows, ordinaryRows] = await database.batch([validated, sql<{ id: number }>`SELECT id FROM users`]);
+    strict.deepStrictEqual(validatedRows, [{ id: 1 }]);
+    strict.deepStrictEqual(ordinaryRows, [{ id: 1 }]);
+
+    const invalidSchema: StandardSchemaV1<unknown, { readonly id: number }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate: () => ({ issues: [{ message: "invalid", path: ["id"] }] }),
+      },
+    };
+    await strict.rejects(
+      database.execute(sql.validateResult(sql<{ id: number }>`SELECT id FROM users`, invalidSchema)),
+      /result validation failed/,
+    );
+  });
+
   await it("emits redacted fingerprinted query, batch, and transaction lifecycles", async () => {
     const starts: DatabaseOperationStart[] = [];
     const ends: DatabaseOperationEnd[] = [];

--- a/packages/postgres/test/stream.test.ts
+++ b/packages/postgres/test/stream.test.ts
@@ -1,6 +1,11 @@
-import type { DatabaseObserver, DatabaseOperationEnd, QueryStream } from "@typed-sql/core";
+import {
+  type DatabaseObserver,
+  type DatabaseOperationEnd,
+  type QueryStream,
+  type StandardSchemaV1,
+  sql,
+} from "@typed-sql/core";
 import { describe, it, strict } from "poku";
-import { sql } from "../../core/src/index.js";
 import {
   createPostgresDatabase,
   type PostgresClientLike,
@@ -131,6 +136,27 @@ await describe("PostgreSQL query streams", async () => {
     strict.strictEqual(pool.client.cursor.closeCount, 1);
     strict.strictEqual(pool.client.releaseCount, 1);
     strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+  });
+
+  await it("validates streamed rows while retaining prepared driver metadata", async () => {
+    const pool = new FakePool();
+    const database = createPostgresDatabase({ pool });
+    const prepared = database.prepare("validated-account-stream", () => sql<{ id: number }>`SELECT id FROM account`);
+    const schema: StandardSchemaV1<unknown, { readonly id: number }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate(value) {
+          const row = value as { readonly id: unknown };
+          return typeof row.id === "number" ? { value: { id: row.id } } : { issues: [{ message: "not number" }] };
+        },
+      },
+    };
+    const stream = database.stream(sql.validateResult(prepared(), schema));
+
+    strict.deepStrictEqual(await stream.next(), { done: false, value: { id: 1 } });
+    strict.strictEqual(pool.client.cursorConfigs[0]?.name, "validated-account-stream");
+    await stream.close();
   });
 
   await it("validates batch sizes without acquiring a connection", () => {

--- a/packages/sqlite/src/runtime.ts
+++ b/packages/sqlite/src/runtime.ts
@@ -1,15 +1,20 @@
+import { createHash } from "node:crypto";
 import {
   assertExecutionCapabilities,
   type Database,
   type ExecutionOptions,
+  hasQueryResultValidator,
   type Query,
   type QueryBatch,
   QueryCardinalityError,
   type QueryResults,
   type QueryStream,
+  queryResultValidationSource,
   renderQuery,
   type SqlRenderer,
   type StreamOptions,
+  validateQueryResultRows,
+  validateQueryResultStream,
 } from "@typed-sql/core";
 import {
   createSqlitePreparedQueryState,
@@ -17,6 +22,7 @@ import {
   type SqlitePreparedQueryFactory,
   type SqlitePreparedQueryState,
 } from "./prepared.js";
+import { SQLITE_DIALECT_VERSION } from "./version.js";
 
 export interface SqliteConnectionLike {
   all(sql: string, values?: readonly unknown[]): readonly Record<string, unknown>[];
@@ -53,6 +59,11 @@ export const sqliteRenderer: SqlRenderer = Object.freeze({
   placeholder: () => "?",
   quoteIdentifier: (identifier: string) => `"${identifier.replaceAll('"', '""')}"`,
 });
+
+function sqliteQueryFingerprint<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): string {
+  const text = renderQuery(query, sqliteRenderer).text;
+  return `sha256:${createHash("sha256").update(`sqlite\0${SQLITE_DIALECT_VERSION}\0${text}`).digest("hex")}`;
+}
 
 const executionCapabilities = Object.freeze({ cancellation: false, deadlines: false });
 const emptyBatchResults = Object.freeze([]);
@@ -184,11 +195,12 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     this.#assertOpen();
     if (options !== undefined) assertExecutionCapabilities(executionCapabilities, options);
     this.#assertNoStream("execute a query");
-    const prepared = this.#prepared.queries.get(query);
+    const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, sqliteRenderer);
     const operation = async (): Promise<readonly Row[]> =>
       (await this.#connection.all(rendered.text, rendered.values)) as readonly Row[];
-    return this.#root ? this.#queue.run(operation) : operation();
+    const rows = await (this.#root ? this.#queue.run(operation) : operation());
+    return this.#validateRows(query, rows);
   }
 
   async one<Row, Params extends readonly unknown[]>(
@@ -217,13 +229,16 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     const operation = async (): Promise<QueryResults<Queries>> => {
       const results: (readonly unknown[])[] = [];
       for (const query of snapshot) {
-        const prepared = this.#prepared.queries.get(query as object);
+        const prepared = this.#prepared.queries.get(
+          queryResultValidationSource(query as Query<unknown, readonly unknown[]>),
+        );
         const rendered = prepared?.rendered ?? renderQuery(query as Query<unknown, readonly unknown[]>, sqliteRenderer);
         results.push(await this.#connection.all(rendered.text, rendered.values));
       }
       return results as QueryResults<Queries>;
     };
-    return this.#root ? this.#queue.run(operation) : operation();
+    const results = await (this.#root ? this.#queue.run(operation) : operation());
+    return this.#validateBatch(snapshot, results);
   }
 
   stream<Row, Params extends readonly unknown[]>(
@@ -232,20 +247,20 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
   ): QueryStream<Row> {
     this.#assertOpen();
     validateBatchSize(options.batchSize);
-    const prepared = this.#prepared.queries.get(query);
+    const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, sqliteRenderer);
-    let stream!: QueryStream<Row>;
-    stream = new SqliteQueryStream<Row>(async () => {
+    let source!: QueryStream<Row>;
+    source = new SqliteQueryStream<Row>(async () => {
       this.#assertOpen();
       this.#assertNoStream("start a query stream");
       const release = this.#root ? await this.#queue.acquire() : () => undefined;
       try {
         const iterator = this.#connection.iterate(rendered.text, rendered.values)[Symbol.iterator]() as Iterator<Row>;
-        this.#streams.add(stream as QueryStream<unknown>);
+        this.#streams.add(source as QueryStream<unknown>);
         return {
           iterator,
           release: () => {
-            this.#streams.delete(stream as QueryStream<unknown>);
+            this.#streams.delete(source as QueryStream<unknown>);
             release();
           },
         };
@@ -254,7 +269,33 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
         throw error;
       }
     });
-    return stream;
+    return hasQueryResultValidator(query)
+      ? validateQueryResultStream(query, source, sqliteQueryFingerprint(query))
+      : source;
+  }
+
+  async #validateRows<Row, Params extends readonly unknown[]>(
+    query: Query<Row, Params>,
+    rows: readonly unknown[],
+  ): Promise<readonly Row[]> {
+    if (!hasQueryResultValidator(query)) return rows as readonly Row[];
+    return validateQueryResultRows(query, rows, sqliteQueryFingerprint(query));
+  }
+
+  async #validateBatch<const Queries extends readonly unknown[]>(
+    queries: QueryBatch<Queries>,
+    results: QueryResults<Queries>,
+  ): Promise<QueryResults<Queries>> {
+    let validated: unknown[] | undefined;
+    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
+    const resultList = results as readonly (readonly unknown[])[];
+    for (let index = 0; index < queryList.length; index += 1) {
+      const query = queryList[index]!;
+      if (!hasQueryResultValidator(query)) continue;
+      validated ??= [...resultList];
+      validated[index] = await validateQueryResultRows(query, resultList[index]!, sqliteQueryFingerprint(query));
+    }
+    return (validated ?? results) as QueryResults<Queries>;
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(

--- a/packages/sqlite/test/runtime.test.ts
+++ b/packages/sqlite/test/runtime.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { QueryResultValidationError, type StandardSchemaV1, sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
-import { sql } from "../src/index.js";
 import { adaptNodeSqliteDatabase, createNodeSqliteDatabase, nodeSqlite } from "../src/node-sqlite.js";
 import { createSqliteDatabase } from "../src/runtime.js";
 
@@ -13,6 +13,50 @@ interface Account {
 }
 
 await describe("node:sqlite runtime adapter", async () => {
+  await it("validates cardinality, batch, stream, and transaction results", async () => {
+    const native = new DatabaseSync(":memory:");
+    native.exec("CREATE TABLE account (id INTEGER PRIMARY KEY, email TEXT NOT NULL) STRICT");
+    native.exec("INSERT INTO account VALUES (1, 'valid@example.test'), (2, 'invalid')");
+    const database = createSqliteDatabase({ connection: adaptNodeSqliteDatabase(native), ownsConnection: true });
+    const schema: StandardSchemaV1<unknown, Account> = {
+      "~standard": {
+        version: 1,
+        vendor: "test-validator",
+        validate(value) {
+          const row = value as Account;
+          return row.email.includes("@") ? { value: row } : { issues: [{ message: "invalid", path: ["email"] }] };
+        },
+      },
+    };
+    const preparedValid = database.prepare(
+      "validated-account",
+      () => sql<Account>`SELECT id, email FROM account WHERE id = 1`,
+    );
+    const valid = sql.validateResult(preparedValid(), schema);
+    const invalid = sql.validateResult(sql<Account>`SELECT id, email FROM account WHERE id = 2`, schema);
+
+    strict.strictEqual((await database.maybeOne(valid))?.id, 1n);
+    await strict.rejects(database.maybeOne(invalid), QueryResultValidationError);
+    await strict.rejects(database.batch([valid, invalid]), QueryResultValidationError);
+    const stream = database.stream(sql.validateResult(sql<Account>`SELECT id, email FROM account ORDER BY id`, schema));
+    const first = await stream.next();
+    strict.strictEqual(first.done, false);
+    strict.strictEqual(first.value.id, 1n);
+    strict.strictEqual(first.value.email, "valid@example.test");
+    await strict.rejects(stream.next(), QueryResultValidationError);
+    strict.deepStrictEqual(await stream.next(), { done: true, value: undefined });
+
+    await strict.rejects(
+      database.transaction(async (transaction) => {
+        await transaction.execute(sql`INSERT INTO account VALUES (3, 'rolled-back')`);
+        await transaction.one(invalid);
+      }),
+      QueryResultValidationError,
+    );
+    strict.strictEqual((await database.one(sql<{ count: bigint }>`SELECT count(*) AS count FROM account`)).count, 2n);
+    await database.close();
+  });
+
   await it("executes, prepares, batches, streams, and nests transactions", async () => {
     const native = new DatabaseSync(":memory:");
     native.exec("CREATE TABLE account (id INTEGER PRIMARY KEY, email TEXT NOT NULL) STRICT");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@7.0.2)
+      zod:
+        specifier: ^4.5.2
+        version: 4.5.2
 
   e2e/postgres:
     dependencies:
@@ -2905,6 +2911,14 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -3073,6 +3087,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5711,6 +5728,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -5891,5 +5912,7 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yocto-queue@0.1.0: {}
+
+  zod@4.5.2: {}
 
   zwitch@2.0.4: {}

--- a/scripts/performance/microbenchmarks.mjs
+++ b/scripts/performance/microbenchmarks.mjs
@@ -161,6 +161,42 @@ export async function deterministicMicrobenchmarks(methodology) {
   assert.ok(postgresObservationStarts > 0);
   assert.equal(postgresObservationEnds, postgresObservationStarts);
 
+  const validationRows = Array.from({ length: 100 }, (_, index) => ({ id: BigInt(index + 1) }));
+  const validationPool = {
+    async query() {
+      return { rows: validationRows };
+    },
+    async connect() {
+      throw new Error("validation microbenchmark does not acquire a connection");
+    },
+    async end() {},
+  };
+  const validationDatabase = createPostgresDatabase({ pool: validationPool });
+  const unvalidatedQuery = sql`SELECT account.id FROM account`;
+  let validatorCalls = 0;
+  const validatedQuery = sql.validateResult(unvalidatedQuery, {
+    "~standard": {
+      version: 1,
+      vendor: "performance",
+      validate(value) {
+        validatorCalls += 1;
+        return { value };
+      },
+    },
+  });
+  results["micro.postgres.validationDisabled.100Rows"] = await latency(
+    () => validationDatabase.execute(unvalidatedQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.equal(validatorCalls, 0);
+  results["micro.postgres.validationEnabled.100Rows"] = await latency(
+    () => validationDatabase.execute(validatedQuery),
+    methodology,
+    asyncIterations,
+  );
+  assert.ok(validatorCalls >= validationRows.length);
+
   const postgresStreamRows = Array.from({ length: 100 }, (_, index) => ({ id: BigInt(index + 1) }));
   let postgresStreamReleases = 0;
   const postgresStreamingDatabase = createPostgresDatabase({

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -25,6 +25,7 @@ const expectedPublicDocs = [
   "docs/guides/observability.md",
   "docs/guides/query-manifests.md",
   "docs/guides/query-plan-governance.md",
+  "docs/guides/result-validation.md",
   "docs/guides/routing-and-retries.md",
   "docs/guides/schema-snapshots.md",
   "docs/index.md",

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -119,6 +119,9 @@ import type {
   QueryRenderSkeleton,
   QueryResult,
   QueryResults,
+  QueryResultValidationFailure,
+  QueryResultValidationIssue,
+  QueryResultValidationOptions,
   QueryRoute,
   QueryRoutePreference,
   QueryRouteSelection,
@@ -143,6 +146,8 @@ import type {
   SqlRenderer,
   SqlSegment,
   SqlTag,
+  StandardSchemaV1,
+  StandardTypedV1,
   StreamOperationStart,
   StreamOptions,
   TransactionDatabase,
@@ -221,6 +226,22 @@ const predicate = coreApi.sql.fragment`account.id >= ${1n}`;
 const composed = coreApi.sql.where(base, predicate);
 const composedParameters: Assert<Equal<QueryParameters<typeof composed>, readonly [bigint]>> = true;
 const emptyParameters: Assert<Equal<QueryParameters<ReturnType<typeof structuralEmptyContract>>, readonly []>> = true;
+
+function resultValidationContract(
+  accountResultSchema: StandardSchemaV1<unknown, Account>,
+  incompatibleResultSchema: StandardSchemaV1<unknown, { readonly id: string }>,
+  anyResultSchema: StandardSchemaV1<unknown, ReturnType<typeof JSON.parse>>,
+) {
+  const validatedResultQuery = coreApi.sql.validateResult(base, accountResultSchema);
+  const validatedResultRow: Assert<Equal<QueryRow<typeof validatedResultQuery>, Account>> = true;
+  const validatedResultParameters: Assert<Equal<QueryParameters<typeof validatedResultQuery>, readonly []>> = true;
+  // @ts-expect-error validator output must be assignable to the compiler-inferred query row
+  coreApi.sql.validateResult(base, incompatibleResultSchema);
+  // @ts-expect-error `any` cannot provide a sound runtime validation boundary
+  coreApi.sql.validateResult(base, anyResultSchema);
+  void validatedResultRow;
+  void validatedResultParameters;
+}
 
 function structuralEmptyContract() {
   return coreApi.sql`SELECT 1${coreApi.sql.empty}`;
@@ -522,6 +543,9 @@ type ReferencedStableTypes =
   | QueryCardinalityExpectation
   | QueryExecutor
   | QueryRenderSkeleton
+  | QueryResultValidationFailure
+  | QueryResultValidationIssue
+  | QueryResultValidationOptions
   | QueryStream<Account>
   | RenderedQuery
   | ReplicaSelectionContext
@@ -539,6 +563,8 @@ type ReferencedStableTypes =
   | SqlAstContext
   | SelectLockingClause
   | StreamOptions
+  | StandardSchemaV1
+  | StandardTypedV1
   | StreamOperationStart
   | SemanticEvidence
   | SemanticFact<string>
@@ -578,6 +604,7 @@ void emptyParameters;
 void executionContract;
 void governedExecutionContract;
 void defaultTransactionContract;
+void resultValidationContract;
 void enrichedTransactionContract;
 void enrichedIsDefaultCompatible;
 void postgresAdapter;
@@ -660,6 +687,7 @@ const expectedRuntimeExports = {
     "UnsupportedAdapterCapabilityError",
     "QueryCancelledError",
     "QueryCardinalityError",
+    "QueryResultValidationError",
     "UnsupportedExecutionCapabilityError",
     "assertDialectPlugin",
     "assertExecutionCapabilities",
@@ -681,12 +709,14 @@ const expectedRuntimeExports = {
     "executionDeadline",
     "getAdapterCapability",
     "hasAdapterCapability",
+    "hasQueryResultValidator",
     "isTypedSqlDiagnosticCode",
     "mapQuerySemanticRanges",
     "mergeQuerySemantics",
     "observeQueryStream",
     "parameterTypeLiteral",
     "queryRoute",
+    "queryResultValidationSource",
     "QUERY_SEMANTICS_VERSION",
     "renderQuery",
     "requireAdapterCapability",
@@ -697,6 +727,8 @@ const expectedRuntimeExports = {
     "unionTypeLiterals",
     "unknownQuerySemantics",
     "UnsafeReplicaRoutingError",
+    "validateQueryResultRows",
+    "validateQueryResultStream",
   ],
   mysql: [
     "MYSQL_DIALECT_VERSION",

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Execute queries", link: "/guides/execution" },
+          { text: "Validate query results", link: "/guides/result-validation" },
           { text: "Transfer bulk data", link: "/guides/bulk-data" },
           { text: "Observe database work", link: "/guides/observability" },
           { text: "Route reads and retry transactions", link: "/guides/routing-and-retries" },


### PR DESCRIPTION
Closes #62

## What changed

- add dependency-free Standard Schema V1 result validation through `sql.validateResult()`
- enforce schema-output compatibility with compiler-inferred query rows
- validate decoded PostgreSQL, MySQL, and SQLite rows across buffered, cardinality, batch, pipeline, stream, and transaction lifecycles
- preserve prepared-query identity and redact runtime values from failures by default
- prove interoperability with real Zod and Valibot consumers in packed E2E tests
- document the inference/decode/validation boundary and add disabled/enabled performance measurements

## Verification

- `pnpm verify`
- packed PostgreSQL + Zod E2E
- packed MySQL + Valibot E2E
