### PR TITLE
website: align mobile editor padding

### DIFF
--- a/website/.vitepress/theme/styles/base.css
+++ b/website/.vitepress/theme/styles/base.css
@@ -168,6 +168,11 @@ body {
 }
 
 @media (max-width: 767px) {
+  .vp-doc div[class*="language-"] {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
   .vp-doc h1 {
     font-size: 2rem;
   }

--- a/website/.vitepress/theme/styles/components.css
+++ b/website/.vitepress/theme/styles/components.css
@@ -638,6 +638,16 @@
 }
 
 @media (max-width: 767px) {
+  .ts-code-editor .cm-content {
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+
+  .ts-code-editor .cm-line {
+    padding-right: 24px;
+    padding-left: 24px;
+  }
+
   .ts-schema-trigger {
     right: 14px;
     bottom: 14px;


### PR DESCRIPTION
## Summary
- keep static code blocks inside the mobile documentation gutter
- match live CodeMirror content padding to VitePress code blocks on small screens
- preserve the existing desktop editor geometry

## Verification
- pnpm docs:check
- pnpm docs:build
- pnpm quality
- git diff --check