### PR TITLE
fix(ci): repair 2.1 release evidence lanes

### DIFF
--- a/.changeset/mysql-current-matrix-targets.md
+++ b/.changeset/mysql-current-matrix-targets.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/mysql": patch
+---
+
+Align the published MySQL support evidence with the exact currently available Docker Official Image patches for the 8.4 and 9.7 LTS lines and the 26.7 innovation canary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,51 +191,51 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: mysql-8.4.12-default
-            version: 8.4.12
-            image: docker.io/library/mysql:8.4.12
+          - label: mysql-8.4.11-default
+            version: 8.4.11
+            image: docker.io/library/mysql:8.4.11
             channel: stable
             mode_profile: default
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE
             experimental: false
-          - label: mysql-8.4.12-lexical
-            version: 8.4.12
-            image: docker.io/library/mysql:8.4.12
+          - label: mysql-8.4.11-lexical
+            version: 8.4.11
+            image: docker.io/library/mysql:8.4.11
             channel: stable
             mode_profile: lexical
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE,ANSI_QUOTES,NO_BACKSLASH_ESCAPES,PIPES_AS_CONCAT
             experimental: false
-          - label: mysql-8.4.12-numeric
-            version: 8.4.12
-            image: docker.io/library/mysql:8.4.12
+          - label: mysql-8.4.11-numeric
+            version: 8.4.11
+            image: docker.io/library/mysql:8.4.11
             channel: stable
             mode_profile: numeric
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE,NO_UNSIGNED_SUBTRACTION
             experimental: false
-          - label: mysql-9.7.3-default
-            version: 9.7.3
-            image: docker.io/library/mysql:9.7.3
+          - label: mysql-9.7.2-default
+            version: 9.7.2
+            image: docker.io/library/mysql:9.7.2
             channel: stable
             mode_profile: default
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE
             experimental: false
-          - label: mysql-9.7.3-lexical
-            version: 9.7.3
-            image: docker.io/library/mysql:9.7.3
+          - label: mysql-9.7.2-lexical
+            version: 9.7.2
+            image: docker.io/library/mysql:9.7.2
             channel: stable
             mode_profile: lexical
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE,ANSI_QUOTES,NO_BACKSLASH_ESCAPES,PIPES_AS_CONCAT
             experimental: false
-          - label: mysql-9.7.3-numeric
-            version: 9.7.3
-            image: docker.io/library/mysql:9.7.3
+          - label: mysql-9.7.2-numeric
+            version: 9.7.2
+            image: docker.io/library/mysql:9.7.2
             channel: stable
             mode_profile: numeric
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE,NO_UNSIGNED_SUBTRACTION
             experimental: false
-          - label: mysql-26.7.1-canary
-            version: 26.7.1
-            image: docker.io/library/mysql:26.7.1
+          - label: mysql-26.7.0-canary
+            version: 26.7.0
+            image: docker.io/library/mysql:26.7.0
             channel: canary
             mode_profile: default
             sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,IGNORE_SPACE
@@ -316,7 +316,7 @@ jobs:
           version: 10.32.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.11
+          node-version: 22.13
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm e2e:packed
@@ -387,6 +387,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
       - run: pnpm --filter @typed-sql/sqlite test
       - run: >-
           node scripts/sqlite-matrix-probe.mjs
@@ -460,13 +461,13 @@ jobs:
           version: 10.32.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.11
+          node-version: 22.13
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm --filter @typed-sql/e2e-postgres generate:snapshot
       - run: pnpm --filter @typed-sql/e2e-mysql generate:snapshot
-      - run: poku packages/language-server/test/language-server.test.ts --reporter=compact --enforce
+      - run: pnpm exec poku packages/language-server/test/language-server.test.ts --reporter=compact --enforce
       - run: pnpm --filter ./packages/vscode package:vsix
       - run: rustup target add wasm32-wasip2
       - run: cargo test --manifest-path editors/zed/Cargo.toml

--- a/docs/dialects/mysql.md
+++ b/docs/dialects/mysql.md
@@ -54,7 +54,7 @@ Division of exact values is nullable because division by zero returns `NULL`.
 ## Version support and differential evidence
 
 The stable contract is patch-compatible within the MySQL 8.4 and 9.7 LTS series. Protected CI runs
-the exact 8.4.12 and 9.7.3 images. Each LTS patch runs a default profile, a lexical profile with
+the exact 8.4.11 and 9.7.2 images. Each LTS patch runs a default profile, a lexical profile with
 `ANSI_QUOTES`, `NO_BACKSLASH_ESCAPES`, and `PIPES_AS_CONCAT`, and a numeric profile with
 `NO_UNSIGNED_SUBTRACTION`. All six LTS jobs are release-blocking.
 
@@ -64,7 +64,7 @@ normalized set before parsing. If a profile adds a mode whose lexical or semanti
 modeled, supported capabilities resolve conservatively and query analysis fails closed with
 `TSQ407`; typed-sql does not assume the extra mode is harmless.
 
-MySQL 26.7.1 runs separately with `versionPolicy: "canary"`. It reports innovation-line catalog,
+MySQL 26.7.0 runs separately with `versionPolicy: "canary"`. It reports innovation-line catalog,
 keyword, collation, syntax, protocol, decoding, and introspection differences against the 9.7
 default profile, but it does not contribute to the stable score. A canary failure therefore exposes
 future work without changing the published LTS support boundary.

--- a/docs/guides/live-verification.md
+++ b/docs/guides/live-verification.md
@@ -105,7 +105,7 @@ Human output points to the source location and prints compiler evidence beside d
 Use the same schema initialization as the application and a disposable database account with only
 the permissions needed to resolve referenced objects. The repository runs the complete PostgreSQL
 flow against exact 14.24, 15.19, 16.15, 17.11, and 18.6 images and reports 19beta3 separately as a
-non-blocking canary. The MySQL flow runs exact 8.4.12 and 9.7.3 LTS patches under default, lexical,
-and unsigned-arithmetic mode profiles, then reports 26.7.1 separately as an innovation canary.
+non-blocking canary. The MySQL flow runs exact 8.4.11 and 9.7.2 LTS patches under default, lexical,
+and unsigned-arithmetic mode profiles, then reports 26.7.0 separately as an innovation canary.
 These jobs generate snapshots and manifests, run live verification, verify the offline cache, and
 assert that no statement values or mutations are sent.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -43,7 +43,7 @@ The report excludes setting values, schema expressions, source text, credentials
 | --- | --- | --- |
 | PostgreSQL | PostgreSQL 14–18 grammar and catalog provider; patch-compatible within each major | PostgreSQL 14.24, 15.19, 16.15, 17.11, and 18.6; PostgreSQL 19beta3 as a non-blocking canary |
 | `pg` | Application-owned driver loaded by `@typed-sql/postgres/pg` | `pg` 8.23.0 |
-| MySQL | MySQL 8.4 and 9.7 LTS grammar and catalog provider; patch-compatible within each LTS series | MySQL 8.4.12 and 9.7.3 across default, lexical-mode, and unsigned-arithmetic profiles; MySQL 26.7.1 as a non-blocking innovation canary |
+| MySQL | MySQL 8.4 and 9.7 LTS grammar and catalog provider; patch-compatible within each LTS series | MySQL 8.4.11 and 9.7.2 across default, lexical-mode, and unsigned-arithmetic profiles; MySQL 26.7.0 as a non-blocking innovation canary |
 | `mysql2` | Application-owned driver loaded by `@typed-sql/mysql/mysql2` | `mysql2` 3.24.1 |
 | SQLite | SQLite 3.39.0–3.53.4 grammar and PRAGMA catalog provider; unknown newer libraries are conservative | Source-built SQLite 3.39.0 and 3.53.4, every supported Node line's bundled library, and a non-blocking 3.54.0 canary |
 | `node:sqlite` | Built-in adapter loaded by `@typed-sql/sqlite/node-sqlite`; Node 22.13+, 24, and 26 | Node 22.13.0 and current Node 22, 24, and 26 lines |

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -13,8 +13,8 @@ pnpm add -D @typed-sql/cli typescript@7.0.2
 of the grammar.
 
 The stable grammar contract covers the MySQL 8.4 and 9.7 LTS series. Protected differential jobs
-exercise exact 8.4.12 and 9.7.3 images under default, lexical, and unsigned-arithmetic SQL-mode
-profiles. MySQL 26.7.1 is reported separately as a non-blocking innovation canary and requires
+exercise exact 8.4.11 and 9.7.2 images under default, lexical, and unsigned-arithmetic SQL-mode
+profiles. MySQL 26.7.0 is reported separately as a non-blocking innovation canary and requires
 `mysql({ versionPolicy: "canary" })`.
 These are the supported SQL-mode profiles; custom profiles containing an unmodeled mode fail closed.
 

--- a/packages/mysql/src/support.ts
+++ b/packages/mysql/src/support.ts
@@ -15,10 +15,10 @@ export type MySqlVersionSupport =
  */
 export const MYSQL_SUPPORT_POLICY = Object.freeze({
   stable: Object.freeze([
-    Object.freeze({ series: "8.4", matrixVersion: "8.4.12" }),
-    Object.freeze({ series: "9.7", matrixVersion: "9.7.3" }),
+    Object.freeze({ series: "8.4", matrixVersion: "8.4.11" }),
+    Object.freeze({ series: "9.7", matrixVersion: "9.7.2" }),
   ] as const),
-  canary: Object.freeze({ series: "26.7", matrixVersion: "26.7.1", channel: "innovation" as const }),
+  canary: Object.freeze({ series: "26.7", matrixVersion: "26.7.0", channel: "innovation" as const }),
   patchCompatibility: "within-lts-series",
   upstreamPolicy: "supported-lts-series",
   innovationPolicy: "canary-only",

--- a/packages/mysql/test/catalog.test.ts
+++ b/packages/mysql/test/catalog.test.ts
@@ -59,13 +59,13 @@ await describe("MySQL versioned core catalogs", async () => {
   });
 
   await it("selects VECTOR type and routine evidence only for 9.7 and later", () => {
-    strict.strictEqual(mySqlCatalogType("vector", schema("8.4.12")), undefined);
-    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("8.4.12")), undefined);
-    strict.strictEqual(mySqlCatalogType("vector(128)", schema("9.7.3"))?.category, "vector");
-    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("9.7.3"))?.result, "integer");
-    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("26.7.1"))?.result, "integer");
-    strict.strictEqual(mySqlCatalogHasRoutineInAnotherSeries("vector_dim", schema("8.4.12")), true);
-    strict.strictEqual(mySqlCatalogHasRoutineInAnotherSeries("made_up", schema("8.4.12")), false);
+    strict.strictEqual(mySqlCatalogType("vector", schema("8.4.11")), undefined);
+    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("8.4.11")), undefined);
+    strict.strictEqual(mySqlCatalogType("vector(128)", schema("9.7.2"))?.category, "vector");
+    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("9.7.2"))?.result, "integer");
+    strict.strictEqual(mySqlCatalogRoutine("vector_dim", schema("26.7.0"))?.result, "integer");
+    strict.strictEqual(mySqlCatalogHasRoutineInAnotherSeries("vector_dim", schema("8.4.11")), true);
+    strict.strictEqual(mySqlCatalogHasRoutineInAnotherSeries("made_up", schema("8.4.11")), false);
   });
 
   await it("fails closed when explicit server evidence has no supported catalog", () => {

--- a/packages/mysql/test/query-structure.test.ts
+++ b/packages/mysql/test/query-structure.test.ts
@@ -29,7 +29,7 @@ const schema = {
 } as const satisfies SchemaSnapshot;
 
 function withMode(sqlMode: string): SchemaSnapshot {
-  return { ...schema, server: mySqlServerEvidence("8.4.12", sqlMode) };
+  return { ...schema, server: mySqlServerEvidence("8.4.11", sqlMode) };
 }
 
 await describe("MySQL query structure", async () => {
@@ -337,7 +337,7 @@ await describe("MySQL query structure", async () => {
     const users = upgraded.relations.users!;
     const structural = {
       ...upgraded,
-      server: mySqlServerEvidence("8.4.12", "ONLY_FULL_GROUP_BY"),
+      server: mySqlServerEvidence("8.4.11", "ONLY_FULL_GROUP_BY"),
       relations: {
         ...upgraded.relations,
         users: {

--- a/packages/mysql/test/support.test.ts
+++ b/packages/mysql/test/support.test.ts
@@ -5,12 +5,12 @@ import { MYSQL_SUPPORT_POLICY, mySqlVersionSupport, parseMySqlVersion } from "..
 await describe("MySQL support policy", async () => {
   await it("publishes immutable LTS and innovation targets", () => {
     strict.deepStrictEqual(MYSQL_SUPPORT_POLICY.stable, [
-      { series: "8.4", matrixVersion: "8.4.12" },
-      { series: "9.7", matrixVersion: "9.7.3" },
+      { series: "8.4", matrixVersion: "8.4.11" },
+      { series: "9.7", matrixVersion: "9.7.2" },
     ]);
     strict.deepStrictEqual(MYSQL_SUPPORT_POLICY.canary, {
       series: "26.7",
-      matrixVersion: "26.7.1",
+      matrixVersion: "26.7.0",
       channel: "innovation",
     });
     strict.strictEqual(MYSQL_SUPPORT_POLICY.patchCompatibility, "within-lts-series");
@@ -30,14 +30,14 @@ await describe("MySQL support policy", async () => {
   });
 
   await it("classifies exact versions without promoting innovation releases implicitly", () => {
-    strict.deepStrictEqual(parseMySqlVersion("9.7.3-commercial"), [9, 7, 3]);
+    strict.deepStrictEqual(parseMySqlVersion("9.7.2-commercial"), [9, 7, 2]);
     strict.strictEqual(parseMySqlVersion("9.7"), undefined);
     strict.strictEqual(mySqlVersionSupport("8.4.0"), "supported");
     strict.strictEqual(mySqlVersionSupport("9.7.99"), "supported");
     strict.strictEqual(mySqlVersionSupport("8.0.44"), "below-supported");
     strict.strictEqual(mySqlVersionSupport("9.6.0"), "unsupported-line");
-    strict.strictEqual(mySqlVersionSupport("26.7.1"), "unsupported-line");
-    strict.strictEqual(mySqlVersionSupport("26.7.1", "canary"), "canary");
+    strict.strictEqual(mySqlVersionSupport("26.7.0"), "unsupported-line");
+    strict.strictEqual(mySqlVersionSupport("26.7.0", "canary"), "canary");
     strict.strictEqual(mySqlVersionSupport("26.7.2-rc1"), "prerelease");
     strict.strictEqual(mySqlVersionSupport("26.7.2-rc1", "canary"), "canary");
     strict.strictEqual(mySqlVersionSupport("27.7.0"), "newer-than-tested");
@@ -45,7 +45,7 @@ await describe("MySQL support policy", async () => {
   });
 
   await it("normalizes semantic settings and rejects unidentified MySQL-compatible products", () => {
-    const evidence = mySqlServerEvidence("9.7.3", {
+    const evidence = mySqlServerEvidence("9.7.2", {
       versionComment: "MySQL Enterprise Server - Commercial",
       sqlMode: "strict_trans_tables,ANSI_QUOTES,strict_trans_tables",
       characterSetServer: " UTF8MB4 ",
@@ -58,8 +58,8 @@ await describe("MySQL support policy", async () => {
     });
     strict.deepStrictEqual(evidence, {
       product: "mysql",
-      version: "9.7.3",
-      versionKey: "9.7.3",
+      version: "9.7.2",
+      versionKey: "9.7.2",
       features: [],
       settings: {
         characterSetConnection: "utf8mb4",
@@ -75,28 +75,28 @@ await describe("MySQL support policy", async () => {
     });
     assertMySqlServerEvidence(evidence);
     strict.strictEqual(
-      mySqlServerEvidence("8.4.12", { versionComment: "Percona Server", sqlMode: "" }).product,
+      mySqlServerEvidence("8.4.11", { versionComment: "Percona Server", sqlMode: "" }).product,
       "mysql-compatible",
     );
     strict.strictEqual(
-      mySqlServerEvidence("8.4.12", { versionComment: "Source distribution", sqlMode: "" }).settings.edition,
+      mySqlServerEvidence("8.4.11", { versionComment: "Source distribution", sqlMode: "" }).settings.edition,
       "source",
     );
     strict.strictEqual(
-      mySqlServerEvidence("8.4.12", { versionComment: "MySQL Commercial", sqlMode: "" }).settings.edition,
+      mySqlServerEvidence("8.4.11", { versionComment: "MySQL Commercial", sqlMode: "" }).settings.edition,
       "commercial",
     );
     strict.strictEqual(
-      mySqlServerEvidence("8.4.12", { versionComment: "MySQL custom build", sqlMode: "" }).settings.edition,
+      mySqlServerEvidence("8.4.11", { versionComment: "MySQL custom build", sqlMode: "" }).settings.edition,
       "unknown",
     );
-    strict.throws(() => mySqlServerEvidence("8.4.12", { characterSetServer: "utf8mb4; DROP" }), /safe identifier/u);
-    strict.throws(() => mySqlServerEvidence("8.4.12", { timeZone: "\u0000" }), /time-zone/u);
-    strict.throws(() => mySqlServerEvidence("8.4.12", { lowerCaseTableNames: 3 }), /must be 0, 1, or 2/u);
+    strict.throws(() => mySqlServerEvidence("8.4.11", { characterSetServer: "utf8mb4; DROP" }), /safe identifier/u);
+    strict.throws(() => mySqlServerEvidence("8.4.11", { timeZone: "\u0000" }), /time-zone/u);
+    strict.throws(() => mySqlServerEvidence("8.4.11", { lowerCaseTableNames: 3 }), /must be 0, 1, or 2/u);
   });
 
   await it("validates allowlisted evidence independently of snapshot parsing", () => {
-    const base = mySqlServerEvidence("8.4.12", "");
+    const base = mySqlServerEvidence("8.4.11", "");
     for (const [settings, pattern] of [
       [{ sqlMode: "strict_trans_tables" }, /normalized mode/u],
       [{ characterSetServer: "UTF8MB4" }, /normalized identifier/u],

--- a/packages/mysql/test/type-resolution.test.ts
+++ b/packages/mysql/test/type-resolution.test.ts
@@ -41,7 +41,7 @@ function evidence(version: string, sqlMode = "STRICT_TRANS_TABLES") {
   });
 }
 
-function schema(version = "8.4.12", sqlMode = "STRICT_TRANS_TABLES"): SchemaSnapshot {
+function schema(version = "8.4.11", sqlMode = "STRICT_TRANS_TABLES"): SchemaSnapshot {
   const upgraded = upgradeSchemaSnapshotV1(legacy);
   const relation = upgraded.relations.values_table!;
   return {
@@ -160,18 +160,18 @@ await describe("MySQL catalog-backed type resolution", async () => {
 
     const signedSubtraction = resolveMySqlStatement(
       parseStatement("SELECT unsigned_id - signed_id AS value FROM values_table"),
-      schema("8.4.12", "NO_UNSIGNED_SUBTRACTION,STRICT_TRANS_TABLES"),
+      schema("8.4.11", "NO_UNSIGNED_SUBTRACTION,STRICT_TRANS_TABLES"),
     );
     strict.strictEqual(signedSubtraction.columns[0]?.databaseType, "bigint");
     strict.strictEqual(signedSubtraction.columns[0]?.unsigned, false);
   });
 
   await it("fails closed on version-gated built-ins", () => {
-    const unsupported = resolveMySqlStatement(parseStatement("SELECT VECTOR_DIM(?) AS dimensions"), schema("8.4.12"));
+    const unsupported = resolveMySqlStatement(parseStatement("SELECT VECTOR_DIM(?) AS dimensions"), schema("8.4.11"));
     strict.ok(unsupported.diagnostics.some(({ code }) => code === "TSQ403"));
     strict.strictEqual(unsupported.columns[0]?.tsType, "unknown");
 
-    const supported = resolveMySqlStatement(parseStatement("SELECT VECTOR_DIM(?) AS dimensions"), schema("9.7.3"));
+    const supported = resolveMySqlStatement(parseStatement("SELECT VECTOR_DIM(?) AS dimensions"), schema("9.7.2"));
     strict.deepStrictEqual(supported.diagnostics, []);
     strict.strictEqual(supported.columns[0]?.tsType, "number");
     strict.strictEqual(supported.columns[0]?.databaseType, "bigint");
@@ -188,7 +188,7 @@ await describe("MySQL catalog-backed type resolution", async () => {
                STRING_TO_VECTOR('[1, 2]') AS vector_value
         FROM values_table
       `),
-      schema("9.7.3"),
+      schema("9.7.2"),
     );
     strict.deepStrictEqual(result.diagnostics, []);
     strict.deepStrictEqual(

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -45,4 +45,26 @@ await describe("CI evidence lanes", async () => {
     for (const sensitive of ["process.env.DATABASE", "process.env.PG", "process.env.MYSQL", "process.env.TOKEN"])
       strict.ok(!writer.includes(sensitive));
   });
+
+  await it("prepares clean-checkout runtime lanes before executing package entrypoints", async () => {
+    const workflow = await readFile(join(workspace, ".github/workflows/ci.yml"), "utf8");
+    const packed = workflow.slice(workflow.indexOf("  packed-real-databases:"), workflow.indexOf("  examples-e2e:"));
+    const sqlite = workflow.slice(
+      workflow.indexOf("  sqlite-node-matrix:"),
+      workflow.indexOf("  sqlite-language-matrix:"),
+    );
+    const editor = workflow.slice(
+      workflow.indexOf("  editor-artifacts:"),
+      workflow.indexOf("  pull-request-distribution:"),
+    );
+
+    strict.ok(packed.includes("node-version: 22.13"), "packed SQLite acceptance must use its minimum Node version");
+    strict.ok(sqlite.includes("pnpm typecheck\n      - run: pnpm --filter @typed-sql/sqlite test"));
+    strict.ok(
+      editor.includes(
+        "pnpm exec poku packages/language-server/test/language-server.test.ts --reporter=compact --enforce",
+      ),
+      "editor artifact tests must resolve the workspace-local Poku executable",
+    );
+  });
 });

--- a/test/contracts/mysql-completeness.test.ts
+++ b/test/contracts/mysql-completeness.test.ts
@@ -60,11 +60,11 @@ await describe("MySQL completeness review", async () => {
     const compatibility = await readFile(join(workspace, "docs", "reference", "compatibility.md"), "utf8");
     const readme = await readFile(join(workspace, "packages", "mysql", "README.md"), "utf8");
 
-    for (const value of ["8.4.12", "9.7.3", "26.7.1", "TSQ407", "MariaDB", "typed-sql compat", "onWarning"])
+    for (const value of ["8.4.11", "9.7.2", "26.7.0", "TSQ407", "MariaDB", "typed-sql compat", "onWarning"])
       strict.ok(guide.includes(value), `MySQL guide is missing ${value}`);
     for (const value of ["zero-date", "fractional precision", "spatial types", "compatibilitySnapshot"])
       strict.ok(mappings.includes(value), `MySQL type mapping is missing ${value}`);
-    for (const value of ["8.4 and 9.7 LTS", "26.7.1", "non-blocking innovation canary"])
+    for (const value of ["8.4 and 9.7 LTS", "26.7.0", "non-blocking innovation canary"])
       strict.ok(compatibility.includes(value), `compatibility reference is missing ${value}`);
     for (const value of ["8.4 and 9.7 LTS", "versionPolicy", "SQL-mode profiles"])
       strict.ok(readme.includes(value), `MySQL README is missing ${value}`);

--- a/test/contracts/mysql-matrix.test.ts
+++ b/test/contracts/mysql-matrix.test.ts
@@ -11,16 +11,16 @@ const workspace = process.cwd();
 await describe("MySQL support matrix", async () => {
   await it("runs every LTS mode profile and keeps the innovation line non-blocking", async () => {
     const workflow = await readFile(join(workspace, ".github", "workflows", "ci.yml"), "utf8");
-    for (const version of ["8.4.12", "9.7.3", "26.7.1"])
+    for (const version of ["8.4.11", "9.7.2", "26.7.0"])
       strict.ok(workflow.includes(`docker.io/library/mysql:${version}`), `workflow is missing MySQL ${version}`);
     for (const label of [
-      "mysql-8.4.12-default",
-      "mysql-8.4.12-lexical",
-      "mysql-8.4.12-numeric",
-      "mysql-9.7.3-default",
-      "mysql-9.7.3-lexical",
-      "mysql-9.7.3-numeric",
-      "mysql-26.7.1-canary",
+      "mysql-8.4.11-default",
+      "mysql-8.4.11-lexical",
+      "mysql-8.4.11-numeric",
+      "mysql-9.7.2-default",
+      "mysql-9.7.2-lexical",
+      "mysql-9.7.2-numeric",
+      "mysql-26.7.0-canary",
     ])
       strict.ok(workflow.includes(label), `workflow is missing ${label}`);
     for (const mode of [
@@ -40,7 +40,7 @@ await describe("MySQL support matrix", async () => {
     strict.ok(container.includes("FROM ${MYSQL_BASE_IMAGE}"));
 
     const support = await readFile(join(workspace, "packages", "mysql", "src", "support.ts"), "utf8");
-    for (const version of ["8.4.12", "9.7.3", "26.7.1"]) strict.ok(support.includes(`matrixVersion: "${version}"`));
+    for (const version of ["8.4.11", "9.7.2", "26.7.0"]) strict.ok(support.includes(`matrixVersion: "${version}"`));
   });
 
   await it("publishes the stable boundary, mode profiles, and separate canary score", async () => {
@@ -48,7 +48,7 @@ await describe("MySQL support matrix", async () => {
     const compatibility = await readFile(join(workspace, "docs", "reference", "compatibility.md"), "utf8");
     const verification = await readFile(join(workspace, "docs", "guides", "live-verification.md"), "utf8");
     const readme = await readFile(join(workspace, "packages", "mysql", "README.md"), "utf8");
-    for (const version of ["8.4.12", "9.7.3", "26.7.1"]) {
+    for (const version of ["8.4.11", "9.7.2", "26.7.0"]) {
       strict.ok(dialect.includes(version), `MySQL guide is missing ${version}`);
       strict.ok(compatibility.includes(version), `compatibility reference is missing ${version}`);
       strict.ok(verification.includes(version), `live verification guide is missing ${version}`);
@@ -96,15 +96,15 @@ await describe("MySQL support matrix", async () => {
         summary: { pass: 1, fail: 0 },
       });
       for (const [series, version] of [
-        ["8.4", "8.4.12"],
-        ["9.7", "9.7.3"],
+        ["8.4", "8.4.11"],
+        ["9.7", "9.7.2"],
       ] as const)
         for (const profile of ["default", "lexical", "numeric"])
           await writeFile(
             join(directory, `${series}-${profile}.json`),
             JSON.stringify(artifact(series, version, profile, "stable")),
           );
-      await writeFile(join(directory, "canary.json"), JSON.stringify(artifact("26.7", "26.7.1", "default", "canary")));
+      await writeFile(join(directory, "canary.json"), JSON.stringify(artifact("26.7", "26.7.0", "default", "canary")));
 
       const output = join(directory, "review.json");
       await execute(


### PR DESCRIPTION
## Summary

- use currently published MySQL Docker Official Image patches in the release matrix and support metadata
- build workspace dependencies before isolated SQLite package tests
- run packed and editor verification on SQLite's Node 22.13 minimum
- resolve Poku through pnpm in the editor artifact lane
- add contract coverage for clean-checkout lane prerequisites

## Verification

- pnpm quality
- pnpm test
- pnpm docs:check
- clean build via pnpm clean, pnpm typecheck, and pnpm --filter @typed-sql/sqlite test
- focused language-server and MySQL matrix contracts
- docker manifest inspect mysql:8.4.11 mysql:9.7.2 mysql:26.7.0

The local planning/ directory is intentionally untracked and is not included in this PR.