### PR TITLE
fix(language-server): preflight preview entrypoint

### DIFF
--- a/.changeset/calm-previews-start.md
+++ b/.changeset/calm-previews-start.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Validate the bundled TypeScript preview entrypoint before proxy initialization so a missing or corrupted installation reports the actionable recovery diagnostic instead of an `EPIPE` process failure.

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { cwd, stderr, stdin, stdout } from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -117,7 +117,7 @@ function failPreview(error: Error): void {
   stderr.write(`${previewFailure.message}\n`);
 }
 
-const previewReady = new Promise<void>((resolvePreview, rejectPreview) => {
+const previewStarted = new Promise<void>((resolvePreview, rejectPreview) => {
   preview.once("spawn", resolvePreview);
   preview.once("error", (error) => {
     const failure = previewError(error.message);
@@ -125,6 +125,14 @@ const previewReady = new Promise<void>((resolvePreview, rejectPreview) => {
     rejectPreview(failure);
   });
 });
+const previewReady = Promise.all([
+  previewStarted,
+  access(previewCli).catch((error: unknown) => {
+    const failure = previewError(error instanceof Error ? error.message : String(error));
+    failPreview(failure);
+    throw failure;
+  }),
+]).then(() => undefined);
 const client = createMessageConnection(stdin, stdout, NullLogger);
 const typescript: MessageConnection = createMessageConnection(preview.stdout, preview.stdin, NullLogger);
 const sourceDocuments = new Map<string, TextDocument>();


### PR DESCRIPTION
## Cause
On Node 22.23.2 the language server could send initialize to the preview subprocess after Node had spawned but after the configured preview CLI had already failed to load. The resulting closed-pipe race surfaced EPIPE instead of the intended recovery diagnostic.

## Fix
- require both subprocess spawn and preview CLI accessibility before proxy initialization
- retain the existing fail-closed preview diagnostic
- record the language-server patch in a changeset

## Verification
- pnpm build
- pnpm --filter @typed-sql/language-server test
- pnpm typecheck
- pnpm quality

The affected Node 22 current matrix lane will run on this PR because the language-server package changed.