### PR TITLE
docs: define the v1 to v2 migration contract

### DIFF
--- a/docs/extending/custom-grammars.md
+++ b/docs/extending/custom-grammars.md
@@ -141,6 +141,9 @@ Three versions have different responsibilities:
 
 Changing placeholder behavior, identifier rules, catalog interpretation, or inferred types requires a grammar-version change whenever an existing snapshot could be interpreted differently. The package version does not replace this explicit check.
 
+For the dialect v3 to v4 semantic boundary and its fail-closed migration path, see
+[Upgrade from typed-sql v1](../guides/upgrading-from-v1.md#upgrade-a-custom-grammar).
+
 ## Conformance kit
 
 `@typed-sql/conformance` is the executable compatibility contract for first- and third-party

--- a/docs/guides/migration-compatibility.md
+++ b/docs/guides/migration-compatibility.md
@@ -12,6 +12,10 @@ description: Compare schema and query artifacts to find source, runtime, and rol
 
 The analyzer is offline and grammar-neutral. It does not apply migrations, contact a database, or require a particular migration framework. Existing tools continue to own migration ordering, locks, rollback, and production execution.
 
+Applications adopting compatibility artifacts from typed-sql v1 should first follow the
+[v1 upgrade guide](./upgrading-from-v1.md#adopt-compiler-and-ci-artifacts) so snapshots and manifests
+come from one coherent package set.
+
 ## Produce the four inputs
 
 Keep one snapshot and manifest from each application revision:

--- a/docs/guides/upgrading-from-v1.md
+++ b/docs/guides/upgrading-from-v1.md
@@ -1,0 +1,207 @@
+---
+title: Upgrade from typed-sql v1
+description: Move applications, custom grammars, runtime adapters, and CI artifacts to the v2 contracts.
+---
+
+# Upgrade from typed-sql v1
+
+typed-sql v2 keeps the application-facing model introduced in v1: application code imports `sql`
+from its grammar package, installs its own database driver, and treats generated schema files as
+compiler inputs. The major version changes the grammar and production-artifact contracts rather
+than replacing native SQL with a generated client or query builder.
+
+Upgrade all stable `@typed-sql/*` packages used by one application to the same major. Do not mix a
+v1 grammar with the v2 compiler or core package. Preview editor packages remain isolated from the
+stable compiler path and can be upgraded independently.
+
+## Upgrade an application
+
+The query import does not change:
+
+```ts
+import { sql, typePolicy } from "@typed-sql/postgres";
+import { createPgDatabase } from "@typed-sql/postgres/pg";
+
+const account = sql`
+  SELECT users.id, users.email
+  FROM users
+  WHERE users.id = ${1n}
+`;
+
+const database = await createPgDatabase({ connectionString: process.env.DATABASE_URL!, typePolicy });
+const row = await database.one(account);
+```
+
+`pg`, `mysql2`, validation libraries, and OpenTelemetry remain application-owned dependencies. The
+grammar package does not install them. SQLite uses the built-in `node:sqlite` adapter and remains an
+experimental package surface.
+
+After upgrading packages, regenerate and check the project:
+
+```sh
+pnpm exec typed-sql generate
+pnpm exec typed-sql check --project tsconfig.json
+```
+
+Regeneration is required when the snapshot's `dialectVersion` differs from the selected grammar.
+It is also recommended for every v1 upgrade because v2 snapshots can record function volatility,
+which supplies evidence for routing, retry, manifest, and compatibility decisions. A v1 snapshot
+whose neutral `formatVersion` is still supported can be read, but missing evidence remains unknown
+rather than being guessed.
+
+The v1 `execute()` and `transaction()` methods remain available. v2 adds `all()`, `one()`, and
+`maybeOne()` cardinality methods, cancellation and deadlines, prepared execution, streams, batches,
+routing, and optional adapter capabilities. Adopt them incrementally; no production feature is
+enabled merely by upgrading the package.
+
+## Adopt compiler and CI artifacts
+
+Start with a query manifest. It gives every statically analyzed query a path-independent identity
+and becomes the input for the other production checks:
+
+```ts
+export default defineConfig({
+  dialect: postgres(),
+  schema: { file: "generated/db/schema.json" },
+  outDir: "generated/db",
+  projects: ["tsconfig.json"],
+  manifest: { outFile: ".typed-sql/queries.json" },
+});
+```
+
+```sh
+pnpm exec typed-sql manifest
+```
+
+Then add only the checks the application needs:
+
+- [Live verification](./live-verification.md) compares manifest evidence with native database
+  metadata and supports a cached offline check.
+- [Query-plan governance](./query-plan-governance.md) records redacted structured plans and reviews
+  explicit budgets.
+- [Migration compatibility](./migration-compatibility.md) compares before/after snapshots and
+  manifests in both rolling-deployment directions.
+- [Observability](./observability.md) correlates runtime work with compiler fingerprints without
+  recording SQL or parameter values by default.
+- [Result validation](./result-validation.md) accepts any compatible Standard Schema V1 validator
+  without adding a validator dependency to typed-sql.
+
+Generated snapshots, manifests, verification proofs, plan artifacts, and compatibility reports are
+versioned inputs. Parse them through the public parser for that artifact instead of casting JSON.
+When a parser rejects a version, regenerate the artifact with one coherent package set. Never edit a
+version field to make an incompatible artifact appear current.
+
+## Upgrade a custom grammar
+
+The breaking grammar change is `DIALECT_CONTRACT_VERSION` 3 to 4. Every analysis must now return
+versioned, evidence-backed `QuerySemantics` beside columns, parameters, diagnostics, and result kind.
+
+A v1 analysis could return only inference evidence:
+
+```ts
+return {
+  columns,
+  parameters,
+  diagnostics,
+  resultKind: "rows",
+};
+```
+
+The v2 contract requires semantics:
+
+```ts
+import {
+  DIALECT_CONTRACT_VERSION,
+  unknownQuerySemantics,
+  type DialectPlugin,
+} from "@typed-sql/core";
+
+const plugin = {
+  contractVersion: DIALECT_CONTRACT_VERSION,
+  // id, grammarVersion, sqlModule, capabilities, policy, and renderer omitted
+  analyze(text, snapshot, policy) {
+    const result = analyzeGrammar(text, snapshot, policy);
+    return {
+      ...result,
+      semantics: result.diagnostics.some((item) => item.severity === "error")
+        ? unknownQuerySemantics(sourceRange(text), "Grammar analysis reported an error.")
+        : analyzeSemantics(text, snapshot),
+    };
+  },
+} satisfies DialectPlugin;
+```
+
+Use `defineQuerySemantics()` for successful evidence. It canonicalizes and freezes operation,
+dependencies, cardinality, volatility, locking, connection affinity, and capability claims. Use
+`unknownQuerySemantics()` until a statement has real grammar or schema evidence. Do not infer a safe
+read, retry, or replica route from a SQL prefix.
+
+Increment the grammar's own `grammarVersion` when placeholder behavior, identifier rules, catalog
+interpretation, built-ins, coercions, nullability, or inferred types would reinterpret an existing
+snapshot. The npm package version does not replace this boundary. Regenerate snapshots after such a
+change and reject a mismatched `dialectVersion` in `validateSnapshot()`.
+
+Run the public conformance fixture before publishing. Its required semantic and capability probes
+make a fail-closed implementation executable rather than documentary. See
+[Author a custom SQL grammar](../extending/custom-grammars.md).
+
+## Upgrade a runtime adapter
+
+Adapters constructed through `createDatabase()` continue to work and gain the portable cardinality
+methods. A custom object that directly implements `Database` must also provide
+`executionCapabilities`, `all()`, `one()`, and `maybeOne()`. Report cancellation or deadline support
+only when the adapter can interrupt native work and clean up its connection conservatively.
+
+Protocol-specific functionality belongs behind a namespaced `AdapterCapability`, not on the neutral
+`Database` interface. Consumers discover it with `getAdapterCapability()` or require it with
+`requireAdapterCapability()`. This is how grammar adapters can expose COPY, LOAD DATA, or future
+native services without teaching core about a dialect or installing a driver.
+
+Live-verification and plan adapters expose their own non-empty `adapterVersion`. Change that value
+when native evidence or normalization changes. Cached proofs and plan comparisons include it so
+incompatible evidence is not silently reused.
+
+## Version boundary reference
+
+These versions are independent. Their current values describe a contract or artifact generation;
+they are not aliases for the typed-sql npm major.
+
+| Public boundary | Current value | Compatibility rule |
+| --- | --- | --- |
+| `DIALECT_CONTRACT_VERSION` | `4` | A grammar must implement the exact plugin protocol. |
+| `QUERY_SEMANTICS_VERSION` | `1` | Semantic evidence must use the exact supported shape. |
+| grammar `grammarVersion` | grammar-owned | A snapshot's `dialectVersion` must be accepted explicitly by the grammar. |
+| `SCHEMA_FORMAT_VERSION` | `1` | Parse through `parseSchemaSnapshot()`; regenerate when unsupported. |
+| `QUERY_MANIFEST_FORMAT_VERSION` | `1` | Parse through `parseQueryManifest()`; regenerate when unsupported. |
+| `QUERY_FINGERPRINT_ALGORITHM` | `typed-sql-v1` | Fingerprints correlate only when the algorithm, grammar, schema, and policy evidence agree. |
+| `QUERY_VERIFICATION_FORMAT_VERSION` | `1` | Parse proofs through `parseQueryVerificationProof()`. |
+| `QUERY_VERIFIER_VERSION` | `typed-sql-v1` | Cached proof keys must match the neutral verifier and grammar adapter versions. |
+| `QUERY_PLAN_FORMAT_VERSION` | `1` | Parse captures through `parseQueryPlanArtifact()`. |
+| `QUERY_PLAN_CAPTURE_VERSION` | `typed-sql-v1` | Compare captures only when capture and environment evidence are compatible. |
+| `QUERY_PLAN_REVIEW_FORMAT_VERSION` | `1` | Parse review reports through `parseQueryPlanReviewReport()`. |
+| `SCHEMA_COMPATIBILITY_FORMAT_VERSION` | `1` | Parse reports through `parseSchemaCompatibilityReport()`. |
+| `SCHEMA_COMPATIBILITY_ANALYZER_VERSION` | `typed-sql-v1` | Recompute reports when the analyzer generation changes. |
+| `GRAMMAR_CONFORMANCE_VERSION` | `1` | A grammar fixture must implement the exact required probe contract. |
+| Standard Schema `~standard.version` | `1` | `sql.validateResult()` accepts structurally compatible Standard Schema V1 validators. |
+| live verifier or plan `adapterVersion` | adapter-owned | Change it whenever native evidence or normalization compatibility changes. |
+
+Names such as `typed-sql-v1` identify the first generation of an artifact algorithm. They remain
+valid in typed-sql v2 until that particular algorithm changes. Renaming them solely to match the npm
+major would invalidate deterministic evidence without changing its meaning.
+
+## Verify the upgrade
+
+An upgrade is complete when the application can perform all of these actions from installed package
+exports, without importing generated application APIs or repository source:
+
+```sh
+pnpm exec typed-sql generate
+pnpm exec typed-sql check --project tsconfig.json
+pnpm exec typed-sql manifest
+pnpm typecheck
+pnpm test
+```
+
+If the application adopts live verification, plan governance, or compatibility analysis, also parse
+and review the resulting artifacts in CI. Keep database credentials in the executable config or CI
+environment; none of the persisted artifacts should contain them.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -12,6 +12,9 @@ Compatibility has two meanings in typed-sql:
 
 A tested version does not imply that every older or newer version is supported. A supported range does not imply that every version in the range runs in every CI job.
 
+For package-major, grammar, snapshot, manifest, verification, plan, compatibility, and adapter
+version boundaries, see [Upgrade from typed-sql v1](../guides/upgrading-from-v1.md).
+
 ## Runtime and compiler
 
 | Surface | Contract |

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -28,6 +28,7 @@ const expectedPublicDocs = [
   "docs/guides/result-validation.md",
   "docs/guides/routing-and-retries.md",
   "docs/guides/schema-snapshots.md",
+  "docs/guides/upgrading-from-v1.md",
   "docs/index.md",
   "docs/reference/api.md",
   "docs/reference/compatibility.md",
@@ -222,6 +223,44 @@ await describe("public documentation", async () => {
         Object.keys(languageServerPackage.bin)[0] ?? "missing-language-server",
       ),
     );
+  });
+
+  await it("keeps the v1 upgrade contract aligned with public version boundaries", async () => {
+    const migration = await text("docs/guides/upgrading-from-v1.md");
+    const customGrammars = await text("docs/extending/custom-grammars.md");
+    const compatibility = await text("docs/guides/migration-compatibility.md");
+
+    for (const boundary of [
+      "DIALECT_CONTRACT_VERSION",
+      "QUERY_SEMANTICS_VERSION",
+      "SCHEMA_FORMAT_VERSION",
+      "QUERY_MANIFEST_FORMAT_VERSION",
+      "QUERY_FINGERPRINT_ALGORITHM",
+      "QUERY_VERIFICATION_FORMAT_VERSION",
+      "QUERY_VERIFIER_VERSION",
+      "QUERY_PLAN_FORMAT_VERSION",
+      "QUERY_PLAN_CAPTURE_VERSION",
+      "QUERY_PLAN_REVIEW_FORMAT_VERSION",
+      "SCHEMA_COMPATIBILITY_FORMAT_VERSION",
+      "SCHEMA_COMPATIBILITY_ANALYZER_VERSION",
+      "GRAMMAR_CONFORMANCE_VERSION",
+      "adapterVersion",
+    ]) {
+      strict.ok(migration.includes(`\`${boundary}\``), `upgrade guide is missing ${boundary}`);
+    }
+
+    for (const durableInvariant of [
+      'from "@typed-sql/postgres"',
+      'from "@typed-sql/postgres/pg"',
+      "application-owned dependencies",
+      "unknownQuerySemantics()",
+      "compiler inputs",
+    ]) {
+      strict.ok(migration.includes(durableInvariant), `upgrade guide is missing ${durableInvariant}`);
+    }
+
+    strict.ok(customGrammars.includes("../guides/upgrading-from-v1.md#upgrade-a-custom-grammar"));
+    strict.ok(compatibility.includes("./upgrading-from-v1.md#adopt-compiler-and-ci-artifacts"));
   });
 
   await it("renders the canonical docs through a reproducible GitHub Pages site", async () => {

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: "Verify against a database", link: "/guides/live-verification" },
           { text: "Govern query plans", link: "/guides/query-plan-governance" },
           { text: "Check migration compatibility", link: "/guides/migration-compatibility" },
+          { text: "Upgrade from v1", link: "/guides/upgrading-from-v1" },
           { text: "Compose conditional SQL", link: "/guides/composition" },
           { text: "Manage schema snapshots", link: "/guides/schema-snapshots" },
           { text: "Configure editors", link: "/guides/editors" },


### PR DESCRIPTION
Closes #79

## Summary

- add a durable application, grammar, adapter, and CI migration guide
- document every public v2 artifact and compatibility-version boundary
- link the custom-grammar, compatibility-analysis, and runtime compatibility references
- enforce the guide and version inventory through the Poku documentation contract

## Verification

- `pnpm docs:check`
- `pnpm docs:build`
- `pnpm quality`
- `pnpm typecheck`
- `git diff --check`