### PR TITLE
perf: index source mappings and bound name suggestions

### DIFF
--- a/.changeset/analysis-suggestions-performance.md
+++ b/.changeset/analysis-suggestions-performance.md
@@ -1,0 +1,6 @@
+---
+"@typed-sql/compiler": patch
+"@typed-sql/core": patch
+---
+
+Index source-analysis offsets and bindings once and bound name-suggestion edit-distance work while preserving query ranges and suggestion tie ordering.

--- a/packages/compiler/src/analysis.ts
+++ b/packages/compiler/src/analysis.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MAX_SOURCE_BYTES,
   DEFAULT_MAX_STRUCTURAL_VARIANTS,
 } from "./compiler.js";
+import { insertionOffsets, sourceBindings } from "./source-mapping.js";
 
 export const SOURCE_ANALYSIS_FORMAT_VERSION = 1 as const;
 
@@ -117,17 +118,6 @@ function cancelled(control?: SourceAnalysisControl): void {
   const error = new Error("typed-sql source analysis cancelled");
   error.name = "AbortError";
   throw error;
-}
-
-function bindingBefore(source: string, tagStart: number): SourceAnalysisBinding | undefined {
-  const prefix = source.slice(0, tagStart);
-  const match = /(?:^|[;{}]\s*|\n\s*)(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*$/u.exec(prefix);
-  if (match === null) return undefined;
-  const name = match[1];
-  if (name === undefined) return undefined;
-  const relativeStart = match[0].lastIndexOf(name);
-  const start = match.index + relativeStart;
-  return { name, range: { start, end: start + name.length } };
 }
 
 function positiveLimit(value: number | undefined, fallback: number, name: string): number {
@@ -240,8 +230,8 @@ export function analyzeSource<Snapshot extends SchemaSnapshot, Policy>(
       })),
     ].sort((left, right) => left.position - right.position),
   );
-  const shiftBefore = (position: number): number =>
-    insertions.reduce((total, insertion) => total + (insertion.position < position ? insertion.length : 0), 0);
+  const shiftBefore = insertionOffsets(insertions);
+  const bindings = sourceBindings(request.source.text);
   const queries = Object.freeze(
     compilation.queries.map(
       ({ query, rowType, parameterType }, index): SourceAnalysisQuery => ({
@@ -259,7 +249,7 @@ export function analyzeSource<Snapshot extends SchemaSnapshot, Policy>(
           end: sourceEnd,
         })),
         ...(() => {
-          const binding = bindingBefore(request.source.text, query.range.start);
+          const binding = bindings.get(query.range.start);
           return binding === undefined ? {} : { binding };
         })(),
       }),

--- a/packages/compiler/src/source-mapping.ts
+++ b/packages/compiler/src/source-mapping.ts
@@ -1,0 +1,29 @@
+import type { SourceAnalysisBinding, SourceAnalysisInsertion } from "./analysis.js";
+
+/** Index declaration suffixes once rather than searching every source prefix. */
+export function sourceBindings(source: string): ReadonlyMap<number, SourceAnalysisBinding> {
+  const bindings = new Map<number, SourceAnalysisBinding>();
+  const pattern = /(?:^|[;{}]\s*|\n\s*)(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*/gu;
+  for (const match of source.matchAll(pattern)) {
+    const name = match[1]!;
+    const start = match.index + match[0].lastIndexOf(name);
+    bindings.set(match.index + match[0].length, { name, range: { start, end: start + name.length } });
+  }
+  return bindings;
+}
+
+/** Sorted insertion positions and cumulative lengths give O(log n) offset lookup. */
+export function insertionOffsets(insertions: readonly SourceAnalysisInsertion[]): (position: number) => number {
+  const sums = [0];
+  for (const insertion of insertions) sums.push(sums[sums.length - 1]! + insertion.length);
+  return (position) => {
+    let low = 0;
+    let high = insertions.length;
+    while (low < high) {
+      const middle = (low + high) >>> 1;
+      if (insertions[middle]!.position < position) low = middle + 1;
+      else high = middle;
+    }
+    return sums[low]!;
+  };
+}

--- a/packages/compiler/src/source-mapping.ts
+++ b/packages/compiler/src/source-mapping.ts
@@ -3,11 +3,38 @@ import type { SourceAnalysisBinding, SourceAnalysisInsertion } from "./analysis.
 /** Index declaration suffixes once rather than searching every source prefix. */
 export function sourceBindings(source: string): ReadonlyMap<number, SourceAnalysisBinding> {
   const bindings = new Map<number, SourceAnalysisBinding>();
-  const pattern = /(?:^|[;{}]\s*|\n\s*)(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*/gu;
-  for (const match of source.matchAll(pattern)) {
-    const name = match[1]!;
-    const start = match.index + match[0].lastIndexOf(name);
-    bindings.set(match.index + match[0].length, { name, range: { start, end: start + name.length } });
+  const whitespace = (index: number): boolean => index >= 0 && index < source.length && /\s/u.test(source[index]!);
+  const skipWhitespace = (index: number): number => {
+    while (whitespace(index)) index += 1;
+    return index;
+  };
+  const boundary = (position: number, allowExport = true): boolean => {
+    let previous = position - 1;
+    let newline = false;
+    while (whitespace(previous)) {
+      newline ||= source[previous] === "\n";
+      previous -= 1;
+    }
+    if (newline || position === 0 || (previous >= 0 && /[;{}]/u.test(source[previous]!))) return true;
+    return (
+      allowExport &&
+      previous < position - 1 &&
+      source.slice(previous - 5, previous + 1) === "export" &&
+      boundary(previous - 5, false)
+    );
+  };
+  // Scan fixed keywords, then consume each declaration's whitespace once. A regex
+  // starting with newline + whitespace can retry an entire whitespace suffix.
+  for (const match of source.matchAll(/\b(?:const|let|var)\b/gu)) {
+    if (!boundary(match.index)) continue;
+    const keywordEnd = match.index + match[0].length;
+    const start = skipWhitespace(keywordEnd);
+    if (start === keywordEnd || start === source.length || !/[A-Za-z_$]/u.test(source[start]!)) continue;
+    let end = start + 1;
+    while (end < source.length && /[\w$]/u.test(source[end]!)) end += 1;
+    const equals = skipWhitespace(end);
+    if (source[equals] !== "=") continue;
+    bindings.set(skipWhitespace(equals + 1), { name: source.slice(start, end), range: { start, end } });
   }
   return bindings;
 }

--- a/packages/compiler/test/source-mapping.test.ts
+++ b/packages/compiler/test/source-mapping.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, strict } from "poku";
+import { insertionOffsets, sourceBindings } from "../src/source-mapping.js";
+
+await describe("indexed source mapping", async () => {
+  await it("preserves strict insertion boundaries, duplicate positions, and arbitrary lookup order", () => {
+    const insertions = [
+      { position: 0, length: 2 },
+      { position: 4, length: 3 },
+      { position: 4, length: 7 },
+      { position: 20, length: 1 },
+    ];
+    const offset = insertionOffsets(insertions);
+    for (const position of [20, 0, 4, 5, 21, 1, -1])
+      strict.strictEqual(
+        offset(position),
+        insertions.reduce((sum, item) => sum + (item.position < position ? item.length : 0), 0),
+      );
+    strict.strictEqual(insertionOffsets([])(10), 0);
+  });
+
+  await it("retains declaration binding names and source spans across whitespace and boundaries", () => {
+    const source =
+      "export const first = sql`SELECT 1`;let second=sql`SELECT 2`;\nfunction f(){\n const third\n = \n sql`SELECT 3`;return sql`SELECT 4`;}\nconst $fifth = sql`SELECT 5`;";
+    const bindings = sourceBindings(source);
+    for (const match of source.matchAll(/sql`/gu)) {
+      const prefix = source.slice(0, match.index);
+      const previous = /(?:^|[;{}]\s*|\n\s*)(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*$/u.exec(prefix);
+      const binding = bindings.get(match.index);
+      strict.strictEqual(binding?.name, previous?.[1]);
+      if (binding !== undefined) strict.strictEqual(source.slice(binding.range.start, binding.range.end), binding.name);
+    }
+  });
+});

--- a/packages/compiler/test/source-mapping.test.ts
+++ b/packages/compiler/test/source-mapping.test.ts
@@ -2,6 +2,14 @@ import { describe, it, strict } from "poku";
 import { insertionOffsets, sourceBindings } from "../src/source-mapping.js";
 
 await describe("indexed source mapping", async () => {
+  await it("handles large whitespace runs without regex backtracking", () => {
+    const whitespace = "\n".repeat(100_000);
+    strict.strictEqual(sourceBindings(whitespace).size, 0);
+    const source = `${whitespace}export const query =${whitespace}sql`;
+    strict.strictEqual(sourceBindings(source).get(source.length - 3)?.name, "query");
+    for (const source of ["  const q = sql", "object.const q = sql", "const = sql", "const q: number = sql"])
+      strict.strictEqual(sourceBindings(source).size, 0);
+  });
   await it("preserves strict insertion boundaries, duplicate positions, and arbitrary lookup order", () => {
     const insertions = [
       { position: 0, length: 2 },

--- a/packages/core/src/name-suggestions.ts
+++ b/packages/core/src/name-suggestions.ts
@@ -1,0 +1,36 @@
+/** Returns limit + 1 when the edit distance cannot produce an accepted suggestion. */
+function boundedDistance(left: string, right: string, limit: number): number {
+  if (Math.abs(left.length - right.length) > limit) return limit + 1;
+  const row = Array.from({ length: left.length + 1 }, (_, index) => index);
+  for (let column = 1; column <= right.length; column += 1) {
+    const start = Math.max(1, column - limit);
+    const end = Math.min(left.length, column + limit);
+    let diagonal = row[start - 1]!;
+    row[0] = column;
+    if (start > 1) row[start - 1] = limit + 1;
+    let minimum = row[0];
+    for (let index = start; index <= end; index += 1) {
+      const above = row[index]!;
+      row[index] = Math.min(above + 1, row[index - 1]! + 1, diagonal + (left[index - 1] === right[column - 1] ? 0 : 1));
+      diagonal = above;
+      minimum = Math.min(minimum, row[index]!);
+    }
+    if (end < left.length) row[end + 1] = limit + 1;
+    if (minimum > limit) return limit + 1;
+  }
+  return row[left.length]!;
+}
+
+export function closestName(name: string, candidates: readonly string[]): string | undefined {
+  let closest: string | undefined;
+  let limit = Math.max(2, Math.floor(name.length / 2));
+  for (const candidate of candidates) {
+    const distance = boundedDistance(name, candidate, limit);
+    if (distance > limit) continue;
+    closest = candidate;
+    if (distance === 0) break;
+    // Only a strictly closer candidate may replace the first equal-distance match.
+    limit = distance - 1;
+  }
+  return closest;
+}

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -63,36 +63,7 @@ export function unionTypeLiterals(types: readonly string[]): string {
   return distinct.includes("unknown") ? "unknown" : distinct.join(" | ") || "unknown";
 }
 
-function editDistance(left: string, right: string): number {
-  const rows = Array.from({ length: left.length + 1 }, (_, index) => index);
-  for (let column = 1; column <= right.length; column += 1) {
-    let diagonal = rows[0]!;
-    rows[0] = column;
-    for (let row = 1; row <= left.length; row += 1) {
-      const above = rows[row]!;
-      rows[row] = Math.min(
-        rows[row]! + 1,
-        rows[row - 1]! + 1,
-        diagonal + (left[row - 1] === right[column - 1] ? 0 : 1),
-      );
-      diagonal = above;
-    }
-  }
-  return rows[left.length]!;
-}
-
-export function closestName(name: string, candidates: readonly string[]): string | undefined {
-  let closest: string | undefined;
-  let closestDistance = Number.POSITIVE_INFINITY;
-  for (const candidate of candidates) {
-    const distance = editDistance(name, candidate);
-    if (distance < closestDistance) {
-      closest = candidate;
-      closestDistance = distance;
-    }
-  }
-  return closest !== undefined && closestDistance <= Math.max(2, Math.floor(name.length / 2)) ? closest : undefined;
-}
+export { closestName } from "./name-suggestions.js";
 
 export interface IndexedTable {
   readonly key: string;

--- a/packages/core/test/name-suggestions.test.ts
+++ b/packages/core/test/name-suggestions.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, strict } from "poku";
+import { closestName } from "../src/index.js";
+
+function reference(name: string, candidates: readonly string[]): string | undefined {
+  let best: string | undefined;
+  let minimum = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const matrix = Array.from({ length: name.length + 1 }, (_, row) =>
+      Array.from({ length: candidate.length + 1 }, (_, column) => (row === 0 ? column : column === 0 ? row : 0)),
+    );
+    for (let row = 1; row <= name.length; row += 1)
+      for (let column = 1; column <= candidate.length; column += 1)
+        matrix[row]![column] = Math.min(
+          matrix[row - 1]![column]! + 1,
+          matrix[row]![column - 1]! + 1,
+          matrix[row - 1]![column - 1]! + (name[row - 1] === candidate[column - 1] ? 0 : 1),
+        );
+    const distance = matrix[name.length]![candidate.length]!;
+    if (distance < minimum) {
+      best = candidate;
+      minimum = distance;
+    }
+  }
+  return minimum <= Math.max(2, Math.floor(name.length / 2)) ? best : undefined;
+}
+
+await describe("bounded name suggestions", async () => {
+  await it("matches a full-matrix oracle including empty names, Unicode, and stable ties", () => {
+    const words = [
+      "",
+      "a",
+      "b",
+      "ab",
+      "ba",
+      "aa",
+      "bbb",
+      "aba",
+      "é",
+      "😀",
+      "users",
+      "uesrs",
+      "user_id",
+      "x".repeat(60),
+    ];
+    for (const name of words)
+      for (const left of words)
+        for (const right of words) strict.strictEqual(closestName(name, [left, right]), reference(name, [left, right]));
+  });
+});


### PR DESCRIPTION
Source analysis previously scanned every insertion twice for each query and repeatedly matched growing source prefixes. It now indexes cumulative offsets and declaration bindings once. Source mapping is isolated in a package-local module.

Name suggestions now prune impossible lengths and use a bounded edit-distance band, tightening the limit after each accepted candidate while retaining first-match ties. The helper is isolated from schema indexing, with the existing public re-export preserved.

Validation: typecheck, exact insertion-boundary and binding-span regressions, a full-matrix suggestion oracle (including empty strings and Unicode), and the complete performance gate pass. Patch Changesets included. These are focused module extractions; grammar resolver semantics and public facades are unchanged.

Closes #114
Closes #115
Closes #118
