### PR TITLE
fix: reconcile companions before registry acceptance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,6 @@ jobs:
       - run: pnpm e2e:packed
         env:
           TYPED_SQL_CONTAINER_ENGINE: docker
-      - name: Verify registry-only release candidate
-        if: inputs.channel == 'stable'
-        run: pnpm e2e:registry
-        env:
-          TYPED_SQL_CONTAINER_ENGINE: docker
-          TYPED_SQL_REGISTRY_TAG: next
-          TYPED_SQL_REGISTRY_PREVIEW_TAG: next
       - run: pnpm audit --prod --audit-level high
       - name: Assert CodeQL release policy
         run: pnpm release:security
@@ -92,6 +85,21 @@ jobs:
       - name: Assert stable release contract
         if: inputs.channel == 'stable'
         run: pnpm release:assert stable
+      - name: Publish experimental companions
+        if: inputs.channel == 'stable'
+        run: pnpm release:companions
+      - id: stable_registry_source
+        name: Resolve stable registry source
+        if: inputs.channel == 'stable'
+        run: node scripts/resolve-stable-registry-source.mjs >> "$GITHUB_OUTPUT"
+      - name: Verify registry-only release candidate
+        if: inputs.channel == 'stable'
+        run: pnpm e2e:registry
+        env:
+          TYPED_SQL_CONTAINER_ENGINE: docker
+          TYPED_SQL_REGISTRY_EXPECTED: ${{ steps.stable_registry_source.outputs.expected }}
+          TYPED_SQL_REGISTRY_TAG: ${{ steps.stable_registry_source.outputs.tag }}
+          TYPED_SQL_REGISTRY_PREVIEW_TAG: next
       - name: Publish beta
         uses: changesets/action/publish@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         if: inputs.channel == 'beta'

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -45,7 +45,7 @@ const consumerSource = process.env.TYPED_SQL_CONSUMER_SOURCE ?? "packed";
 const registryOnly = consumerSource === "registry";
 const registryTag = process.env.TYPED_SQL_REGISTRY_TAG ?? "next";
 const registryPreviewTag = process.env.TYPED_SQL_REGISTRY_PREVIEW_TAG ?? "next";
-const registryExpected = process.env.TYPED_SQL_REGISTRY_EXPECTED;
+const registryExpected = process.env.TYPED_SQL_REGISTRY_EXPECTED || undefined;
 if (!registryOnly && consumerSource !== "packed") {
   throw new Error(`TYPED_SQL_CONSUMER_SOURCE must be packed or registry, received ${consumerSource}`);
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "release:security": "node scripts/code-scanning-policy.mjs",
     "release:beta": "pnpm release:assert beta && node scripts/publish-prerelease.mjs",
     "release:rc": "pnpm release:assert rc && node scripts/publish-prerelease.mjs rc",
+    "release:companions": "pnpm release:assert stable && node scripts/publish-prerelease.mjs companions",
     "release:stable": "pnpm release:assert stable && node scripts/publish-prerelease.mjs stable",
     "release:rehearse": "node scripts/rehearse-stable-release.mjs",
     "release:check": "pnpm verify && pnpm --filter @typed-sql/e2e-packed e2e && pnpm audit --prod --audit-level high",

--- a/scripts/publish-prerelease.d.mts
+++ b/scripts/publish-prerelease.d.mts
@@ -54,4 +54,5 @@ export function publicationCommands(
 }[];
 export function publishPrerelease(options?: PublishPrereleaseOptions): Promise<void>;
 export function publishRelease(options?: PublishReleaseOptions): Promise<void>;
+export function publishExperimentalCompanions(options?: PublishReleaseOptions): Promise<void>;
 export function main(): Promise<void>;

--- a/scripts/publish-prerelease.mjs
+++ b/scripts/publish-prerelease.mjs
@@ -190,10 +190,20 @@ export async function publishPrerelease(options = {}) {
   return publishRelease({ ...options, channel: "beta" });
 }
 
+export async function publishExperimentalCompanions(options = {}) {
+  const workspace = options.workspace ?? defaultWorkspace;
+  const plan = options.plan ?? (await loadExperimentalCompanionPlan(workspace));
+  return publishRelease({ ...options, channel: "stable", workspace, plan, companionPlan: undefined });
+}
+
 export async function main() {
   const requestedChannel = process.argv[2] ?? "beta";
+  if (requestedChannel === "companions") {
+    await publishExperimentalCompanions();
+    return;
+  }
   if (requestedChannel !== "beta" && requestedChannel !== "rc" && requestedChannel !== "stable") {
-    throw new Error("Usage: node scripts/publish-prerelease.mjs <beta|rc|stable>");
+    throw new Error("Usage: node scripts/publish-prerelease.mjs <beta|rc|stable|companions>");
   }
   await publishRelease({ channel: requestedChannel });
 }

--- a/scripts/resolve-stable-registry-source.d.mts
+++ b/scripts/resolve-stable-registry-source.d.mts
@@ -1,0 +1,17 @@
+import type { ReleasePlan } from "./publish-prerelease.mjs";
+
+export interface StableRegistrySource {
+  readonly tag: "latest" | "next";
+  readonly expected: "workspace" | undefined;
+}
+
+export interface ResolveStableRegistrySourceOptions {
+  readonly workspace?: string;
+  readonly plan?: ReleasePlan;
+  readonly isPublished?: (name: string, version: string) => Promise<boolean>;
+}
+
+export function resolveStableRegistrySource(
+  options?: ResolveStableRegistrySourceOptions,
+): Promise<StableRegistrySource>;
+export function main(): Promise<void>;

--- a/scripts/resolve-stable-registry-source.mjs
+++ b/scripts/resolve-stable-registry-source.mjs
@@ -1,0 +1,28 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isPublishedOnNpm, loadReleasePlan } from "./publish-prerelease.mjs";
+
+const defaultWorkspace = fileURLToPath(new URL("..", import.meta.url));
+
+export async function resolveStableRegistrySource(options = {}) {
+  const workspace = options.workspace ?? defaultWorkspace;
+  const plan = options.plan ?? (await loadReleasePlan("stable", workspace));
+  const isPublished = options.isPublished ?? isPublishedOnNpm;
+
+  for (const pkg of plan.packages) {
+    if (!(await isPublished(pkg.name, pkg.version))) {
+      return { tag: "next", expected: undefined };
+    }
+  }
+
+  return { tag: "latest", expected: "workspace" };
+}
+
+export async function main() {
+  const source = await resolveStableRegistrySource();
+  process.stdout.write(`tag=${source.tag}\nexpected=${source.expected ?? ""}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/test/contracts/rc-release.test.ts
+++ b/test/contracts/rc-release.test.ts
@@ -150,8 +150,15 @@ await describe("release-candidate policy", async () => {
     const verifyPublished = workflow.indexOf("name: Verify published prerelease from npm");
     strict.ok(assertRc > 0 && publishRc > assertRc && verifyPublished > publishRc);
     const verifyRegistryCandidate = workflow.indexOf("name: Verify registry-only release candidate");
+    const assertStable = workflow.indexOf("run: pnpm release:assert stable");
+    const publishCompanions = workflow.indexOf("name: Publish experimental companions");
     const publishStable = workflow.indexOf("script: pnpm release:stable");
-    strict.ok(verifyRegistryCandidate > 0 && publishStable > verifyRegistryCandidate);
+    strict.ok(
+      assertStable > 0 &&
+        publishCompanions > assertStable &&
+        verifyRegistryCandidate > publishCompanions &&
+        publishStable > verifyRegistryCandidate,
+    );
     strict.ok(workflow.includes('node scripts/detect-pending-changesets.mjs >> "$GITHUB_OUTPUT"'));
   });
 

--- a/test/contracts/registry-acceptance.test.ts
+++ b/test/contracts/registry-acceptance.test.ts
@@ -52,18 +52,31 @@ await describe("registry-only consumer acceptance", async () => {
     }
   });
 
-  await it("blocks stable publication until npm next passes", async () => {
+  await it("blocks stable publication until a coherent npm graph passes", async () => {
     const workflow = await readFile(resolve(workspace, ".github/workflows/release.yml"), "utf8");
     const gate = workflow.indexOf("Verify registry-only release candidate");
     const stableAssertion = workflow.indexOf("Assert stable release contract");
+    const companionPublish = workflow.indexOf("Publish experimental companions");
+    const sourceResolution = workflow.indexOf("Resolve stable registry source");
     const stablePublish = workflow.indexOf("script: pnpm release:stable");
 
     strict.ok(gate >= 0, "release workflow must run the registry-only gate");
-    strict.ok(workflow.slice(gate, stableAssertion).includes("TYPED_SQL_REGISTRY_TAG: next"));
-    strict.ok(workflow.slice(gate, stableAssertion).includes("TYPED_SQL_REGISTRY_PREVIEW_TAG: next"));
-    strict.ok(workflow.slice(gate, stableAssertion).includes("if: inputs.channel == 'stable'"));
-    strict.ok(gate < stableAssertion, "registry gate must precede the stable release assertion");
-    strict.ok(stableAssertion < stablePublish, "registry gate and assertion must precede stable publication");
+    strict.ok(
+      workflow
+        .slice(gate, stablePublish)
+        .includes("TYPED_SQL_REGISTRY_TAG: ${{ steps.stable_registry_source.outputs.tag }}"),
+    );
+    strict.ok(
+      workflow
+        .slice(gate, stablePublish)
+        .includes("TYPED_SQL_REGISTRY_EXPECTED: ${{ steps.stable_registry_source.outputs.expected }}"),
+    );
+    strict.ok(workflow.slice(gate, stablePublish).includes("TYPED_SQL_REGISTRY_PREVIEW_TAG: next"));
+    strict.ok(workflow.slice(gate, stablePublish).includes("if: inputs.channel == 'stable'"));
+    strict.ok(stableAssertion < companionPublish, "stable policy must pass before companion publication");
+    strict.ok(companionPublish < sourceResolution, "companion publication must precede source resolution");
+    strict.ok(sourceResolution < gate, "registry source resolution must precede registry acceptance");
+    strict.ok(gate < stablePublish, "registry acceptance must precede stable publication");
 
     const stableVerification = workflow.indexOf("Verify published stable packages from npm");
     strict.ok(workflow.slice(stableVerification).includes("TYPED_SQL_REGISTRY_TAG: latest"));

--- a/test/contracts/release-publisher.test.ts
+++ b/test/contracts/release-publisher.test.ts
@@ -9,11 +9,13 @@ import {
   loadReleasePlan,
   type PrereleasePlan,
   publicationCommands,
+  publishExperimentalCompanions,
   publishPrerelease,
   publishRelease,
 } from "../../scripts/publish-prerelease.mjs";
 import { splitChangeset } from "../../scripts/rehearse-stable-release.mjs";
 import { validateReleaseManifest } from "../../scripts/release-policy.mjs";
+import { resolveStableRegistrySource } from "../../scripts/resolve-stable-registry-source.mjs";
 
 const plan: PrereleasePlan = {
   npmTag: "next",
@@ -263,6 +265,50 @@ await describe("prerelease publisher", async () => {
       log: () => undefined,
     });
     strict.deepStrictEqual(retry, ["tags"]);
+  });
+
+  await it("publishes the companion plan independently before registry acceptance", async () => {
+    const events: string[] = [];
+    await publishExperimentalCompanions({
+      plan: {
+        npmTag: "next",
+        packages: [{ name: "@typed-sql/sqlite", version: "2.0.0-rc.2", directory: "/packages/sqlite" }],
+      },
+      isPublished: async () => false,
+      publishPackage: async ({ name }, npmTag) => {
+        events.push(`publish:${name}:${npmTag}`);
+      },
+      createTags: async () => {
+        events.push("tags");
+      },
+      log: () => undefined,
+    });
+    strict.deepStrictEqual(events, ["publish:@typed-sql/sqlite:next", "tags"]);
+  });
+
+  await it("selects one coherent stable registry graph for fresh and resumed releases", async () => {
+    const stablePlan = {
+      npmTag: "latest" as const,
+      packages: [
+        { name: "@typed-sql/core", version: "2.0.0", directory: "/packages/core" },
+        { name: "@typed-sql/schema", version: "2.0.0", directory: "/packages/schema" },
+      ],
+    };
+
+    strict.deepStrictEqual(
+      await resolveStableRegistrySource({
+        plan: stablePlan,
+        isPublished: async (name) => name === "@typed-sql/core",
+      }),
+      { tag: "next", expected: undefined },
+    );
+    strict.deepStrictEqual(
+      await resolveStableRegistrySource({
+        plan: stablePlan,
+        isPublished: async () => true,
+      }),
+      { tag: "latest", expected: "workspace" },
+    );
   });
 
   await it("splits mixed Changesets without losing experimental release notes", () => {

--- a/test/contracts/stable-rehearsal.test.ts
+++ b/test/contracts/stable-rehearsal.test.ts
@@ -52,6 +52,10 @@ await describe("stable release rehearsal policy", async () => {
       manifest.scripts["release:stable"],
       "pnpm release:assert stable && node scripts/publish-prerelease.mjs stable",
     );
+    strict.strictEqual(
+      manifest.scripts["release:companions"],
+      "pnpm release:assert stable && node scripts/publish-prerelease.mjs companions",
+    );
     strict.ok(!manifest.scripts["release:stable"]?.includes("changeset publish"));
     const publisher = await readFile(resolve(workspace, "scripts/publish-prerelease.mjs"), "utf8");
     strict.ok(publisher.includes("loadExperimentalCompanionPlan"));


### PR DESCRIPTION
## Summary

- add a protected, retry-safe `release:companions` path for the declared experimental packages
- run audit, CodeQL policy, and the stable contract before any recovery publication
- publish missing experimental companions to `next` before testing the registry-only candidate
- keep the later stable publication step idempotent: it skips existing stable and companion versions

## Why

After a partial stable publication, `latest` may already point at stable packages while `next` still contains companions built against the old RC identities. Registry acceptance must therefore happen after companion reconciliation, not before it. The previous retry was cancelled before npm mutation when this deterministic ordering issue was identified.

## Verification

- `pnpm quality`
- `pnpm typecheck`
- focused Poku release-publisher, RC workflow-order, and stable-rehearsal contracts
- PR #91 already proved the companion tarballs and full packed real-database consumers

Completes recovery from run #33274571699.