### PR TITLE
fix: align experimental companions with v2 stable

### DIFF
--- a/packages/language-server/CHANGELOG.md
+++ b/packages/language-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @typed-sql/language-server
 
+## 2.0.0-rc.2
+
+### Patch Changes
+
+- Align the experimental language server with the stable 2.0.0 packages and the compatible
+  `@typed-sql/ts-bridge@2.0.0-rc.2` companion.
+
 ## 2.0.0-rc.1
 
 ### Patch Changes

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typed-sql/language-server",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Experimental grammar-agnostic TypeScript 7 language server for typed-sql.",
   "license": "MIT",
   "author": "Lojhan",

--- a/packages/sqlite/CHANGELOG.md
+++ b/packages/sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @typed-sql/sqlite
 
+## 2.0.0-rc.2
+
+### Patch Changes
+
+- Align the experimental SQLite package with the stable 2.0.0 core, AST, and schema packages so npm
+  consumers retain one coherent set of branded query and fragment types.
+
 ## 2.0.0-rc.1
 
 ### Patch Changes

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typed-sql/sqlite",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "SQLite grammar, sound schema introspection, type resolution, and optional application-owned adapters for typed-sql.",
   "license": "MIT",
   "author": "Lojhan",

--- a/packages/ts-bridge/CHANGELOG.md
+++ b/packages/ts-bridge/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @typed-sql/ts-bridge
 
+## 2.0.0-rc.2
+
+### Patch Changes
+
+- Align the experimental TypeScript preview bridge with the stable 2.0.0 compiler, core, and schema
+  packages while keeping the bridge on the independent `next` track.
+
 ## 2.0.0-rc.1
 
 ### Patch Changes

--- a/packages/ts-bridge/package.json
+++ b/packages/ts-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typed-sql/ts-bridge",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Experimental TypeScript 7 preview semantic bridge for typed-sql query inference.",
   "license": "MIT",
   "author": "Lojhan",

--- a/scripts/publish-prerelease.d.mts
+++ b/scripts/publish-prerelease.d.mts
@@ -26,6 +26,7 @@ export interface PublishReleaseOptions {
   readonly channel?: "beta" | "rc" | "stable";
   readonly workspace?: string;
   readonly plan?: ReleasePlan;
+  readonly companionPlan?: ReleasePlan;
   readonly isPublished?: (name: string, version: string) => Promise<boolean>;
   readonly publishPackage?: (pkg: ReleasePackage, npmTag: string) => Promise<void>;
   readonly createTags?: (workspace: string) => Promise<void>;
@@ -40,6 +41,7 @@ export interface RegistryLookupOptions {
 
 export function loadPrereleasePlan(workspace?: string): Promise<PrereleasePlan>;
 export function loadReleasePlan(channel: "beta" | "rc" | "stable", workspace?: string): Promise<ReleasePlan>;
+export function loadExperimentalCompanionPlan(workspace?: string): Promise<PrereleasePlan>;
 export function isPublishedOnNpm(name: string, version: string, options?: RegistryLookupOptions): Promise<boolean>;
 export function publicationCommands(
   pkg: ReleasePackage,

--- a/scripts/publish-prerelease.mjs
+++ b/scripts/publish-prerelease.mjs
@@ -64,6 +64,29 @@ export async function loadReleasePlan(requestedChannel, workspace = defaultWorks
   return { npmTag: release.npmTag, packages };
 }
 
+export async function loadExperimentalCompanionPlan(workspace = defaultWorkspace) {
+  const release = await loadReleaseManifest(workspace);
+  if (release.channel !== "stable") {
+    throw new Error(`Experimental companion publication requires stable, found ${release.channel}:${release.npmTag}`);
+  }
+
+  const versionPattern = new RegExp(`^${escapeRegularExpression(release.series)}-(?:beta|rc)\\.\\d+$`, "u");
+  const packages = [];
+  for (const expectedName of release.packagePolicy.experimental) {
+    const directory = packageDirectory(workspace, expectedName);
+    const manifest = JSON.parse(await readFile(join(directory, "package.json"), "utf8"));
+    if (manifest.name !== expectedName) {
+      throw new Error(`${directory}/package.json declares ${manifest.name}, expected ${expectedName}`);
+    }
+    if (!versionPattern.test(manifest.version)) {
+      throw new Error(`${manifest.name}@${manifest.version} is not an experimental version for ${release.series}`);
+    }
+    packages.push({ name: manifest.name, version: manifest.version, directory });
+  }
+
+  return { npmTag: "next", packages };
+}
+
 export async function loadPrereleasePlan(workspace = defaultWorkspace) {
   return loadReleasePlan("beta", workspace);
 }
@@ -139,18 +162,25 @@ export async function publishRelease(options = {}) {
   const workspace = options.workspace ?? defaultWorkspace;
   const requestedChannel = options.channel ?? "beta";
   const plan = options.plan ?? (await loadReleasePlan(requestedChannel, workspace));
+  const companionPlan =
+    requestedChannel === "stable"
+      ? (options.companionPlan ??
+        (options.plan === undefined ? await loadExperimentalCompanionPlan(workspace) : undefined))
+      : undefined;
   const isPublished = options.isPublished ?? isPublishedOnNpm;
   const publishPackage = options.publishPackage ?? publishWithNpm;
   const createTags = options.createTags ?? createChangesetsTags;
   const log = options.log ?? console.log;
 
-  for (const pkg of plan.packages) {
-    if (await isPublished(pkg.name, pkg.version)) {
-      log(`Skipping ${pkg.name}@${pkg.version}: already published.`);
-      continue;
+  for (const currentPlan of companionPlan === undefined ? [plan] : [plan, companionPlan]) {
+    for (const pkg of currentPlan.packages) {
+      if (await isPublished(pkg.name, pkg.version)) {
+        log(`Skipping ${pkg.name}@${pkg.version}: already published.`);
+        continue;
+      }
+      log(`Publishing ${pkg.name}@${pkg.version} to npm tag ${currentPlan.npmTag}.`);
+      await publishPackage(pkg, currentPlan.npmTag);
     }
-    log(`Publishing ${pkg.name}@${pkg.version} to npm tag ${plan.npmTag}.`);
-    await publishPackage(pkg, plan.npmTag);
   }
 
   await createTags(workspace);

--- a/test/contracts/release-publisher.test.ts
+++ b/test/contracts/release-publisher.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, it, strict } from "poku";
 import {
   isPublishedOnNpm,
+  loadExperimentalCompanionPlan,
   loadPrereleasePlan,
   loadReleasePlan,
   type PrereleasePlan,
@@ -213,6 +214,57 @@ await describe("prerelease publisher", async () => {
     strict.deepStrictEqual(events, ["tags"]);
   });
 
+  await it("reconciles experimental companions on next after an immutable stable train", async () => {
+    const stablePlan = {
+      npmTag: "latest" as const,
+      packages: [{ name: "@typed-sql/core", version: "2.0.0", directory: "/packages/core" }],
+    };
+    const companionPlan: PrereleasePlan = {
+      npmTag: "next",
+      packages: [
+        { name: "@typed-sql/ts-bridge", version: "2.0.0-rc.2", directory: "/packages/ts-bridge" },
+        { name: "@typed-sql/sqlite", version: "2.0.0-rc.2", directory: "/packages/sqlite" },
+      ],
+    };
+    const published = new Set(["@typed-sql/core@2.0.0"]);
+    const firstRun: string[] = [];
+    await strict.rejects(
+      publishRelease({
+        channel: "stable",
+        plan: stablePlan,
+        companionPlan,
+        isPublished: async (name, version) => published.has(`${name}@${version}`),
+        publishPackage: async ({ name, version }, npmTag) => {
+          published.add(`${name}@${version}`);
+          firstRun.push(`publish:${name}:${npmTag}`);
+          if (name === "@typed-sql/sqlite") throw new Error("registry response lost after acceptance");
+        },
+        createTags: async () => {
+          firstRun.push("tags");
+        },
+        log: () => undefined,
+      }),
+      /registry response lost/u,
+    );
+    strict.deepStrictEqual(firstRun, ["publish:@typed-sql/ts-bridge:next", "publish:@typed-sql/sqlite:next"]);
+
+    const retry: string[] = [];
+    await publishRelease({
+      channel: "stable",
+      plan: stablePlan,
+      companionPlan,
+      isPublished: async (name, version) => published.has(`${name}@${version}`),
+      publishPackage: async ({ name }) => {
+        retry.push(`republished:${name}`);
+      },
+      createTags: async () => {
+        retry.push("tags");
+      },
+      log: () => undefined,
+    });
+    strict.deepStrictEqual(retry, ["tags"]);
+  });
+
   await it("splits mixed Changesets without losing experimental release notes", () => {
     const split = splitChangeset(
       `---\n"@typed-sql/core": patch\n"@typed-sql/ts-bridge": patch\n---\n\nDescribe the shared change.\n`,
@@ -317,6 +369,16 @@ await describe("prerelease publisher", async () => {
       strict.deepStrictEqual(await loadReleasePlan("stable", temporary), {
         npmTag: "latest",
         packages: [{ name: "@typed-sql/core", version: "1.0.0", directory: join(temporary, "packages", "core") }],
+      });
+      strict.deepStrictEqual(await loadExperimentalCompanionPlan(temporary), {
+        npmTag: "next",
+        packages: [
+          {
+            name: "@typed-sql/ts-bridge",
+            version: "1.0.0-beta.3",
+            directory: join(temporary, "packages", "ts-bridge"),
+          },
+        ],
       });
     } finally {
       await rm(temporary, { recursive: true, force: true });

--- a/test/contracts/stable-rehearsal.test.ts
+++ b/test/contracts/stable-rehearsal.test.ts
@@ -53,6 +53,9 @@ await describe("stable release rehearsal policy", async () => {
       "pnpm release:assert stable && node scripts/publish-prerelease.mjs stable",
     );
     strict.ok(!manifest.scripts["release:stable"]?.includes("changeset publish"));
+    const publisher = await readFile(resolve(workspace, "scripts/publish-prerelease.mjs"), "utf8");
+    strict.ok(publisher.includes("loadExperimentalCompanionPlan"));
+    strict.ok(publisher.includes('return { npmTag: "next", packages }'));
   });
 
   await it("publishes durable release notes with the supported and experimental boundaries", async () => {


### PR DESCRIPTION
## Summary

- publish `@typed-sql/sqlite`, `@typed-sql/ts-bridge`, and `@typed-sql/language-server` as `2.0.0-rc.2` against the stable `2.0.0` package identities
- make stable release retries reconcile experimental companions on npm `next` without promoting them to `latest`
- preserve append-only, exact-version retry behavior across both the stable and experimental tracks

## Why

The first protected stable run successfully published all ten stable `2.0.0` packages, then the registry-only consumer gate exposed that the existing experimental `rc.1` tarballs depended exactly on stable-package `rc.1` identities. Installing SQLite from `next` alongside core from `latest` therefore produced two branded query type identities and inference correctly failed closed. The aggregate `v2.0.0` release was withheld.

This PR creates compatible `rc.2` companions whose packed manifests resolve shared packages to `2.0.0`. Rerunning the same protected stable workflow will skip all already-published stable versions, publish only missing experimental companions to `next`, repeat registry acceptance, and then publish the aggregate release.

## Verification

- `pnpm quality`
- `pnpm typecheck`
- `pnpm test:contracts`
- `TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:packed`
- inspected packed companion manifests: shared stable dependencies are exactly `2.0.0`, while language-server depends on `@typed-sql/ts-bridge@2.0.0-rc.2`

Recovery for failed run #33274571699.