### PR TITLE
fix(schema): stabilize hash collation with legacy compatibility

### DIFF
--- a/.changeset/portable-schema-hashes.md
+++ b/.changeset/portable-schema-hashes.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/schema": minor
+"@typed-sql/compiler": patch
+"@typed-sql/postgres": patch
+"@typed-sql/sqlite": patch
+---
+
+Make schema and policy hash ordering independent of the host locale, including unordered v2 semantic arrays. Add content-checking compatibility helpers so legacy hashes remain accepted in their originating locale.

--- a/docs/guides/schema-snapshots.md
+++ b/docs/guides/schema-snapshots.md
@@ -28,6 +28,15 @@ The configured provider introspects the selected schemas and writes deterministi
 
 Commit the snapshot. It gives application code, CI, and editors the same catalog contract and makes schema changes reviewable without database access.
 
+Schema and type-policy hashing uses explicit English collation, with code-unit ordering to break
+Unicode collation ties, rather than the operating system's default locale. Unordered constraint,
+index, and routine collections follow the same policy. Existing English-locale hashes are preserved
+except for previously ambiguous collation ties. Legacy hashes remain accepted when verified in their
+originating locale; regenerate legacy snapshots and their related manifest/proof artifacts there
+before moving them between locales. Compatibility checking always hashes the content and rejects
+changes; a legacy hash is not a validation bypass. Adapter authors can use `matchesSchemaHash` and
+`matchesTypePolicyHash` from `@typed-sql/schema` for this compatibility check.
+
 Inspect how that evidence changes grammar support without contacting the database:
 
 ```sh

--- a/packages/compiler/src/compatibility.ts
+++ b/packages/compiler/src/compatibility.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { SchemaSnapshot as CoreSchemaSnapshot, QueryDependency, SourceRange } from "@typed-sql/core";
 import {
-  calculateSchemaHash,
+  matchesSchemaHash,
   parseSchemaSnapshot,
   type RelationSnapshot,
   type RoutineSnapshot,
@@ -1215,11 +1215,9 @@ function validateInputs(options: AnalyzeSchemaCompatibilityOptions): void {
   ) {
     throw new TypeError("Compatibility snapshots and manifests must use the same dialect");
   }
-  const beforeHash = calculateSchemaHash(options.before);
-  const afterHash = calculateSchemaHash(options.after);
-  if (options.beforeManifest.schemaHash !== beforeHash)
+  if (!matchesSchemaHash(options.before, options.beforeManifest.schemaHash))
     throw new TypeError("Before manifest is stale for the before snapshot");
-  if (options.afterManifest.schemaHash !== afterHash)
+  if (!matchesSchemaHash(options.after, options.afterManifest.schemaHash))
     throw new TypeError("After manifest is stale for the after snapshot");
 }
 

--- a/packages/postgres/src/runtime-compatibility.ts
+++ b/packages/postgres/src/runtime-compatibility.ts
@@ -1,7 +1,7 @@
 import type { DialectServerEvidence } from "@typed-sql/core";
 import {
-  calculateSchemaHash,
-  calculateTypePolicyHash,
+  matchesSchemaHash,
+  matchesTypePolicyHash,
   parseSchemaSnapshot,
   type SchemaSnapshotV2,
 } from "@typed-sql/schema";
@@ -95,10 +95,10 @@ export function validatePostgresRuntimeCompatibility(
     );
   }
   if (snapshot.metadata !== undefined) {
-    if (snapshot.metadata.schemaHash !== calculateSchemaHash(snapshot)) {
+    if (!matchesSchemaHash(snapshot, snapshot.metadata.schemaHash)) {
       throw new PostgresRuntimeCompatibilityError("artifact", "PostgreSQL snapshot schema identity is corrupt");
     }
-    if (snapshot.metadata.typePolicyHash !== calculateTypePolicyHash(policy ?? {})) {
+    if (!matchesTypePolicyHash(policy ?? {}, snapshot.metadata.typePolicyHash)) {
       throw new PostgresRuntimeCompatibilityError(
         "type-policy",
         "PostgreSQL snapshot type-policy evidence does not match the runtime codec policy",

--- a/packages/schema/src/generator.ts
+++ b/packages/schema/src/generator.ts
@@ -9,6 +9,7 @@ import type {
   SchemaSnapshotV2,
 } from "./model.js";
 import { LEGACY_SCHEMA_FORMAT_VERSION, SCHEMA_FORMAT_VERSION } from "./model.js";
+import { compareLegacySchemaKeys, compareSchemaKeys } from "./ordering.js";
 import { upgradeSchemaSnapshotV1 } from "./v1/upgrade.js";
 import { parseSchemaSnapshotV2, schemaSnapshotV2Envelope } from "./v2/codec.js";
 
@@ -38,18 +39,22 @@ export interface SchemaHashInput {
 }
 
 export function canonicalizeSchemaValue(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalizeSchemaValue);
+  return canonicalize(value, compareSchemaKeys);
+}
+
+function canonicalize(value: unknown, compare: (left: string, right: string) => number): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item, compare));
   if (typeof value !== "object" || value === null) return value;
   return Object.fromEntries(
     Object.entries(value)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, item]) => [key, canonicalizeSchemaValue(item)]),
+      .sort(([a], [b]) => compare(a, b))
+      .map(([key, item]) => [key, canonicalize(item, compare)]),
   );
 }
 
-const hash = (value: unknown): string =>
+const hash = (value: unknown, compare = compareSchemaKeys): string =>
   createHash("sha256")
-    .update(JSON.stringify(canonicalizeSchemaValue(value)))
+    .update(JSON.stringify(canonicalize(value, compare)))
     .digest("hex");
 
 /** One-way identity for semantically relevant expressions that must not be stored verbatim. */
@@ -57,7 +62,7 @@ export function fingerprintSchemaExpression(expression: string): string {
   return `sha256:${createHash("sha256").update(expression).digest("hex")}`;
 }
 
-function hashableSchema(schema: SchemaHashInput): unknown {
+function hashableSchema(schema: SchemaHashInput, compare = compareSchemaKeys): unknown {
   if (schema.formatVersion === SCHEMA_FORMAT_VERSION) {
     if (
       schema.dialectVersion === undefined ||
@@ -69,7 +74,7 @@ function hashableSchema(schema: SchemaHashInput): unknown {
     ) {
       throw new TypeError("Schema format 2 hashing requires the complete v2 envelope");
     }
-    const normalized = parseSchemaSnapshotV2(schemaSnapshotV2Envelope(schema as SchemaSnapshotV2));
+    const normalized = parseSchemaSnapshotV2(schemaSnapshotV2Envelope(schema as SchemaSnapshotV2), compare);
     const { metadata: _metadata, ...envelope } = schemaSnapshotV2Envelope(normalized);
     return envelope;
   }
@@ -86,6 +91,19 @@ export function calculateSchemaHash(schema: SchemaHashInput): string {
 
 export function calculateTypePolicyHash(policy: unknown): string {
   return hash(policy);
+}
+
+/** Accept new portable hashes and legacy hashes valid under this process's locale. */
+export function matchesSchemaHash(schema: SchemaHashInput, expected: string): boolean {
+  return (
+    calculateSchemaHash(schema) === expected ||
+    hash(hashableSchema(schema, compareLegacySchemaKeys), compareLegacySchemaKeys) === expected
+  );
+}
+
+/** Legacy fallback validates the same policy; it never bypasses content checking. */
+export function matchesTypePolicyHash(policy: unknown, expected: string): boolean {
+  return calculateTypePolicyHash(policy) === expected || hash(policy, compareLegacySchemaKeys) === expected;
 }
 
 export interface SchemaDriftResult {
@@ -188,8 +206,8 @@ export function checkSchemaDrift(
           } satisfies SchemaSnapshotV1);
   const actualSchemaHash = calculateSchemaHash(comparableCurrent);
   const actualTypePolicyHash = calculateTypePolicyHash(policy);
-  const schemaChanged = generated.metadata.schemaHash !== actualSchemaHash;
-  const typePolicyChanged = generated.metadata.typePolicyHash !== actualTypePolicyHash;
+  const schemaChanged = !matchesSchemaHash(comparableCurrent, generated.metadata.schemaHash);
+  const typePolicyChanged = !matchesTypePolicyHash(policy, generated.metadata.typePolicyHash);
   return {
     drifted: schemaChanged || typePolicyChanged,
     schemaChanged,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,6 +11,8 @@ export {
   checkSchemaDrift,
   fingerprintSchemaExpression,
   generateSchemaPackage,
+  matchesSchemaHash,
+  matchesTypePolicyHash,
   serializeSchemaSnapshot,
 } from "./generator.js";
 export {

--- a/packages/schema/src/ordering.ts
+++ b/packages/schema/src/ordering.ts
@@ -1,0 +1,6 @@
+// Preserve historical English ordering while removing the host's locale from artifact identity.
+const collator = new Intl.Collator("en");
+export const compareSchemaKeys = (left: string, right: string): number =>
+  collator.compare(left, right) || (left < right ? -1 : left > right ? 1 : 0);
+
+export const compareLegacySchemaKeys = (left: string, right: string): number => left.localeCompare(right);

--- a/packages/schema/src/v2/codec.ts
+++ b/packages/schema/src/v2/codec.ts
@@ -24,6 +24,7 @@ import type {
   TableSnapshot,
   TypeSnapshot,
 } from "../model.js";
+import { compareSchemaKeys } from "../ordering.js";
 import { SCHEMA_FORMAT_VERSION } from "./model.js";
 
 type RecordValue = Readonly<Record<string, unknown>>;
@@ -391,7 +392,11 @@ function parseIndex(value: unknown, path: string): IndexSnapshot {
   };
 }
 
-function parseRelation(value: unknown, path: string): RelationSnapshot {
+function parseRelation(
+  value: unknown,
+  path: string,
+  compare: (left: string, right: string) => number,
+): RelationSnapshot {
   const source = record(value, path);
   allowed(source, ["schema", "name", "kind", "columns", "constraints", "indexes", "capabilities", "extension"], path);
   const columns = objectMap(source.columns, `${path}.columns`, parseColumn);
@@ -401,16 +406,16 @@ function parseRelation(value: unknown, path: string): RelationSnapshot {
   if (!Array.isArray(source.indexes)) throw new TypeError(`${path}.indexes must be an array`);
   const constraints = source.constraints
     .map((item, index) => parseConstraint(item, `${path}.constraints[${index}]`))
-    .sort((left, right) => left.identity.localeCompare(right.identity));
+    .sort((left, right) => compare(left.identity, right.identity));
   const indexes = source.indexes
     .map((item, index) => parseIndex(item, `${path}.indexes[${index}]`))
-    .sort((left, right) => left.identity.localeCompare(right.identity));
+    .sort((left, right) => compare(left.identity, right.identity));
   const capabilities =
     source.capabilities === undefined
       ? undefined
       : Object.fromEntries(
           Object.entries(record(source.capabilities, `${path}.capabilities`))
-            .sort(([left], [right]) => left.localeCompare(right))
+            .sort(([left], [right]) => compare(left, right))
             .map(([key, item]) => {
               if (
                 typeof item !== "string" &&
@@ -691,7 +696,7 @@ function legacyViews(
 }
 
 /** Parses a strict canonical v2 envelope and adds transitional v1 resolver views in memory. */
-export function parseSchemaSnapshotV2(value: unknown): SchemaSnapshotV2 {
+export function parseSchemaSnapshotV2(value: unknown, compare = compareSchemaKeys): SchemaSnapshotV2 {
   const source = record(value, "schema");
   allowed(
     source,
@@ -714,7 +719,7 @@ export function parseSchemaSnapshotV2(value: unknown): SchemaSnapshotV2 {
   }
   const namespaces = objectMap(source.namespaces, "schema.namespaces", parseNamespace);
   const types = objectMap(source.types, "schema.types", parseType);
-  const relations = objectMap(source.relations, "schema.relations", parseRelation);
+  const relations = objectMap(source.relations, "schema.relations", (item, path) => parseRelation(item, path, compare));
   const routineSource = record(source.routines, "schema.routines");
   const routines = Object.fromEntries(
     Object.keys(routineSource)
@@ -726,7 +731,7 @@ export function parseSchemaSnapshotV2(value: unknown): SchemaSnapshotV2 {
           key,
           overloads
             .map((item, index) => parseRoutine(item, `schema.routines.${key}[${index}]`))
-            .sort((left, right) => left.identity.localeCompare(right.identity)),
+            .sort((left, right) => compare(left.identity, right.identity)),
         ];
       }),
   );

--- a/packages/schema/test/portable-hashes.test.ts
+++ b/packages/schema/test/portable-hashes.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { describe, it, strict } from "poku";
+import { canonicalizeSchemaValue } from "../src/index.js";
+
+await describe("portable artifact hashes", async () => {
+  await it("uses explicit collation with a total ordering for equivalent Unicode keys", () => {
+    strict.deepStrictEqual(
+      canonicalizeSchemaValue({ é: 1, "e\u0301": 2, z: 3 }),
+      canonicalizeSchemaValue({ z: 3, "e\u0301": 2, é: 1 }),
+    );
+    strict.strictEqual(
+      JSON.stringify(canonicalizeSchemaValue({ é: 1, "e\u0301": 2 })),
+      JSON.stringify(canonicalizeSchemaValue({ "e\u0301": 2, é: 1 })),
+    );
+  });
+
+  await it("keeps new identities portable and verifies old identities without accepting changed content", () => {
+    const moduleUrl = new URL("../src/index.ts", import.meta.url).href;
+    const codecUrl = new URL("../src/v2/codec.ts", import.meta.url).href;
+    const script = `
+      import { createHash } from 'node:crypto';
+      import assert from 'node:assert/strict';
+      import { calculateSchemaHash, calculateTypePolicyHash, matchesSchemaHash, matchesTypePolicyHash,
+        checkSchemaDrift, serializeSchemaSnapshot, upgradeSchemaSnapshotV1 } from ${JSON.stringify(moduleUrl)};
+      import { parseSchemaSnapshotV2, schemaSnapshotV2Envelope } from ${JSON.stringify(codecUrl)};
+      const canonical = value => Array.isArray(value) ? value.map(canonical) : value && typeof value === 'object'
+        ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([k,v]) => [k, canonical(v)])) : value;
+      const legacyHash = value => createHash('sha256').update(JSON.stringify(canonical(value))).digest('hex');
+      const policy = { z: { z: 1, ä: 2 }, ä: [1, 2] };
+      const v1 = { formatVersion: 1, dialect: 'test', tables: {}, enums: { z: ['z'], ä: ['ä'] } };
+      const base = upgradeSchemaSnapshotV1(v1);
+      const index = identity => ({ name: identity, identity, unique: false, columns: [], predicate: 'none', valid: true });
+      const schema = { ...base, relations: { t: { name: 't', kind: 'table', columns: {}, constraints: [], indexes: [index('z'), index('ä')] } } };
+      const legacy = legacyHash(schemaSnapshotV2Envelope(parseSchemaSnapshotV2(schemaSnapshotV2Envelope(schema), (a,b) => a.localeCompare(b))));
+      assert(matchesSchemaHash(v1, legacyHash(v1)));
+      assert(matchesSchemaHash(schema, legacy));
+      assert(matchesSchemaHash(schema, calculateSchemaHash(schema)));
+      assert(!matchesSchemaHash({ ...schema, dialect: 'other' }, legacy));
+      assert(matchesTypePolicyHash(policy, legacyHash(policy)));
+      assert(matchesTypePolicyHash(policy, calculateTypePolicyHash(policy)));
+      assert(!matchesTypePolicyHash({}, legacyHash(policy)));
+      assert.equal(checkSchemaDrift({ ...schema, metadata: { generatorVersion: 'legacy', schemaHash: legacy, typePolicyHash: legacyHash(policy) } }, schema, policy).drifted, false);
+      process.stdout.write(JSON.stringify({ schema: calculateSchemaHash(schema), policy: calculateTypePolicyHash(policy), serialized: serializeSchemaSnapshot(schema), legacy }));
+    `;
+    const run = (locale: string) =>
+      JSON.parse(
+        execFileSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+          encoding: "utf8",
+          env: { ...process.env, LANG: locale, LC_ALL: locale },
+        }),
+      ) as { schema: string; policy: string; serialized: string; legacy: string };
+    const english = run("en_US.UTF-8");
+    const swedish = run("sv_SE.UTF-8");
+    strict.notStrictEqual(english.legacy, swedish.legacy);
+    strict.strictEqual(english.schema, swedish.schema);
+    strict.strictEqual(english.policy, swedish.policy);
+    strict.strictEqual(english.serialized, swedish.serialized);
+  });
+});

--- a/packages/sqlite/src/node-sqlite.ts
+++ b/packages/sqlite/src/node-sqlite.ts
@@ -1,7 +1,7 @@
 import type { PathLike } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { DialectServerEvidence } from "@typed-sql/core";
-import { calculateTypePolicyHash, type SchemaSnapshotV2 } from "@typed-sql/schema";
+import { matchesTypePolicyHash, type SchemaSnapshotV2 } from "@typed-sql/schema";
 import { sqliteServerEvidence } from "./capabilities.js";
 import { type SqliteQueryable, SqliteSchemaProvider } from "./provider.js";
 import { createSqliteDatabase, type SqliteConnectionLike, type SqliteDatabase } from "./runtime.js";
@@ -199,7 +199,7 @@ function validateSnapshotCompatibility(
       "SQLite snapshot compile options do not match the opened connection",
     );
   }
-  if (snapshot.metadata !== undefined && snapshot.metadata.typePolicyHash !== calculateTypePolicyHash(policy ?? {})) {
+  if (snapshot.metadata !== undefined && !matchesTypePolicyHash(policy ?? {}, snapshot.metadata.typePolicyHash)) {
     throw new NodeSqliteCompatibilityError(
       "type-policy",
       "SQLite snapshot type-policy evidence does not match the Node adapter policy",

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -1010,6 +1010,8 @@ const expectedRuntimeExports = {
     "defineSchemaSnapshotV2",
     "fingerprintSchemaExpression",
     "generateSchemaPackage",
+    "matchesSchemaHash",
+    "matchesTypePolicyHash",
     "loadGeneratedSchemaSnapshot",
     "loadSchemaSnapshot",
     "loadTypePolicy",


### PR DESCRIPTION
## Summary

Closes #111.

- Use explicit English collation with a code-unit tie-breaker for portable canonicalization, including v2 semantic arrays.
- Preserve existing English hashes and accept legacy hashes under their original locale through content-checking match helpers.
- Apply compatibility checking to drift, PostgreSQL/SQLite runtime policy validation and compiler manifest/snapshot matching.
- Document legacy artifact regeneration and add minor/patch Changesets; formats and hash encoding do not change.

## Verification

- Clean build and seven schema/compiler/runtime regression test files pass.
- Cross-process English/Swedish tests verify matching new hashes and serialization, legacy validation, and rejection of changed content.
- Existing canonical hash golden fixture remains unchanged.
