### PR TITLE
ci: build before scheduled reliability tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm fuzz:replay
       - run: pnpm mutation:pilot -- --report artifacts/evidence/mutation.json
       - run: pnpm audit --prod --audit-level high


### PR DESCRIPTION
## Summary

- build workspace packages before scheduled fuzz and property tests resolve package exports
- unblock workflow-dispatch release evidence on clean runners

## Verification

- pnpm build
- pnpm fuzz:replay
- pnpm mutation:pilot -- --report /private/tmp/typed-sql-mutation-evidence.json
- git diff --check

No package behavior changes and no Changeset required. Local planning files remain untracked.