### PR TITLE
fix(config): reload imported helpers and refresh editor analysis

### DIFF
--- a/.changeset/imported-config-reload.md
+++ b/.changeset/imported-config-reload.md
@@ -1,0 +1,6 @@
+---
+"@typed-sql/config": patch
+"@typed-sql/language-server": patch
+---
+
+Refresh changed local configuration dependencies and recognize their editor file-watch events, while reusing unchanged evaluated configurations.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { dirname, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { assertDialectPlugin, type SchemaSnapshot, type TypedSqlConfig } from "@typed-sql/core";
-import { register } from "tsx/esm/api";
+import { tsImport } from "tsx/esm/api";
 
 const configNames = [
   "typed-sql.config.ts",
@@ -13,13 +13,19 @@ const configNames = [
   "typed-sql.config.js",
 ] as const;
 export const CONFIG_CACHE_LIMIT = 32;
-const configLoader = register({ namespace: "typed-sql-config" });
 const configCache = new Map<string, Promise<LoadedConfig>>();
+const dependencyHashes = new WeakMap<LoadedConfig, ReadonlyMap<string, string>>();
+const hashFile = async (file: string): Promise<string> =>
+  createHash("sha256")
+    .update(await readFile(file))
+    .digest("hex");
 
 export interface LoadedConfig {
   readonly file: string;
   readonly directory: string;
   readonly config: TypedSqlConfig<SchemaSnapshot, unknown>;
+  /** Local modules imported while evaluating this configuration, for editor file watchers. */
+  readonly dependencies?: readonly string[];
 }
 
 export interface LoadConfigOptions {
@@ -40,7 +46,7 @@ export async function discoverConfig(start = process.cwd()): Promise<string> {
   let directory = resolve(start);
   while (true) {
     for (const name of configNames) {
-      const candidate = join(directory, name);
+      const candidate = resolve(directory, name);
       if (await exists(candidate)) return candidate;
     }
     const parent = dirname(directory);
@@ -66,25 +72,50 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Loade
     options.file === undefined
       ? await discoverConfig(options.cwd)
       : resolve(options.cwd ?? process.cwd(), options.file);
-  const source = await readFile(file);
-  const hash = createHash("sha256").update(source).digest("hex");
+  const hash = await hashFile(file);
   const key = `${file}\0${hash}`;
   const cached = configCache.get(key);
   if (cached !== undefined) {
+    const loaded = await cached;
+    const unchanged = await Promise.all(
+      [...dependencyHashes.get(loaded)!].map(async ([path, previous]) => {
+        try {
+          return (await hashFile(path)) === previous;
+        } catch {
+          return false;
+        }
+      }),
+    );
+    if (configCache.get(key) !== cached) return loadConfig(options);
     configCache.delete(key);
-    configCache.set(key, cached);
-    return cached;
+    if (unchanged.every(Boolean)) {
+      configCache.set(key, cached);
+      return loaded;
+    }
   }
-  const specifier = new URL(pathToFileURL(file));
-  specifier.searchParams.set("typed-sql-config", hash);
-  const loading = configLoader
-    .import(specifier.href, pathToFileURL(join(dirname(file), "package.json")).href)
-    .then((module: { readonly default?: unknown }) => {
+  const dependencies = new Set<string>([file]);
+  // A fresh tsx namespace reloads the entire imported module graph, not only the
+  // entry module. Reuse is handled above once every recorded dependency matches.
+  const loading = tsImport(pathToFileURL(file).href, {
+    parentURL: import.meta.url,
+    onImport(url) {
+      if (!url.startsWith("file:")) return;
+      const path = fileURLToPath(url);
+      if (!path.split(sep).includes("node_modules")) dependencies.add(path);
+    },
+  })
+    .then(async (module: { readonly default?: unknown }) => {
       if (!isConfig(module.default)) throw new TypeError(`${file} must default-export defineConfig({...})`);
-      return { file, directory: dirname(file), config: module.default };
+      const paths = Object.freeze([...dependencies].sort());
+      const loaded = { file, directory: dirname(file), config: module.default, dependencies: paths };
+      dependencyHashes.set(
+        loaded,
+        new Map(await Promise.all(paths.map(async (path) => [path, await hashFile(path)] as const))),
+      );
+      return loaded;
     })
     .catch((error: unknown) => {
-      configCache.delete(key);
+      if (configCache.get(key) === loading) configCache.delete(key);
       throw error;
     });
   configCache.set(key, loading);

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -7,6 +7,35 @@ import { CONFIG_CACHE_LIMIT, discoverConfig, fromConfig, loadConfig } from "../s
 const fixture = new URL("../../../e2e/postgres/typed-sql.config.ts", import.meta.url);
 
 await describe("typed-sql config", async () => {
+  await it("reloads a transitive helper without an entry edit and coalesces unchanged loads", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "typed-sql-config-dependencies-"));
+    const file = join(directory, "typed-sql.config.mts");
+    const helper = join(directory, "policy.mts");
+    try {
+      await writeFile(helper, 'export const policy = { bigint: "string" };');
+      await writeFile(join(directory, "shared.mts"), 'export { policy } from "./policy.mts";');
+      await writeFile(
+        file,
+        `import original from ${JSON.stringify(fixture.href)};\nimport { policy } from "./shared.mts";\nexport default { ...original, typePolicy: policy };`,
+      );
+      const first = await loadConfig({ file });
+      strict.deepStrictEqual(first.config.typePolicy, { bigint: "string" });
+      strict.ok(first.dependencies?.includes(helper));
+      await writeFile(helper, 'export const policy = { bigint: "number" };');
+      const second = await loadConfig({ file });
+      strict.notStrictEqual(second, first);
+      strict.deepStrictEqual(second.config.typePolicy, { bigint: "number" });
+      const repeated = await Promise.all([loadConfig({ file }), loadConfig({ file })]);
+      strict.ok(repeated.every((loaded) => loaded === second));
+      await rm(helper);
+      await strict.rejects(loadConfig({ file }));
+      await writeFile(helper, 'export const policy = { bigint: "bigint" };');
+      strict.deepStrictEqual((await loadConfig({ file })).config.typePolicy, { bigint: "bigint" });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   await it("loads a TypeScript config and preserves its installed dialect", async () => {
     const loaded = await loadConfig({ file: fixture.pathname });
     strict.strictEqual(loaded.config.dialect.id, "postgres");

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -563,7 +563,11 @@ export class TypedSqlLanguageService {
       this.#settings.schemaPath === undefined
         ? fromConfig(loaded.directory, loaded.config.schema.file)
         : this.#configuredPath(this.#settings.schemaPath);
-    return fileName === resolve(loaded.file) || fileName === resolve(schemaPath);
+    return (
+      fileName === resolve(loaded.file) ||
+      fileName === resolve(schemaPath) ||
+      loaded.dependencies?.includes(fileName) === true
+    );
   }
 
   async close(): Promise<void> {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -763,15 +763,21 @@ client.onNotification("workspace/didChangeWatchedFiles", (params) => {
               ),
             )
           ).filter((change): change is WatchedFileChange => change !== undefined);
-    for (const service of services.values()) service.invalidate();
+    const refresh =
+      changes === undefined ||
+      nativeChanges!.length !== changes.length ||
+      changes.some(({ uri }) => /\/tsconfig[^/]*\.json$/u.test(uri));
+    if (refresh) for (const service of services.values()) service.invalidate();
     if (nativeChanges === undefined || nativeChanges.length > 0) {
       await typescript.sendNotification(
         "workspace/didChangeWatchedFiles",
         nativeChanges === undefined ? params : { ...(isObject(params) ? params : {}), changes: nativeChanges },
       );
     }
-    await refreshOpenDocuments();
-    await resetVirtualDocuments();
+    if (refresh) {
+      await refreshOpenDocuments();
+      await resetVirtualDocuments();
+    }
   });
 });
 

--- a/packages/language-server/test/service.test.ts
+++ b/packages/language-server/test/service.test.ts
@@ -26,6 +26,35 @@ function positionAt(text: string, offset: number): { readonly line: number; read
 }
 
 await describe("typed-sql language service", async () => {
+  await it("watches imported policy helpers and refreshes analysis after dependency-only edits", async () => {
+    const directory = await mkdtemp(join(workspaceDirectory, ".typed-sql-config-watch-"));
+    const config = join(directory, "typed-sql.config.mts");
+    const helper = join(directory, "policy.mts");
+    const watched = new TypedSqlLanguageService(workspaceDirectory, {
+      configPath: config,
+      schemaPath: schemaFile,
+      projectFile,
+      nativePreview: false,
+    });
+    try {
+      await writeFile(helper, 'export const policy = { bigint: "string" };');
+      await writeFile(
+        config,
+        `import original from ${JSON.stringify(pathToFileURL(configFile).href)};\nimport { policy } from "./policy.mts";\nexport default { ...original, typePolicy: policy };`,
+      );
+      const current = document("config-policy.ts");
+      const before = await watched.analysis(current);
+      strict.strictEqual(await watched.handlesWatchedFile(pathToFileURL(helper).href), true);
+      await writeFile(helper, 'export const policy = { bigint: "number" };');
+      watched.invalidate();
+      const after = await watched.analysis(current);
+      strict.notStrictEqual(after?.identity.typePolicyHash, before?.identity.typePolicyHash);
+    } finally {
+      await watched.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   const service = new TypedSqlLanguageService(workspaceDirectory, {
     configPath: configFile,
     schemaPath: schemaFile,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -138,7 +138,7 @@ async function startClient(folder: vscode.WorkspaceFolder): Promise<void> {
     return;
   }
   const watcher = vscode.workspace.createFileSystemWatcher(
-    new vscode.RelativePattern(folder, "**/{typed-sql.config.*,schema.json}"),
+    new vscode.RelativePattern(folder, "**/{typed-sql.config.*,schema.json,*.ts,*.mts,*.cts,*.js,*.mjs,*.cjs,*.json}"),
   );
   const client = new LanguageClient(
     `typed-sql-${folder.index}`,


### PR DESCRIPTION
Changing an imported config helper previously left the effective configuration cached until the entry config changed. Config loading now fingerprints local dependencies and reloads the full module graph in a fresh tsx namespace when any dependency changes; unchanged evaluations are reused.

The language service recognizes dependency file events, and VS Code watches supported helper extensions. Ordinary source-file watcher events are forwarded to TypeScript without rebuilding all SQL analyses; configuration/schema/tsconfig changes refresh them.

Validation: clean build/typecheck, config regression including transitive edits/deletion/recreation, language-service policy-hash refresh, all five config/language-server test files including the packaged server, config coverage (100% lines, 93.02% branches), and a built VSIX whose bundled watcher was inspected. Patch Changesets included.

Closes #112
