### PR TITLE
fix(release): wait for exact registry versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
         run: pnpm e2e:registry
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
+          TYPED_SQL_REGISTRY_EXPECTED: workspace
           TYPED_SQL_REGISTRY_TAG: next
           TYPED_SQL_REGISTRY_PREVIEW_TAG: next
       - name: Publish stable
@@ -125,5 +126,6 @@ jobs:
         run: pnpm e2e:registry
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
+          TYPED_SQL_REGISTRY_EXPECTED: workspace
           TYPED_SQL_REGISTRY_TAG: latest
           TYPED_SQL_REGISTRY_PREVIEW_TAG: next

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -45,8 +45,12 @@ const consumerSource = process.env.TYPED_SQL_CONSUMER_SOURCE ?? "packed";
 const registryOnly = consumerSource === "registry";
 const registryTag = process.env.TYPED_SQL_REGISTRY_TAG ?? "next";
 const registryPreviewTag = process.env.TYPED_SQL_REGISTRY_PREVIEW_TAG ?? "next";
+const registryExpected = process.env.TYPED_SQL_REGISTRY_EXPECTED;
 if (!registryOnly && consumerSource !== "packed") {
   throw new Error(`TYPED_SQL_CONSUMER_SOURCE must be packed or registry, received ${consumerSource}`);
+}
+if (registryExpected !== undefined && registryExpected !== "workspace") {
+  throw new Error(`TYPED_SQL_REGISTRY_EXPECTED must be workspace when set, received ${registryExpected}`);
 }
 const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split(".").map(Number);
 const requiresExperimentalSqlite = nodeMajor === 22 && nodeMinor < 13;
@@ -142,10 +146,13 @@ await describe(`${consumerSource} real-database consumers`, async () => {
       for (const directory of packageNames) {
         const manifest = JSON.parse(await readFile(join(workspace, "packages", directory, "package.json"), "utf8")) as {
           readonly name: string;
+          readonly version: string;
         };
-        if (registryOnly)
-          dependencies[manifest.name] = previewPackageNames.has(manifest.name) ? registryPreviewTag : registryTag;
-        else {
+        if (registryOnly) {
+          const sourceTag = previewPackageNames.has(manifest.name) ? registryPreviewTag : registryTag;
+          dependencies[manifest.name] =
+            registryExpected === "workspace" && sourceTag === registryTag ? manifest.version : sourceTag;
+        } else {
           const before = new Set(await readdir(tarballs));
           await execFile("pnpm", ["--silent", "--filter", manifest.name, "pack", "--pack-destination", tarballs], {
             cwd: workspace,


### PR DESCRIPTION
## Summary

- pin post-publish registry consumers to each workspace package's exact released version
- retain dist-tag resolution for preview tooling on the stable channel
- let the existing bounded install retry wait for npm registry propagation instead of accepting a stale `next` package

## Evidence

- `pnpm exec biome check .github/workflows/release.yml e2e/packed/test/packed-real.e2e.test.ts`
- `pnpm --filter @typed-sql/e2e-packed exec tsc --project tsconfig.json --noEmit --pretty false`
- `TYPED_SQL_CONTAINER_ENGINE=podman TYPED_SQL_REGISTRY_EXPECTED=workspace TYPED_SQL_REGISTRY_TAG=next TYPED_SQL_REGISTRY_PREVIEW_TAG=next pnpm e2e:registry`

This addresses the npm propagation race observed in release run 33268961628: npm accepted and signed MySQL rc.1 but its `next` tag remained temporarily on 1.0.0-rc.0 while the other packages were already visible.