### PR TITLE
ci: require live database and packaged editor evidence before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           fail-on-severity: high
 
   quality:
+    # The protected quality check cannot pass without representative runtime/artifact evidence.
+    needs: [packed-real-databases, editor-artifacts]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -307,7 +309,6 @@ jobs:
           retention-days: 14
 
   packed-real-databases:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -452,7 +453,6 @@ jobs:
           retention-days: 14
 
   editor-artifacts:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -12,11 +12,9 @@ await describe("CI evidence lanes", async () => {
       "typescript-editor-matrix",
       "postgres-e2e",
       "mysql-e2e",
-      "packed-real-databases",
       "examples-e2e",
       "sqlite-node-matrix",
       "sqlite-language-matrix",
-      "editor-artifacts",
     ]) {
       const section = workflow.slice(workflow.indexOf(`  ${job}:`));
       strict.ok(
@@ -36,6 +34,19 @@ await describe("CI evidence lanes", async () => {
     ]) {
       strict.ok(workflow.includes(evidence), `CI lane lost ${evidence}`);
     }
+  });
+
+  await it("requires representative live database and packaged editor checks before protected quality", async () => {
+    const workflow = await readFile(join(workspace, ".github/workflows/ci.yml"), "utf8");
+    for (const job of ["packed-real-databases", "editor-artifacts"]) {
+      const start = workflow.indexOf(`  ${job}:\n`);
+      strict.ok(start >= 0);
+      const end = workflow.indexOf("\n  ", start + `  ${job}:\n`.length);
+      strict.ok(!workflow.slice(start, end).includes("if:"), `${job} must not exclude pull requests`);
+    }
+    strict.ok(workflow.includes("needs: [packed-real-databases, editor-artifacts]"));
+    strict.ok(workflow.includes("pnpm e2e:packed"));
+    strict.ok(workflow.includes("pnpm editor:artifacts:smoke"));
   });
 
   await it("writes only structured identifiers and environment-owned run metadata", async () => {

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -41,8 +41,8 @@ await describe("CI evidence lanes", async () => {
     for (const job of ["packed-real-databases", "editor-artifacts"]) {
       const start = workflow.indexOf(`  ${job}:\n`);
       strict.ok(start >= 0);
-      const end = workflow.indexOf("\n  ", start + `  ${job}:\n`.length);
-      strict.ok(!workflow.slice(start, end).includes("if:"), `${job} must not exclude pull requests`);
+      const section = workflow.slice(start).split(/\n(?=  \S)/u)[0]!;
+      strict.ok(!/^    if:/mu.test(section), `${job} must not exclude pull requests`);
     }
     strict.ok(workflow.includes("needs: [packed-real-databases, editor-artifacts]"));
     strict.ok(workflow.includes("pnpm e2e:packed"));


### PR DESCRIPTION
## Summary

Closes #119.

- Run the existing packed PostgreSQL/MySQL/SQLite acceptance lane on pull requests.
- Run packaged language-server, VSIX, Zed Rust/WASM and artifact smoke verification on pull requests.
- Make the protected quality job depend on these two lanes, so a failed or unfinished runtime/artifact check cannot be bypassed by a green source-only check.
- Keep full database-version, SQL-mode, Node/editor, SQLite and example matrices outside pull requests.

## Verification

CI lane contracts verify the policy. This PR itself must pass both real-database and packaged editor lanes before quality and merge; no branch-protection bypass or weakened budget.
