### PR TITLE
refactor(core): share prepared query registration across adapters

### DIFF
--- a/.changeset/shared-prepared-registration.md
+++ b/.changeset/shared-prepared-registration.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/core": minor
+"@typed-sql/postgres": patch
+"@typed-sql/mysql": patch
+"@typed-sql/sqlite": patch
+---
+
+Share grammar-neutral prepared-query registration and ownership checks while retaining each adapter's statement naming, capacity, and public factory types.

--- a/docs/extending/custom-grammars.md
+++ b/docs/extending/custom-grammars.md
@@ -23,6 +23,8 @@ A grammar package should:
 
 Installing the grammar must not install a driver. Driver adapters load the application dependency lazily and return an actionable installation error when it is absent.
 
+Execution adapters can reuse `registerPreparedQuery` from `@typed-sql/core` for prepared-factory registration, query ownership, and render-variant checks. The adapter supplies its statement metadata, optional capacity policy, and logical owner-name mapping. Physical statement names and database-specific limits remain adapter responsibilities.
+
 ## Minimal implementation
 
 ```ts

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export type {
   TransactionOperationStart,
 } from "./observation.js";
 export { databaseErrorCompletion, observeQueryStream, startDatabaseObservation } from "./observation.js";
+export { registerPreparedQuery } from "./prepared.js";
 export type {
   ControlledQueryExecutor,
   Database,

--- a/packages/core/src/prepared.ts
+++ b/packages/core/src/prepared.ts
@@ -1,0 +1,56 @@
+import {
+  PreparedQueryRenderCache,
+  type PreparedQueryRenderVariant,
+  type Query,
+  type RenderedQuery,
+  type SqlRenderer,
+} from "./query.js";
+
+/** Grammar-neutral registration and query ownership; adapters supply naming and capacity policy. */
+export function registerPreparedQuery<
+  Arguments extends readonly unknown[],
+  Row,
+  Params extends readonly unknown[],
+  Metadata extends { readonly statementName: string; readonly rendered: RenderedQuery },
+>(options: {
+  readonly state: {
+    readonly variantCapacity: number;
+    readonly statements: Map<string, { readonly variants: PreparedQueryRenderCache }>;
+    readonly queries: WeakMap<object, Metadata>;
+  };
+  readonly renderer: SqlRenderer;
+  readonly statementName: string;
+  readonly factory: (...args: Arguments) => Query<Row, Params>;
+  readonly metadata: (variant: PreparedQueryRenderVariant) => Metadata;
+  readonly ownerName?: (metadata: Metadata) => string;
+  readonly capacity?: { readonly maximum: number; readonly message: string };
+}): ((...args: Arguments) => Query<Row, Params>) & { readonly statementName: string } {
+  const { state, renderer, statementName, factory } = options;
+  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0"))
+    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
+  if (state.statements.has(statementName))
+    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
+  if (options.capacity !== undefined && state.statements.size >= options.capacity.maximum)
+    throw new RangeError(options.capacity.message);
+  const statement = { variants: new PreparedQueryRenderCache(state.variantCapacity) };
+  state.statements.set(statementName, statement);
+  const prepared = (...args: Arguments): Query<Row, Params> => {
+    const query = factory(...args);
+    const existing = state.queries.get(query);
+    if (existing !== undefined) {
+      if ((options.ownerName?.(existing) ?? existing.statementName) !== statementName)
+        throw new TypeError(
+          `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
+        );
+      return query;
+    }
+    const variant = statement.variants.bind(query, renderer);
+    if (variant === undefined)
+      throw new TypeError(
+        `Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text and structure`,
+      );
+    state.queries.set(query, options.metadata(variant));
+    return query;
+  };
+  return Object.freeze(Object.assign(prepared, { statementName }));
+}

--- a/packages/core/test/prepared.test.ts
+++ b/packages/core/test/prepared.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, strict } from "poku";
+import { type PreparedQueryRenderCache, type RenderedQuery, registerPreparedQuery, sql } from "../src/index.js";
+
+interface Metadata {
+  readonly statementName: string;
+  readonly rendered: RenderedQuery;
+  readonly owner?: string;
+}
+const renderer = { placeholder: () => "?", quoteIdentifier: (name: string) => name };
+const state = () => ({
+  variantCapacity: 1,
+  statements: new Map<string, { readonly variants: PreparedQueryRenderCache }>(),
+  queries: new WeakMap<object, Metadata>(),
+});
+
+await describe("prepared-query registration", async () => {
+  await it("retains query identity, parameter values, adapter metadata, and first-owner rules", () => {
+    const registry = state();
+    const query = sql`SELECT ${1}`;
+    let metadataCalls = 0;
+    const prepared = registerPreparedQuery({
+      state: registry,
+      renderer,
+      statementName: "logical",
+      factory: () => query,
+      ownerName: (metadata) => metadata.owner!,
+      metadata: ({ rendered }) => {
+        metadataCalls += 1;
+        return { statementName: "physical", owner: "logical", rendered };
+      },
+    });
+    strict.strictEqual(prepared(), query);
+    strict.strictEqual(prepared(), query);
+    strict.strictEqual(prepared.statementName, "logical");
+    strict.strictEqual(metadataCalls, 1);
+    strict.ok(Object.isFrozen(prepared));
+    strict.deepStrictEqual(registry.queries.get(query)?.rendered.values, [1]);
+    const other = registerPreparedQuery({
+      state: registry,
+      renderer,
+      statementName: "other",
+      factory: () => query,
+      metadata: ({ rendered }) => ({ statementName: "other", rendered }),
+    });
+    strict.throws(other, /cannot use both prepared statement "physical" and "other"/);
+  });
+
+  await it("validates registration before reserving names and rejects changed SQL structures", () => {
+    const registry = state();
+    let expanded = false;
+    const options = {
+      state: registry,
+      renderer,
+      statementName: "query",
+      factory: () => (expanded ? sql`SELECT 2` : sql`SELECT 1`),
+      metadata: ({ rendered }: { readonly rendered: RenderedQuery }) => ({ statementName: "query", rendered }),
+    };
+    for (const statementName of ["", "bad\0name"])
+      strict.throws(() => registerPreparedQuery({ ...options, statementName }), /non-empty/);
+    strict.strictEqual(registry.statements.size, 0);
+    const prepared = registerPreparedQuery(options);
+    prepared();
+    strict.throws(() => registerPreparedQuery(options), /already registered/);
+    strict.throws(
+      () => registerPreparedQuery({ ...options, statementName: "second", capacity: { maximum: 1, message: "full" } }),
+      /full/,
+    );
+    expanded = true;
+    strict.throws(prepared, /same SQL text and structure/);
+    const fixed = sql`SELECT 3`;
+    const reusable = registerPreparedQuery({
+      ...options,
+      state: state(),
+      factory: () => fixed,
+      capacity: { maximum: 1, message: "full" },
+    });
+    strict.strictEqual(reusable(), reusable());
+  });
+});

--- a/packages/mysql/src/prepared.ts
+++ b/packages/mysql/src/prepared.ts
@@ -3,6 +3,7 @@ import {
   PreparedQueryRenderCache,
   type Query,
   type RenderedQuery,
+  registerPreparedQuery,
   type SqlRenderer,
 } from "@typed-sql/core";
 
@@ -49,51 +50,21 @@ export function createMySqlPreparedQueryState(
   };
 }
 
-function validateStatementName(statementName: string): void {
-  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0")) {
-    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
-  }
-}
-
 export function prepareMySqlQuery<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
   state: MySqlPreparedQueryState,
   renderer: SqlRenderer,
   statementName: string,
   factory: (...args: Arguments) => Query<Row, Params>,
 ): MySqlPreparedQueryFactory<Arguments, Row, Params> {
-  validateStatementName(statementName);
-  if (state.statements.has(statementName)) {
-    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
-  }
-  if (state.statements.size >= state.capacity) {
-    throw new RangeError(
-      `MySQL prepared statement limit of ${state.capacity} has been reached; reuse an existing prepared factory or increase preparedStatementLimit`,
-    );
-  }
-
-  const statement: PreparedStatement = { variants: new PreparedQueryRenderCache(state.variantCapacity) };
-  state.statements.set(statementName, statement);
-
-  const prepared = (...args: Arguments): Query<Row, Params> => {
-    const query = factory(...args);
-    const existing = state.queries.get(query);
-    if (existing !== undefined && existing.statementName !== statementName) {
-      throw new TypeError(
-        `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
-      );
-    }
-
-    let rendered = existing?.rendered;
-    if (rendered === undefined) rendered = statement.variants.bind(query, renderer)?.rendered;
-    if (rendered === undefined) {
-      throw new TypeError(
-        `Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text and structure`,
-      );
-    }
-
-    if (existing === undefined) state.queries.set(query, { statementName, rendered });
-    return query;
-  };
-
-  return Object.freeze(Object.assign(prepared, { statementName }));
+  return registerPreparedQuery({
+    state,
+    renderer,
+    statementName,
+    factory,
+    metadata: (variant) => ({ statementName, rendered: variant.rendered }),
+    capacity: {
+      maximum: state.capacity,
+      message: `MySQL prepared statement limit of ${state.capacity} has been reached; reuse an existing prepared factory or increase preparedStatementLimit`,
+    },
+  });
 }

--- a/packages/postgres/src/prepared.ts
+++ b/packages/postgres/src/prepared.ts
@@ -4,6 +4,7 @@ import {
   PreparedQueryRenderCache,
   type Query,
   type RenderedQuery,
+  registerPreparedQuery,
   type SqlRenderer,
 } from "@typed-sql/core";
 
@@ -50,55 +51,22 @@ function physicalStatementName(statementName: string, text: string, primary: boo
   return `tsqlv_${fingerprint}`;
 }
 
-function validateStatementName(statementName: string): void {
-  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0")) {
-    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
-  }
-}
-
 export function preparePostgresQuery<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
   state: PostgresPreparedQueryState,
   renderer: SqlRenderer,
   statementName: string,
   factory: (...args: Arguments) => Query<Row, Params>,
 ): PostgresPreparedQueryFactory<Arguments, Row, Params> {
-  validateStatementName(statementName);
-  if (state.statements.has(statementName)) {
-    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
-  }
-
-  const statement: PreparedStatement = { variants: new PreparedQueryRenderCache(state.variantCapacity) };
-  state.statements.set(statementName, statement);
-
-  const prepared = (...args: Arguments): Query<Row, Params> => {
-    const query = factory(...args);
-    const existing = state.queries.get(query);
-    if (existing !== undefined && existing.logicalStatementName !== statementName) {
-      throw new TypeError(
-        `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
-      );
-    }
-
-    let rendered = existing?.rendered;
-    let physicalName = existing?.statementName;
-    if (rendered === undefined) {
-      const variant = statement.variants.bind(query, renderer);
-      rendered = variant?.rendered;
-      if (variant !== undefined) {
-        physicalName = physicalStatementName(statementName, variant.rendered.text, variant.primary);
-      }
-    }
-    if (rendered === undefined || physicalName === undefined) {
-      throw new TypeError(
-        `Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text and structure`,
-      );
-    }
-
-    if (existing === undefined) {
-      state.queries.set(query, { logicalStatementName: statementName, statementName: physicalName, rendered });
-    }
-    return query;
-  };
-
-  return Object.freeze(Object.assign(prepared, { statementName }));
+  return registerPreparedQuery({
+    state,
+    renderer,
+    statementName,
+    factory,
+    ownerName: (metadata: PostgresPreparedQueryMetadata) => metadata.logicalStatementName,
+    metadata: (variant) => ({
+      logicalStatementName: statementName,
+      statementName: physicalStatementName(statementName, variant.rendered.text, variant.primary),
+      rendered: variant.rendered,
+    }),
+  });
 }

--- a/packages/sqlite/src/prepared.ts
+++ b/packages/sqlite/src/prepared.ts
@@ -3,6 +3,7 @@ import {
   PreparedQueryRenderCache,
   type Query,
   type RenderedQuery,
+  registerPreparedQuery,
   type SqlRenderer,
 } from "@typed-sql/core";
 
@@ -41,46 +42,17 @@ export function createSqlitePreparedQueryState(
   };
 }
 
-function validateStatementName(statementName: string): void {
-  if (typeof statementName !== "string" || statementName.length === 0 || statementName.includes("\0")) {
-    throw new TypeError("Prepared statement names must be non-empty and cannot contain NUL");
-  }
-}
-
 export function prepareSqliteQuery<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(
   state: SqlitePreparedQueryState,
   renderer: SqlRenderer,
   statementName: string,
   factory: (...args: Arguments) => Query<Row, Params>,
 ): SqlitePreparedQueryFactory<Arguments, Row, Params> {
-  validateStatementName(statementName);
-  if (state.statements.has(statementName)) {
-    throw new TypeError(`Prepared statement name ${JSON.stringify(statementName)} is already registered`);
-  }
-
-  const statement: PreparedStatement = { variants: new PreparedQueryRenderCache(state.variantCapacity) };
-  state.statements.set(statementName, statement);
-
-  const prepared = (...args: Arguments): Query<Row, Params> => {
-    const query = factory(...args);
-    const existing = state.queries.get(query);
-    if (existing !== undefined && existing.statementName !== statementName) {
-      throw new TypeError(
-        `A query cannot use both prepared statement ${JSON.stringify(existing.statementName)} and ${JSON.stringify(statementName)}`,
-      );
-    }
-
-    let rendered = existing?.rendered;
-    if (rendered === undefined) rendered = statement.variants.bind(query, renderer)?.rendered;
-    if (rendered === undefined) {
-      throw new TypeError(
-        `Prepared statement ${JSON.stringify(statementName)} must always render the same SQL text and structure`,
-      );
-    }
-
-    if (existing === undefined) state.queries.set(query, { statementName, rendered });
-    return query;
-  };
-
-  return Object.freeze(Object.assign(prepared, { statementName }));
+  return registerPreparedQuery({
+    state,
+    renderer,
+    statementName,
+    factory,
+    metadata: (variant) => ({ statementName, rendered: variant.rendered }),
+  });
 }

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -890,6 +890,7 @@ const expectedRuntimeExports = {
     "queryRoute",
     "queryResultValidationSource",
     "redactDebugContext",
+    "registerPreparedQuery",
     "QUERY_SEMANTICS_VERSION",
     "renderQuery",
     "resolveDialectCapabilityStates",


### PR DESCRIPTION
## Summary

Closes #117.

- Share registration, name validation, variant binding and query ownership in core.
- Keep PostgreSQL physical names, MySQL capacity policy and all adapter APIs unchanged.
- Add an additive adapter-author helper, documentation and appropriate minor/patch Changesets.

## Verification

- Build and typecheck pass.
- Core and all three grammar coverage gates pass; the new helper has 100% coverage.
- Runtime regression tests, public API contracts, isolated packed-consumer tests and the performance gate pass.
- No dependency major upgrades, release publication or SQL semantic changes.
