### PR TITLE
fix: verify MySQL enum evidence against live catalog

### DIFF
--- a/.changeset/mysql-live-enum-evidence.md
+++ b/.changeset/mysql-live-enum-evidence.md
@@ -1,0 +1,7 @@
+---
+"@typed-sql/compiler": minor
+"@typed-sql/mysql": minor
+---
+
+Use live MySQL catalog origins to preserve enum result evidence, and compare parameter metadata in
+the safe input direction so compiler-enforced literal subsets do not become false mismatches.

--- a/docs/guides/live-verification.md
+++ b/docs/guides/live-verification.md
@@ -63,7 +63,12 @@ Cached verification rejects a missing, malformed, or stale proof. Regenerate the
 The default verifier accepts only evidence-backed `read` and `write` operations. It invokes the database's prepare/describe mechanism but never executes the statement and never supplies parameter values:
 
 - PostgreSQL uses session-local `PREPARE`, reads `pg_prepared_statements`, then always `DEALLOCATE`s. PostgreSQL 18 exposes both parameter and result types. Older servers that do not expose result types are reported as incomplete instead of being treated as verified.
-- MySQL uses binary `COM_STMT_PREPARE` metadata through the application-installed `mysql2` adapter, then closes the prepared statement without `COM_STMT_EXECUTE`.
+- MySQL uses binary `COM_STMT_PREPARE` metadata through the application-installed `mysql2` adapter,
+  resolves origin columns against the live `information_schema.columns` catalog, then closes the
+  prepared statement without `COM_STMT_EXECUTE`. Origin lookup preserves catalog types such as enum
+  value sets that the prepare packet otherwise reports only as a string class. Parameter comparison
+  is directional: a compiler-enforced literal subset is compatible with the broader native input
+  class, while result columns still require native output evidence assignable to the inferred type.
 - DDL, transaction-control, unknown, dynamic, stale, and unsupported queries are explicit skips or errors. They are never silently marked verified.
 
 Prepare metadata does not prove runtime cardinality, business constraints, permissions for every production role, or query-plan quality.

--- a/e2e/mysql/src/verify-query.ts
+++ b/e2e/mysql/src/verify-query.ts
@@ -1,10 +1,12 @@
 import { sql } from "@typed-sql/mysql";
 
-export const accountVerificationQuery = sql`
-  SELECT users.id, users.email
-  FROM users
-  WHERE users.id >= ${1n}
-`;
+export function accountVerificationQuery(status: "active" | "suspended") {
+  return sql`
+    SELECT users.id, users.email, users.status
+    FROM users
+    WHERE users.status = ${status} AND users.id >= ${1n}
+  `;
+}
 
 export const accountPlanMutation = sql`
   UPDATE users SET email = ${"must-not-persist@example.com"} WHERE users.id = ${1n}

--- a/packages/compiler/src/verification.ts
+++ b/packages/compiler/src/verification.ts
@@ -237,6 +237,66 @@ function normalizedType(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/gu, " ");
 }
 
+function topLevelUnionMembers(value: string): readonly string[] {
+  const members: string[] = [];
+  let start = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  let depth = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    if (quote !== undefined) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === "(" || char === "[" || char === "{") depth += 1;
+    else if (char === ")" || char === "]" || char === "}") depth = Math.max(0, depth - 1);
+    else if (char === "|" && depth === 0) {
+      members.push(value.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  members.push(value.slice(start).trim());
+  return members;
+}
+
+type PrimitiveType = "string" | "number" | "bigint" | "boolean" | "null" | "undefined";
+
+function primitiveType(member: string): PrimitiveType | undefined {
+  if (["string", "number", "bigint", "boolean", "null", "undefined"].includes(member)) {
+    return member as PrimitiveType;
+  }
+  if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:e[+-]?\d+)?$/iu.test(member)) return "number";
+  if (/^-?(?:0|[1-9]\d*)n$/u.test(member)) return "bigint";
+  if (member === "true" || member === "false") return "boolean";
+  if (member.startsWith('"') && member.endsWith('"')) {
+    try {
+      return typeof JSON.parse(member) === "string" ? "string" : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Parameter metadata describes what the server accepts, so a compiler-side literal subset is safe. */
+function parameterTypeCompatible(expected: string, actual: string): boolean {
+  if (expected === actual) return true;
+  const accepted = topLevelUnionMembers(actual);
+  const supplied = topLevelUnionMembers(expected);
+  return (
+    supplied.length > 0 &&
+    supplied.every((member) =>
+      accepted.some(
+        (target) => member === target || (primitiveType(target) === target && primitiveType(member) === target),
+      ),
+    )
+  );
+}
+
 function compareField(
   target: "column" | "parameter",
   expected: QueryVerificationExpectedField,
@@ -254,7 +314,12 @@ function compareField(
     add("column-name", expected.name, actual.name);
   }
   if (expected.tsType !== "unknown" && actual.tsType !== undefined) {
-    if (expected.tsType !== actual.tsType) add("typescript-type", expected.tsType, actual.tsType);
+    if (
+      expected.tsType !== actual.tsType &&
+      (target !== "parameter" || !parameterTypeCompatible(expected.tsType, actual.tsType))
+    ) {
+      add("typescript-type", expected.tsType, actual.tsType);
+    }
   } else if (
     expected.databaseType !== undefined &&
     actual.databaseType !== undefined &&

--- a/packages/compiler/test/verification.test.ts
+++ b/packages/compiler/test/verification.test.ts
@@ -153,6 +153,105 @@ await describe("live query verification", async () => {
     strict.ok(!serialized.includes("private"));
   });
 
+  await it("accepts literal parameter subsets without weakening result verification", async () => {
+    const value = fixture();
+    const compareParameterTypes = async (expected: string, actual: string) =>
+      verifyQueryManifest({
+        manifest: value.manifest,
+        candidates: [
+          {
+            ...value.candidates[0]!,
+            parameters: value.candidates[0]!.parameters.map((field) => ({ ...field, tsType: expected })),
+          },
+        ],
+        verifier: verifier({
+          async verify() {
+            return {
+              columns: [
+                { index: 1, databaseType: "bigint", tsType: "bigint" },
+                { index: 2, databaseType: "text", tsType: "string" },
+              ],
+              parameters: [{ index: 1, databaseType: "native", tsType: actual }],
+            };
+          },
+        }),
+      });
+    const literalParameter = {
+      ...value.candidates[0]!,
+      parameters: value.candidates[0]!.parameters.map((field) => ({
+        ...field,
+        tsType: '"active" | "suspended"',
+      })),
+    };
+    const accepted = await verifyQueryManifest({
+      manifest: value.manifest,
+      candidates: [literalParameter],
+      verifier: verifier({
+        async verify() {
+          return {
+            columns: [
+              { index: 1, databaseType: "bigint", tsType: "bigint" },
+              { index: 2, databaseType: "text", tsType: "string" },
+            ],
+            parameters: [{ index: 1, databaseType: "varchar", tsType: "string" }],
+          };
+        },
+      }),
+    });
+    strict.strictEqual(accepted.verified, 1);
+
+    const literalColumn = {
+      ...value.candidates[0]!,
+      columns: value.candidates[0]!.columns.map((field, index) =>
+        index === 1 ? { ...field, tsType: '"active" | "suspended"' } : field,
+      ),
+    };
+    const rejected = await verifyQueryManifest({
+      manifest: value.manifest,
+      candidates: [literalColumn],
+      verifier: verifier(),
+    });
+    strict.strictEqual(rejected.mismatched, 1);
+
+    const broadParameter = {
+      ...value.candidates[0]!,
+      parameters: value.candidates[0]!.parameters.map((field) => ({ ...field, tsType: "string" })),
+    };
+    const narrowNativeInput = await verifyQueryManifest({
+      manifest: value.manifest,
+      candidates: [broadParameter],
+      verifier: verifier({
+        async verify() {
+          return {
+            columns: [
+              { index: 1, databaseType: "bigint", tsType: "bigint" },
+              { index: 2, databaseType: "text", tsType: "string" },
+            ],
+            parameters: [{ index: 1, databaseType: "enum", tsType: '"active" | "suspended"' }],
+          };
+        },
+      }),
+    });
+    strict.strictEqual(narrowNativeInput.mismatched, 1);
+
+    for (const [expected, actual] of [
+      ['"pipe|value" | "escaped\\\\value"', "string"],
+      ["1 | -2.5 | 6e2", "number"],
+      ["1n | -2n", "bigint"],
+      ["true | false", "boolean"],
+      ["null | undefined", "null | undefined"],
+    ] as const) {
+      strict.strictEqual((await compareParameterTypes(expected, actual)).verified, 1, `${expected} -> ${actual}`);
+    }
+    for (const [expected, actual] of [
+      ["number", "1 | 2"],
+      ['{ readonly kind: "x|y" }', "string"],
+      [String.raw`"\q"`, "string"],
+    ] as const) {
+      strict.strictEqual((await compareParameterTypes(expected, actual)).mismatched, 1, `${expected} !-> ${actual}`);
+    }
+  });
+
   await it("bounds native concurrency and rejects stale or malformed proof", async () => {
     const value = fixture();
     const base = value.candidates[0]!;

--- a/packages/mysql/src/mysql2.ts
+++ b/packages/mysql/src/mysql2.ts
@@ -48,6 +48,11 @@ export interface MySql2SchemaProviderOptions {
 
 interface MySql2VerificationField {
   readonly name?: string;
+  readonly orgName?: string;
+  readonly table?: string;
+  readonly orgTable?: string;
+  readonly db?: string;
+  readonly schema?: string;
   readonly columnType?: number;
   readonly type?: number;
   readonly columnLength?: number;
@@ -141,7 +146,7 @@ async function uri(value: MySql2Options["connectionUri"]): Promise<string> {
   return result;
 }
 
-const MYSQL_LIVE_VERIFIER_VERSION = "mysql-com-stmt-prepare-v1";
+const MYSQL_LIVE_VERIFIER_VERSION = "mysql-com-stmt-prepare-v2";
 const mysqlTypeNames = new Map<number, string>([
   [0, "decimal"],
   [1, "tinyint"],
@@ -172,17 +177,41 @@ const mysqlTypeNames = new Map<number, string>([
   [255, "geometry"],
 ]);
 
+interface MySqlCatalogColumnRow extends Record<string, unknown> {
+  readonly tableSchema: string;
+  readonly tableName: string;
+  readonly columnName: string;
+  readonly columnType: string;
+}
+
+function catalogColumnKey(schema: string, table: string, column: string): string {
+  return `${schema}\0${table}\0${column}`;
+}
+
 function verificationField(
   field: MySql2VerificationField,
   index: number,
   policy: MySqlTypePolicy,
   schema?: MySqlSchemaSnapshot,
+  catalogColumns?: ReadonlyMap<string, string>,
   exposeNullability = true,
 ) {
   const code = field.columnType ?? field.type ?? 6;
   const length = field.columnLength ?? field.length;
   const base = mysqlTypeNames.get(code) ?? `mysql-type-${code}`;
-  const databaseType = code === 1 && length === 1 ? "tinyint(1)" : base;
+  const originSchema = field.schema ?? field.db;
+  const originTable = field.orgTable ?? field.table;
+  const originColumn = field.orgName;
+  const catalogType =
+    originSchema === undefined ||
+    originSchema.length === 0 ||
+    originTable === undefined ||
+    originTable.length === 0 ||
+    originColumn === undefined ||
+    originColumn.length === 0
+      ? undefined
+      : catalogColumns?.get(catalogColumnKey(originSchema, originTable, originColumn));
+  const databaseType = catalogType ?? (code === 1 && length === 1 ? "tinyint(1)" : base);
   const flags = field.flags;
   return {
     index,
@@ -198,6 +227,7 @@ export function createMySql2LiveVerifier(options: MySql2LiveVerifierOptions): Li
   const ownsPool = options.pool === undefined;
   let poolPromise: Promise<MySql2LiveVerifierPool> | undefined;
   let serverPromise: ReturnType<LiveQueryVerifier["server"]> | undefined;
+  let catalogColumnsPromise: Promise<ReadonlyMap<string, string>> | undefined;
   const acquirePool = (): Promise<MySql2LiveVerifierPool> => {
     poolPromise ??= (async () => {
       if (options.pool !== undefined) return options.pool;
@@ -225,11 +255,24 @@ export function createMySql2LiveVerifier(options: MySql2LiveVerifierOptions): Li
     })();
     return serverPromise;
   };
+  const catalogColumns = (): Promise<ReadonlyMap<string, string>> => {
+    catalogColumnsPromise ??= (async () => {
+      const pool = await acquirePool();
+      const [rows] = await pool.query<MySqlCatalogColumnRow[]>(
+        "SELECT TABLE_SCHEMA AS tableSchema, TABLE_NAME AS tableName, COLUMN_NAME AS columnName, COLUMN_TYPE AS columnType FROM information_schema.columns WHERE TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys') ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION",
+      );
+      return new Map(
+        rows.map((row) => [catalogColumnKey(row.tableSchema, row.tableName, row.columnName), row.columnType]),
+      );
+    })();
+    return catalogColumnsPromise;
+  };
   return {
     dialect: "mysql",
     adapterVersion: MYSQL_LIVE_VERIFIER_VERSION,
     server,
     async verify(request) {
+      const catalog = await catalogColumns();
       const connection = await (await acquirePool()).getConnection();
       let statement: MySql2VerificationStatement | undefined;
       try {
@@ -241,10 +284,10 @@ export function createMySql2LiveVerifier(options: MySql2LiveVerifierOptions): Li
         const policy = options.typePolicy ?? defaultMySqlTypePolicy;
         return {
           columns: (native.columns ?? []).map((field, offset) =>
-            verificationField(field, offset + 1, policy, options.schema),
+            verificationField(field, offset + 1, policy, options.schema, catalog),
           ),
           parameters: (native.parameters ?? []).map((field, offset) =>
-            verificationField(field, offset + 1, policy, options.schema, false),
+            verificationField(field, offset + 1, policy, options.schema, catalog, false),
           ),
         };
       } finally {

--- a/packages/mysql/test/verification.test.ts
+++ b/packages/mysql/test/verification.test.ts
@@ -13,7 +13,20 @@ class VerificationPool implements MySql2LiveVerifierPool {
   released = 0;
   ended = false;
 
-  async query<Row extends Record<string, unknown>[]>(): Promise<readonly [Row, unknown]> {
+  async query<Row extends Record<string, unknown>[]>(sql: string): Promise<readonly [Row, unknown]> {
+    if (sql.includes("information_schema.columns")) {
+      return [
+        [
+          {
+            tableSchema: "app",
+            tableName: "users",
+            columnName: "status",
+            columnType: "enum('active','suspended')",
+          },
+        ] as unknown as Row,
+        [],
+      ];
+    }
     return [[{ version: "8.4.11", comment: "MySQL Community", sqlMode: "STRICT_TRANS_TABLES" }] as unknown as Row, []];
   }
 
@@ -26,6 +39,14 @@ class VerificationPool implements MySql2LiveVerifierPool {
             columns: [
               { name: "id", columnType: 8, flags: 1 },
               { name: "email", columnType: 253, flags: 0 },
+              {
+                name: "status",
+                orgName: "status",
+                orgTable: "users",
+                schema: "app",
+                columnType: 254,
+                flags: 1,
+              },
             ],
             parameters: [{ columnType: 8 }],
           },
@@ -53,15 +74,22 @@ await describe("MySQL live verification", async () => {
     strict.strictEqual(server.version, "8.4.11");
     const evidence = await verifier.verify({
       fingerprint: `sha256:${"a".repeat(64)}`,
-      sql: "SELECT id, email FROM users WHERE id = ?",
+      sql: "SELECT id, email, status FROM users WHERE id = ?",
       operation: "read",
     });
     strict.deepStrictEqual(evidence.columns, [
       { index: 1, name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
       { index: 2, name: "email", databaseType: "varchar", tsType: "string", nullable: true },
+      {
+        index: 3,
+        name: "status",
+        databaseType: "enum('active','suspended')",
+        tsType: '"active" | "suspended"',
+        nullable: false,
+      },
     ]);
     strict.deepStrictEqual(evidence.parameters, [{ index: 1, databaseType: "bigint", tsType: "bigint" }]);
-    strict.deepStrictEqual(pool.prepared, ["SELECT id, email FROM users WHERE id = ?"]);
+    strict.deepStrictEqual(pool.prepared, ["SELECT id, email, status FROM users WHERE id = ?"]);
     strict.strictEqual(pool.closed, 1);
     strict.strictEqual(pool.released, 1);
     await verifier.close();


### PR DESCRIPTION
## Summary

- preserve exact MySQL enum output evidence by resolving prepared-field origins against the live `information_schema.columns` catalog
- compare parameter types directionally so compiler-enforced literal subsets are compatible with a broader native input class without weakening result verification
- exercise enum outputs and enum parameters in the real MySQL E2E verification query
- version the native verification adapter so stale proofs cannot be reused

## Soundness

Result evidence remains strict: a native `string` output cannot prove an inferred enum union. Only an origin-backed live catalog type can do that. Parameter evidence is directional because the compiler constrains which values the application can supply; broad compiler inputs are still rejected against narrower native evidence.

## Verification

- `pnpm verify`
- `TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:mysql`
- focused compiler and MySQL Poku suites
- compiler coverage: 98.30% statements / 90.34% branches
- MySQL coverage: 96.95% statements / 90.36% branches
