### PR TITLE
fix: contain failed recovery and nested transaction lifecycles

### DIFF
--- a/.changeset/mysql-failed-recovery.md
+++ b/.changeset/mysql-failed-recovery.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/mysql": patch
+---
+
+Discard transaction connections after failed rollback or savepoint recovery, preserve the original error, and prevent an invalidated parent from committing or dispatching further work.

--- a/.changeset/sqlite-scope-lifecycle.md
+++ b/.changeset/sqlite-scope-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/sqlite": patch
+---
+
+Prevent child transactions from dispatching after their parent ends, reject overlapping sibling transaction work, and recheck queued work during database shutdown.

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -215,6 +215,20 @@ interface MySqlConnectionOperation {
   finish(): void;
 }
 
+function discardFailedRecovery(connection: MySqlConnectionLike, state?: MySqlTransactionConnectionState): void {
+  if (state?.discarded === true) return;
+  if (state !== undefined) {
+    state.usable = false;
+    state.discarded = true;
+  }
+  try {
+    connection.destroy?.();
+  } catch {
+    // Preserve the initiating failure. Never release a lease whose recovery failed,
+    // including host adapters that cannot destroy it or whose destroy hook throws.
+  }
+}
+
 function createMySqlConnectionOperation(): MySqlConnectionOperation {
   let finish!: () => void;
   const completion = new Promise<void>((resolve) => {
@@ -788,17 +802,21 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         await transaction.#invalidateScope();
       }
       if (transaction === undefined || transaction.#transactionState?.discarded !== true) {
+        let recovered = true;
         if (began) {
           try {
             await connection.rollback();
           } catch {
-            /* Preserve the original failure. */
+            recovered = false;
+            discardFailedRecovery(connection, transaction === undefined ? undefined : transaction.#transactionState);
           }
         }
-        try {
-          connection.release();
-        } catch {
-          /* Preserve the original failure. */
+        if (recovered) {
+          try {
+            connection.release();
+          } catch {
+            /* Preserve the original failure. */
+          }
         }
       }
       throw error;
@@ -839,7 +857,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
         try {
           await connection.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
         } catch {
-          /* Preserve the original failure. */
+          discardFailedRecovery(connection, this.#transactionState);
         }
       }
       throw error;
@@ -871,6 +889,8 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
   }
 
   async #assertTransactionReadyForFinalize(connectionFinalizing = false): Promise<void> {
+    if (this.#transactionState?.discarded === true)
+      throw new Error("This MySQL transaction connection is no longer active");
     const leakedExecutes = new Set(this.#executes);
     if (this.#transactionState?.execute !== undefined) leakedExecutes.add(this.#transactionState.execute);
     const leakedBatch = this.#transactionState?.batch;

--- a/packages/mysql/test/execute-lifecycle.test.ts
+++ b/packages/mysql/test/execute-lifecycle.test.ts
@@ -142,6 +142,57 @@ class ExecutePool implements MySqlPoolLike {
 const nextTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 await describe("MySQL transaction execute ownership", async () => {
+  await it("discards failed rollback leases and preserves the callback failure even if destruction fails", async () => {
+    for (const destroyFails of [false, true]) {
+      const pool = new ExecutePool();
+      const failure = new Error("callback failure");
+      pool.connection.rollback = async () => {
+        pool.connection.events.push("ROLLBACK FAILED");
+        throw new Error("rollback failed");
+      };
+      pool.connection.destroy = () => {
+        pool.connection.destroyCount += 1;
+        if (destroyFails) throw new Error("destroy failed");
+      };
+      const database = createMySqlDatabase({ pool });
+      await strict.rejects(
+        database.transaction(async () => {
+          throw failure;
+        }),
+        (error) => error === failure,
+      );
+      strict.strictEqual(pool.connection.releaseCount, 0);
+      strict.strictEqual(pool.connection.destroyCount, 1);
+    }
+  });
+
+  await it("invalidates the parent after failed savepoint recovery even if the callback catches it", async () => {
+    const pool = new ExecutePool();
+    const failure = new Error("nested failure");
+    pool.connection.query = async (text) => {
+      pool.connection.events.push(text);
+      if (text.startsWith("ROLLBACK TO")) throw new Error("savepoint recovery failed");
+      return { rows: [] };
+    };
+    const database = createMySqlDatabase({ pool });
+    await strict.rejects(
+      database.transaction(async (outer) => {
+        await strict.rejects(
+          outer.transaction(async () => {
+            throw failure;
+          }),
+          (error) => error === failure,
+        );
+        await strict.rejects(outer.execute(accountQuery), /no longer active/);
+      }),
+      /no longer active/,
+    );
+    strict.strictEqual(pool.connection.destroyCount, 1);
+    strict.strictEqual(pool.connection.releaseCount, 0);
+    strict.ok(!pool.connection.events.includes("COMMIT"));
+    strict.ok(!pool.connection.events.includes("ROLLBACK"));
+  });
+
   await it("rejects incompatible physical connections before application SQL dispatch", async () => {
     const pool = new ExecutePool();
     const expected = pool.connection.serverEvidence;

--- a/packages/mysql/test/provider-runtime.test.ts
+++ b/packages/mysql/test/provider-runtime.test.ts
@@ -1046,10 +1046,9 @@ await describe("MySQL provider and runtime", async () => {
       "BEGIN",
       "SAVEPOINT typed_sql_2",
       "ROLLBACK TO SAVEPOINT typed_sql_2",
-      "ROLLBACK",
     ]);
-    strict.strictEqual(pool.connection.rollbackCount, 1);
-    strict.strictEqual(pool.connection.releaseCount, 1);
+    strict.strictEqual(pool.connection.rollbackCount, 0);
+    strict.strictEqual(pool.connection.releaseCount, 0);
   });
 
   await it("preserves decoder failures across outer and nested transaction cleanup", async () => {
@@ -1068,7 +1067,7 @@ await describe("MySQL provider and runtime", async () => {
     );
     strict.deepStrictEqual(outerPool.connection.commands, ["BEGIN", "SELECT 1", "ROLLBACK"]);
     strict.strictEqual(outerPool.connection.rollbackCount, 1);
-    strict.strictEqual(outerPool.connection.releaseCount, 1);
+    strict.strictEqual(outerPool.connection.releaseCount, 0);
 
     const nestedPool = new FakePool();
     nestedPool.connection.failRelease = true;
@@ -1086,10 +1085,9 @@ await describe("MySQL provider and runtime", async () => {
       "SAVEPOINT typed_sql_2",
       "SELECT 1",
       "ROLLBACK TO SAVEPOINT typed_sql_2",
-      "ROLLBACK",
     ]);
-    strict.strictEqual(nestedPool.connection.rollbackCount, 1);
-    strict.strictEqual(nestedPool.connection.releaseCount, 1);
+    strict.strictEqual(nestedPool.connection.rollbackCount, 0);
+    strict.strictEqual(nestedPool.connection.releaseCount, 0);
   });
 
   await it("enforces lossless numeric policies and explicit decimal codecs", async () => {

--- a/packages/sqlite/src/runtime.ts
+++ b/packages/sqlite/src/runtime.ts
@@ -165,9 +165,12 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
   readonly #ownsConnection: boolean;
   readonly #transactionDepth: number;
   readonly #root: boolean;
+  readonly #parent: SqliteDatabaseImplementation | undefined;
+  readonly #children = new Set<SqliteDatabaseImplementation>();
   readonly #streams = new Set<QueryStream<unknown>>();
   #scopeOpen = true;
   #closed = false;
+  #closing: Promise<void> | undefined;
   readonly executionCapabilities = executionCapabilities;
 
   constructor(
@@ -177,6 +180,7 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     ownsConnection: boolean,
     transactionDepth: number,
     root: boolean,
+    parent?: SqliteDatabaseImplementation,
   ) {
     this.#connection = connection;
     this.#queue = queue;
@@ -184,6 +188,7 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     this.#ownsConnection = ownsConnection;
     this.#transactionDepth = transactionDepth;
     this.#root = root;
+    this.#parent = parent;
   }
 
   async execute<Row, Params extends readonly unknown[]>(query: Query<Row, Params>): Promise<readonly Row[]> {
@@ -199,8 +204,10 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     this.#assertNoStream("execute a query");
     const prepared = this.#prepared.queries.get(queryResultValidationSource(query));
     const rendered = prepared?.rendered ?? renderQuery(query, sqliteRenderer);
-    const operation = async (): Promise<readonly Row[]> =>
-      (await this.#connection.all(rendered.text, rendered.values)) as readonly Row[];
+    const operation = async (): Promise<readonly Row[]> => {
+      this.#assertOpen();
+      return this.#connection.all(rendered.text, rendered.values) as readonly Row[];
+    };
     const rows = await (this.#root ? this.#queue.run(operation) : operation());
     return this.#validateRows(query, rows);
   }
@@ -229,6 +236,7 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     if (queries.length === 0) return emptyBatchResults as QueryResults<Queries>;
     const snapshot = [...queries] as QueryBatch<Queries>;
     const operation = async (): Promise<QueryResults<Queries>> => {
+      this.#assertOpen();
       const results: (readonly unknown[])[] = [];
       for (const query of snapshot) {
         const prepared = this.#prepared.queries.get(
@@ -257,6 +265,7 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
       this.#assertNoStream("start a query stream");
       const release = this.#root ? await this.#queue.acquire() : () => undefined;
       try {
+        this.#assertOpen();
         const iterator = this.#connection.iterate(rendered.text, rendered.values)[Symbol.iterator]() as Iterator<Row>;
         this.#streams.add(source as QueryStream<unknown>);
         return {
@@ -313,9 +322,9 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     this.#assertNoStream("start a transaction");
     if (typeof fn !== "function") throw new TypeError("SQLite transaction callback must be a function");
     const operation = async (): Promise<Value> => {
+      this.#assertOpen();
       const depth = this.#transactionDepth + 1;
       const savepoint = `typed_sql_${depth}`;
-      await this.#connection.exec(this.#transactionDepth === 0 ? "BEGIN" : `SAVEPOINT ${savepoint}`);
       const scope = new SqliteDatabaseImplementation(
         this.#connection,
         this.#queue,
@@ -323,26 +332,41 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
         false,
         depth,
         false,
+        this,
       );
+      this.#children.add(scope);
+      let began = false;
       try {
+        this.#connection.exec(this.#transactionDepth === 0 ? "BEGIN" : `SAVEPOINT ${savepoint}`);
+        began = true;
         const result = await fn(scope);
-        await scope.#closeStreams();
         scope.#scopeOpen = false;
-        await this.#connection.exec(this.#transactionDepth === 0 ? "COMMIT" : `RELEASE SAVEPOINT ${savepoint}`);
+        if (scope.#children.size > 0) {
+          throw new Error(
+            "SQLite transaction callback returned with an active child transaction; await nested work before returning",
+          );
+        }
+        await scope.#closeStreams();
+        if (!this.#scopeIsOpen()) throw new Error("SQLite transaction scope is closed");
+        this.#connection.exec(this.#transactionDepth === 0 ? "COMMIT" : `RELEASE SAVEPOINT ${savepoint}`);
         return result;
       } catch (error) {
-        await scope.#closeStreams().catch(() => undefined);
         scope.#scopeOpen = false;
+        await scope.#closeStreams().catch(() => undefined);
         try {
-          if (this.#transactionDepth === 0) await this.#connection.exec("ROLLBACK");
-          else {
-            await this.#connection.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`);
-            await this.#connection.exec(`RELEASE SAVEPOINT ${savepoint}`);
+          if (began && this.#scopeIsOpen()) {
+            if (this.#transactionDepth === 0) this.#connection.exec("ROLLBACK");
+            else {
+              this.#connection.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+              this.#connection.exec(`RELEASE SAVEPOINT ${savepoint}`);
+            }
           }
         } catch {
           // Preserve the callback or query failure.
         }
         throw error;
+      } finally {
+        this.#children.delete(scope);
       }
     };
     return this.#root ? this.#queue.run(operation) : operation();
@@ -350,27 +374,35 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
 
   async close(): Promise<void> {
     if (!this.#root) throw new Error("Transaction-scoped SQLite databases do not own connection lifecycle");
-    if (this.#closed) return;
-    await this.#closeStreams();
-    await this.#queue.run(async () => {
-      if (this.#closed) return;
-      this.#closed = true;
-      if (this.#ownsConnection) await this.#connection.close?.();
-    });
+    this.#closing ??= (async () => {
+      await this.#closeStreams();
+      await this.#queue.run(() => {
+        this.#closed = true;
+        if (this.#ownsConnection) this.#connection.close?.();
+      });
+    })();
+    return this.#closing;
   }
 
   async #closeStreams(): Promise<void> {
+    await Promise.all([...this.#children].map((child) => child.#closeStreams()));
     const streams = [...this.#streams];
     await Promise.all(streams.map((stream) => stream.close()));
   }
 
   #assertNoStream(operation: string): void {
+    if (!this.#root && this.#children.size > 0)
+      throw new Error(`Cannot ${operation} while a SQLite child transaction is active`);
     if (this.#streams.size > 0) throw new Error(`Cannot ${operation} while a SQLite query stream is active`);
   }
 
   #assertOpen(): void {
-    if (this.#closed) throw new Error("SQLite database is closed");
-    if (!this.#scopeOpen) throw new Error("SQLite transaction scope is closed");
+    if (this.#closed || this.#closing !== undefined) throw new Error("SQLite database is closed");
+    if (!this.#scopeIsOpen()) throw new Error("SQLite transaction scope is closed");
+  }
+
+  #scopeIsOpen(): boolean {
+    return this.#scopeOpen && !this.#closed && (this.#parent === undefined || this.#parent.#scopeIsOpen());
   }
 }
 

--- a/packages/sqlite/test/runtime-edge.test.ts
+++ b/packages/sqlite/test/runtime-edge.test.ts
@@ -30,6 +30,87 @@ function memoryConnection(rows: readonly Record<string, unknown>[] = []): Sqlite
 }
 
 await describe("SQLite runtime edge contracts", async () => {
+  await it("rolls back an escaped child and blocks its later dispatch", async () => {
+    const connection = memoryConnection();
+    const database = createSqliteDatabase({ connection });
+    let resume!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    let child!: Promise<void>;
+    await strict.rejects(
+      database.transaction(async (outer) => {
+        child = outer.transaction(async (inner) => {
+          await gate;
+          await inner.all(sql`SELECT escaped`);
+        });
+      }),
+      /active child transaction/,
+    );
+    strict.deepStrictEqual(connection.commands, ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK"]);
+    resume();
+    await strict.rejects(child, /scope is closed/);
+    strict.deepStrictEqual(connection.commands, ["BEGIN", "SAVEPOINT typed_sql_2", "ROLLBACK"]);
+    await database.transaction(async () => undefined);
+  });
+
+  await it("rejects sibling and parent work while a child owns the scope", async () => {
+    const database = createSqliteDatabase({ connection: memoryConnection() });
+    await database.transaction(async (outer) => {
+      let resume!: () => void;
+      const child = outer.transaction(
+        async () =>
+          new Promise<void>((resolve) => {
+            resume = resolve;
+          }),
+      );
+      await strict.rejects(
+        outer.transaction(async () => undefined),
+        /child transaction is active/,
+      );
+      await strict.rejects(outer.all(sql`SELECT 1`), /child transaction is active/);
+      resume();
+      await child;
+      await outer.all(sql`SELECT 1`);
+    });
+  });
+
+  await it("rejects queued query and stream startup during shutdown without leaking the queue", async () => {
+    const connection = memoryConnection();
+    let closed = 0;
+    const database = createSqliteDatabase({
+      connection: {
+        ...connection,
+        close() {
+          closed += 1;
+        },
+      },
+      ownsConnection: true,
+    });
+    let resume!: () => void;
+    let started!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const transaction = database.transaction(async () => {
+      started();
+      await new Promise<void>((resolve) => {
+        resume = resolve;
+      });
+    });
+    await ready;
+    const queued = database.all(sql`SELECT queued`);
+    const stream = database.stream(sql`SELECT streamed`);
+    const next = stream.next();
+    const closing = database.close();
+    const queryRejected = strict.rejects(queued, /closed/);
+    const streamRejected = strict.rejects(next, /closed/);
+    await strict.rejects(database.all(sql`SELECT late`), /closed/);
+    resume();
+    await Promise.all([transaction, queryRejected, streamRejected, closing, database.close()]);
+    strict.strictEqual(closed, 1);
+  });
+
   await it("enforces cardinality, capabilities, lifecycle, and connection shape", async () => {
     const empty = createSqliteDatabase({ connection: memoryConnection() });
     strict.deepStrictEqual(await empty.batch([]), []);


### PR DESCRIPTION
Fix transaction recovery and scope containment in the MySQL and SQLite adapters.

MySQL previously returned a connection to its pool after rollback failed. Failed rollback/savepoint recovery now discards the lease, preserves the initiating error, and prevents a caught nested failure from allowing a parent commit. Host adapters without a destroy hook retain the unsafe lease rather than releasing it.

SQLite previously allowed an unawaited child transaction to run SQL after its parent committed. Parent finalization now rejects active children and rolls back; descendants are invalidated. Sibling/parent work cannot overlap an active child, and queued queries and stream startup recheck shutdown state.

Validation: clean build and typecheck; all 32 MySQL/SQLite test files pass, including new recovery, escaped-child, sibling-ownership, and queued-shutdown regressions. Patch Changesets included.

Closes #109
Closes #110
