### PR TITLE
fix: unblock 2.1 database release evidence

### DIFF
--- a/.changeset/mysql-current-matrix-targets.md
+++ b/.changeset/mysql-current-matrix-targets.md
@@ -2,4 +2,4 @@
 "@typed-sql/mysql": patch
 ---
 
-Align the published MySQL support evidence with the exact currently available Docker Official Image patches for the 8.4 and 9.7 LTS lines and the 26.7 innovation canary.
+Align the published MySQL support evidence with the exact currently available Docker Official Image patches for the 8.4 and 9.7 LTS lines and the 26.7 innovation canary. Keep typed bulk loading portable across modeled SQL modes by expressing field, escape, and line delimiters as hexadecimal SQL literals instead of mode-sensitive escaped strings.

--- a/.changeset/postgres-v1-domain-operators.md
+++ b/.changeset/postgres-v1-domain-operators.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/postgres": patch
+---
+
+Preserve domain evidence from legacy snapshots and schema-qualified v2 introspection during PostgreSQL operator resolution so parameters compared with domain-typed columns retain their inferred base type.

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -181,7 +181,6 @@ await describe(`${consumerSource} real-database consumers`, async () => {
             typescript: `link:${join(workspace, "node_modules", "typescript")}`,
             "@types/node": `link:${join(workspace, "node_modules", "@types", "node")}`,
             "@types/pg": `link:${join(workspace, "node_modules", "@types", "pg")}`,
-            "@typed-sql/typescript-preview": `link:${join(workspace, "packages", "ts-bridge", "node_modules", "@typed-sql", "typescript-preview")}`,
             "vscode-jsonrpc": `link:${join(workspace, "packages", "language-server", "node_modules", "vscode-jsonrpc")}`,
             "vscode-languageserver": `link:${join(workspace, "packages", "language-server", "node_modules", "vscode-languageserver")}`,
             "vscode-languageserver-textdocument": `link:${join(workspace, "packages", "language-server", "node_modules", "vscode-languageserver-textdocument")}`,

--- a/packages/mysql/src/bulk.ts
+++ b/packages/mysql/src/bulk.ts
@@ -123,7 +123,7 @@ function loadDataStatement(text: string, parameterCount: number): string {
   const quote = mysqlRenderer.quoteIdentifier;
   const table = `${statement.table.schema === undefined ? "" : `${quote(statement.table.schema.name)}.`}${quote(statement.table.name.name)}`;
   const columns = statement.columns.map(({ name }) => quote(name)).join(", ");
-  return `LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE ${table} CHARACTER SET utf8mb4 FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (${columns})`;
+  return `LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE ${table} CHARACTER SET utf8mb4 FIELDS TERMINATED BY X'09' ESCAPED BY X'5C' LINES TERMINATED BY X'0A' (${columns})`;
 }
 
 function cancelled(signal: AbortSignal | undefined): void {

--- a/packages/mysql/test/bulk.test.ts
+++ b/packages/mysql/test/bulk.test.ts
@@ -93,7 +93,7 @@ await describe("MySQL LOAD DATA capability", async () => {
       { id: 2n, email: "two\texample.com", note: "line\nbreak\\tail" },
     ]);
     strict.deepStrictEqual(statements, [
-      "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE `app`.`account` CHARACTER SET utf8mb4 FIELDS TERMINATED BY '\\t' ESCAPED BY '\\\\' LINES TERMINATED BY '\\n' (`id`, `email`, `note`)",
+      "LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE `app`.`account` CHARACTER SET utf8mb4 FIELDS TERMINATED BY X'09' ESCAPED BY X'5C' LINES TERMINATED BY X'0A' (`id`, `email`, `note`)",
     ]);
     const encoded = new TextDecoder().decode(Buffer.concat(chunks));
     strict.strictEqual(encoded, "1\tone@example.com\t\\N\n2\ttwo\\texample.com\tline\\nbreak\\\\tail\n");

--- a/packages/postgres/src/type-resolution.ts
+++ b/packages/postgres/src/type-resolution.ts
@@ -1,4 +1,9 @@
-import type { SchemaSnapshot, TypeSnapshot } from "@typed-sql/schema";
+import {
+  type SchemaSnapshot,
+  type SchemaSnapshotV2,
+  type TypeSnapshot,
+  upgradeSchemaSnapshotV1,
+} from "@typed-sql/schema";
 import {
   type PostgresCastContext,
   type PostgresTypeCategory,
@@ -55,6 +60,7 @@ const numericOperatorTypes = new Set(["smallint", "integer", "bigint", "numeric"
 // the other snapshot-indexed resolver caches instead of rebuilding it for every expression.
 const operatorCandidatesBySchema = new WeakMap<SchemaSnapshot, Map<string, readonly PostgresCandidate<string>[]>>();
 const defaultOperatorCandidates = new Map<string, readonly PostgresCandidate<string>[]>();
+const upgradedSchemas = new WeakMap<SchemaSnapshot, SchemaSnapshotV2>();
 
 export interface PostgresCandidate<Value> {
   readonly value: Value;
@@ -104,17 +110,27 @@ function normalize(value: string): string {
 }
 
 function schemaTypes(schema?: SchemaSnapshot): readonly TypeSnapshot[] {
-  return schema?.formatVersion === 2 ? Object.values(schema.types) : [];
+  if (schema === undefined) return [];
+  if (schema.formatVersion === 2) return Object.values(schema.types);
+  const cached = upgradedSchemas.get(schema);
+  if (cached !== undefined) return Object.values(cached.types);
+  const upgraded = upgradeSchemaSnapshotV1(schema);
+  upgradedSchemas.set(schema, upgraded);
+  return Object.values(upgraded.types);
 }
 
 function typeEvidence(databaseType: string, schema?: SchemaSnapshot): TypeSnapshot | undefined {
   const normalized = normalize(databaseType);
-  return schemaTypes(schema).find(
+  const types = schemaTypes(schema);
+  const exact = types.find(
     (type) =>
       normalize(type.databaseType) === normalized ||
       normalize(type.identity) === normalized ||
       normalize(`${type.schema === undefined ? "" : `${type.schema}.`}${type.name}`) === normalized,
   );
+  if (exact !== undefined) return exact;
+  const unqualified = types.filter((type) => normalize(type.name) === normalized);
+  return unqualified.length === 1 ? unqualified[0] : undefined;
 }
 
 /** Canonical PostgreSQL type identity for overload and coercion decisions. */

--- a/packages/postgres/test/resolver-matrix.test.ts
+++ b/packages/postgres/test/resolver-matrix.test.ts
@@ -60,11 +60,38 @@ const schema = {
   },
 } as const satisfies SchemaSnapshot;
 
+const legacyDomainSchema = {
+  formatVersion: 1,
+  dialect: "postgres",
+  tables: {
+    users: {
+      name: "users",
+      columns: {
+        email: { name: "email", databaseType: "email_address", tsType: "string", nullable: false },
+      },
+    },
+  },
+  domains: {
+    email_address: { name: "email_address", databaseType: "text", tsType: "string", nullable: false },
+  },
+} as const satisfies SchemaSnapshot;
+
 function codes(sql: string): readonly string[] {
   return resolveStatement(parseStatement(sql), schema).diagnostics.map((diagnostic) => diagnostic.code);
 }
 
 await describe("PostgreSQL resolver branch matrix", async () => {
+  await it("infers unknown parameters compared with v1 domain columns", () => {
+    const result = resolveSelect(parseSelect("SELECT email <> $1 AS differs FROM users"), legacyDomainSchema);
+    strict.deepStrictEqual(result.diagnostics, []);
+    strict.deepStrictEqual(result.parameters, [{ index: 1, databaseType: "text", tsType: "string", nullable: false }]);
+    strict.strictEqual(result.columns.length, 1);
+    strict.strictEqual(result.columns[0]?.name, "differs");
+    strict.strictEqual(result.columns[0]?.tsType, "boolean");
+    strict.strictEqual(result.columns[0]?.nullable, false);
+    strict.strictEqual(result.columns[0]?.databaseType, "boolean");
+  });
+
   await it("infers set-operation rows and diagnoses incompatible arity", () => {
     const compound = resolveSelect(
       parseSelect("SELECT 1 AS value UNION ALL SELECT 'two' AS ignored INTERSECT SELECT 3 AS final_name"),

--- a/packages/postgres/test/type-resolution.test.ts
+++ b/packages/postgres/test/type-resolution.test.ts
@@ -68,6 +68,32 @@ const structuralSchema = (() => {
   } as const satisfies SchemaSnapshot;
 })();
 
+const legacyDomainSchema = {
+  formatVersion: 1,
+  dialect: "postgres",
+  tables: {},
+  domains: {
+    email_address: { name: "email_address", databaseType: "text", tsType: "string", nullable: false },
+  },
+} as const satisfies SchemaSnapshot;
+
+const qualifiedDomainSchema = {
+  ...upgradeSchemaSnapshotV1({ formatVersion: 1, dialect: "postgres", tables: {} }),
+  types: {
+    email_address: {
+      kind: "domain",
+      schema: "public",
+      name: "email_address",
+      identity: "pg:16385",
+      databaseType: "text",
+      tsType: "string",
+      baseTypeIdentity: "text",
+      nullable: true,
+      checks: [],
+    },
+  },
+} as const satisfies SchemaSnapshot;
+
 await describe("PostgreSQL type resolution", async () => {
   await it("uses canonical type identities and cast contexts", () => {
     strict.strictEqual(postgresCanonicalType("INT4"), "integer");
@@ -85,6 +111,24 @@ await describe("PostgreSQL type resolution", async () => {
     strict.strictEqual(postgresCanCoerce("text", "uuid", "assignment"), false);
     strict.strictEqual(postgresCanCoerce("uuid", "text", "implicit"), false);
     strict.strictEqual(postgresCanCoerce("boolean", "date", "explicit"), false);
+  });
+
+  await it("uses v1 domain evidence when resolving an unknown operator operand", () => {
+    strict.strictEqual(postgresCanonicalType("email_address", legacyDomainSchema), "text");
+    const operator = resolvePostgresOperator("<>", "email_address", undefined, legacyDomainSchema);
+    strict.strictEqual(operator.kind, "selected");
+    if (operator.kind === "selected") {
+      strict.strictEqual(operator.candidate, "<>");
+      strict.deepStrictEqual(operator.argumentTypes, ["text", "text"]);
+      strict.strictEqual(operator.resultType, "boolean");
+    }
+  });
+
+  await it("uses an unambiguous schema-qualified domain name from v2 introspection", () => {
+    strict.strictEqual(postgresCanonicalType("email_address", qualifiedDomainSchema), "text");
+    const operator = resolvePostgresOperator("<>", "email_address", undefined, qualifiedDomainSchema);
+    strict.strictEqual(operator.kind, "selected");
+    if (operator.kind === "selected") strict.deepStrictEqual(operator.argumentTypes, ["text", "text"]);
   });
 
   await it("selects common types without allowing reverse narrowing", () => {

--- a/poku.config.js
+++ b/poku.config.js
@@ -5,5 +5,5 @@ export default defineConfig({
   filter: /\.test\.ts$/,
   exclude: /fixtures/,
   isolation: "process",
-  timeout: 60_000,
+  timeout: 120_000,
 });


### PR DESCRIPTION
## Summary

- make MySQL typed bulk loading portable under `NO_BACKSLASH_ESCAPES` by using hexadecimal delimiter literals
- preserve PostgreSQL domain evidence for legacy v1 and schema-qualified v2 snapshots
- make packed TypeScript dependency resolution deterministic and raise the expanded contract-suite timeout

## Verification

- `pnpm quality`
- `pnpm test`
- MySQL 8.4.11 lexical-mode `pnpm e2e:mysql`
- `TYPED_SQL_CONTAINER_ENGINE=podman pnpm e2e:packed`

Local `planning/` files are intentionally excluded.