### PR TITLE
refactor(compiler): share artifact serialization primitives

### DIFF
--- a/packages/compiler/src/artifact-serialization.ts
+++ b/packages/compiler/src/artifact-serialization.ts
@@ -1,0 +1,12 @@
+/** Stable UTF-16 code-unit ordering used by compiler artifact identities. */
+export const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
+
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => compareText(left, right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+}

--- a/packages/compiler/src/compatibility.ts
+++ b/packages/compiler/src/compatibility.ts
@@ -9,6 +9,7 @@ import {
   serializeSchemaSnapshot,
   type TypeSnapshot,
 } from "@typed-sql/schema";
+import { canonicalize, compareText } from "./artifact-serialization.js";
 import type { QueryManifest, QueryManifestLocation, QueryManifestVariant } from "./manifest.js";
 import { parseQueryManifest, serializeQueryManifest } from "./manifest.js";
 
@@ -161,7 +162,6 @@ interface ManifestReferences {
 }
 
 const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
-const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 const relationKey = (key: string) => `relation:${key}`;
 const relationWriteKey = (key: string) => `relation-write:${key}`;
 const columnKey = (table: string, column: string) => `column:${table}.${column}`;
@@ -311,16 +311,6 @@ function assertQueryReference(value: unknown, description: string): asserts valu
   assertHash(value.variantFingerprint, `${description}.variantFingerprint`);
   assertLocation(value.source, `${description}.source`);
   if (value.dependencyRange !== undefined) assertRange(value.dependencyRange, `${description}.dependencyRange`);
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value !== "object" || value === null) return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => compareText(left, right))
-      .map(([key, item]) => [key, canonicalize(item)]),
-  );
 }
 
 function targetIdentity(target: SchemaCompatibilityTarget): string {

--- a/packages/compiler/src/manifest.ts
+++ b/packages/compiler/src/manifest.ts
@@ -17,6 +17,7 @@ import {
   type SqlDiagnostic,
 } from "@typed-sql/core";
 import { calculateSchemaHash, calculateTypePolicyHash } from "@typed-sql/schema";
+import { canonicalize, compareText } from "./artifact-serialization.js";
 import { compileSource } from "./compiler.js";
 import { extractDynamicQueries, extractStaticQueries } from "./scanner.js";
 
@@ -188,7 +189,6 @@ export interface BuildQueryManifestResult {
 }
 
 const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
-const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 
 function portableRelative(rootDir: string, file: string): string {
   const root = resolve(rootDir);
@@ -506,16 +506,6 @@ export function buildQueryManifest<Snapshot extends SchemaSnapshot, Policy>(
       unresolvedQueries: queries.filter((query) => query.status === "unresolved").length,
     },
   };
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value !== "object" || value === null) return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => compareText(left, right))
-      .map(([key, item]) => [key, canonicalize(item)]),
-  );
 }
 
 export function serializeQueryManifest(manifest: QueryManifest): string {

--- a/packages/compiler/src/plans.ts
+++ b/packages/compiler/src/plans.ts
@@ -8,6 +8,7 @@ import type {
   QueryPlanNode,
   QueryPlanSampleProvider,
 } from "@typed-sql/core";
+import { canonicalize, compareText } from "./artifact-serialization.js";
 import {
   parseQueryManifest,
   type QueryManifest,
@@ -151,17 +152,6 @@ export interface ReviewQueryPlansOptions {
 }
 
 const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
-const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value !== "object" || value === null) return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => compareText(left, right))
-      .map(([key, item]) => [key, canonicalize(item)]),
-  );
-}
 
 function manifestHash(manifest: QueryManifest): string {
   return `sha256:${sha256(serializeQueryManifest(manifest))}`;

--- a/packages/compiler/src/verification.ts
+++ b/packages/compiler/src/verification.ts
@@ -11,6 +11,7 @@ import type {
   ResolvedParameter,
   SchemaSnapshot,
 } from "@typed-sql/core";
+import { canonicalize, compareText } from "./artifact-serialization.js";
 import { compileSource } from "./compiler.js";
 import {
   buildQueryManifest,
@@ -142,7 +143,6 @@ export interface VerifyQueryManifestResult {
 }
 
 const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
-const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 
 function portableRelative(rootDir: string, file: string): string {
   const root = resolve(rootDir);
@@ -385,16 +385,6 @@ async function boundedMap<Input, Output>(
   };
   await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker));
   return output;
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value !== "object" || value === null) return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => compareText(left, right))
-      .map(([key, item]) => [key, canonicalize(item)]),
-  );
 }
 
 function normalizedServer(server: LiveQueryVerificationServer): LiveQueryVerificationServer {

--- a/packages/compiler/test/analysis.test.ts
+++ b/packages/compiler/test/analysis.test.ts
@@ -93,6 +93,23 @@ await describe("authoritative source analysis service", async () => {
 
   await it("rejects malformed requests and cancellation without publishing partial success", () => {
     strict.throws(
+      () => analyzeSource({ ...request, formatVersion: 2 as never }, context),
+      /Unsupported source analysis request/,
+    );
+    for (const version of [-1, 0.5, "", "bad\0version"])
+      strict.throws(
+        () => analyzeSource({ ...request, source: { ...request.source, version } }, context),
+        /Source analysis version/,
+      );
+    for (const project of [
+      { ...request.project, id: "" },
+      { ...request.project, id: "bad\0project" },
+      { ...request.project, generation: -1 },
+      { ...request.project, configHash: "" },
+      { ...request.project, configHash: "bad\0hash" },
+    ])
+      strict.throws(() => analyzeSource({ ...request, project }, context), /project identity is invalid/);
+    strict.throws(
       () => analyzeSource({ ...request, source: { ...request.source, id: "" } }, context),
       /non-empty string/u,
     );


### PR DESCRIPTION
Consolidate the four identical compiler artifact canonicalizers and text comparators into a package-local serialization module. Manifest, plan, verification, and compatibility serializers retain their existing ordering, output, and identities; schema's legacy locale-sensitive serializer is intentionally handled separately in #111.

Validation: typecheck and artifact manifest, plan, verification, and compatibility suites, including determinism and round-trip contracts. The local full-suite attempt exposed an existing discovery-test assumption when TMPDIR is inside a repository (it finds the ancestor tsconfig); CI exercises the normal full-suite environment. No public API or packaged behavior change.

Closes #116
