### PR TITLE
fix(ci): build packages before documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Build workspace packages
+        run: pnpm build
       - run: pnpm docs:build
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:

--- a/test/contracts/documentation.test.ts
+++ b/test/contracts/documentation.test.ts
@@ -612,6 +612,7 @@ await describe("public documentation", async () => {
     for (const contract of [
       "branches: [main]",
       "pnpm install --frozen-lockfile",
+      "pnpm build",
       "pnpm docs:build",
       "path: website/.vitepress/dist",
       "name: github-pages",
@@ -620,6 +621,10 @@ await describe("public documentation", async () => {
     ]) {
       strict.ok(pagesWorkflow.includes(contract), `.github/workflows/pages.yml is missing ${contract}`);
     }
+    strict.ok(
+      pagesWorkflow.indexOf("pnpm build") < pagesWorkflow.indexOf("pnpm docs:build"),
+      ".github/workflows/pages.yml must build workspace dependencies before the documentation site",
+    );
   });
 
   await it("runs the homepage playground through the PostgreSQL grammar", () => {


### PR DESCRIPTION
## Cause
The standalone Pages workflow built the VitePress site immediately after dependency installation. The browser playground imports workspace packages whose exports resolve through generated dist files, so a clean runner could not resolve @typed-sql/core.

## Fix
- run the canonical workspace build before docs:build
- enforce that ordering in the documentation contract test

## Verification
- pnpm build
- pnpm docs:build
- pnpm docs:check
- pnpm quality