### PR TITLE
test: share deferred fixtures and verify CI evidence behavior

### DIFF
--- a/packages/mysql/test/execute-lifecycle.test.ts
+++ b/packages/mysql/test/execute-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { DatabaseObserver, DatabaseOperationEnd, DatabaseOperationStart, StandardSchemaV1 } from "@typed-sql/core";
 import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
+import { type Deferred, deferred } from "../../../test/helpers/deferred.js";
 import { mySqlServerEvidence } from "../src/capabilities.js";
 import {
   createMySqlDatabase,
@@ -12,22 +13,6 @@ import {
   type MySqlTransaction,
   MySqlWarningError,
 } from "../src/runtime.js";
-
-interface Deferred<Value> {
-  readonly promise: Promise<Value>;
-  reject(reason: unknown): void;
-  resolve(value: Value): void;
-}
-
-function deferred<Value>(): Deferred<Value> {
-  let resolve!: (value: Value) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
 
 interface BlockedExecute {
   readonly result: Deferred<MySqlExecutionResult>;

--- a/packages/postgres/test/pipeline.test.ts
+++ b/packages/postgres/test/pipeline.test.ts
@@ -8,6 +8,7 @@ import {
   sql,
 } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
+import { type Deferred, deferred } from "../../../test/helpers/deferred.js";
 import {
   createPostgresDatabase,
   type PostgresClientLike,
@@ -20,29 +21,13 @@ type Equal<Left, Right> =
   (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2 ? true : false;
 type Assert<Value extends true> = Value;
 
-interface DeferredResult {
-  readonly promise: Promise<PostgresQueryResult>;
-  readonly reject: (error: Error) => void;
-  readonly resolve: (result: PostgresQueryResult) => void;
-}
-
-function deferredResult(): DeferredResult {
-  let reject!: (error: Error) => void;
-  let resolve!: (result: PostgresQueryResult) => void;
-  const promise = new Promise<PostgresQueryResult>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
-
 class PipelineClient implements PostgresClientLike {
   pipeline = true;
   readonly calls: (PostgresQueryConfig | string)[] = [];
   readonly releaseArguments: (Error | boolean | undefined)[] = [];
   readonly rows = new Map<string, readonly Record<string, unknown>[]>();
   readonly errors = new Map<string, Error>();
-  readonly #blocked = new Map<string, DeferredResult>();
+  readonly #blocked = new Map<string, Deferred<PostgresQueryResult>>();
   readonly #callWaiters: { readonly count: number; readonly resolve: () => void }[] = [];
 
   async query(config: PostgresQueryConfig | string): Promise<PostgresQueryResult> {
@@ -57,7 +42,7 @@ class PipelineClient implements PostgresClientLike {
   }
 
   block(text: string): void {
-    this.#blocked.set(text, deferredResult());
+    this.#blocked.set(text, deferred<PostgresQueryResult>());
   }
 
   resolve(text: string, rows: readonly Record<string, unknown>[] = []): void {

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -43,8 +43,8 @@ await describe("CI evidence lanes", async () => {
     for (const job of ["packed-real-databases", "editor-artifacts"]) {
       const start = workflow.indexOf(`  ${job}:\n`);
       strict.ok(start >= 0);
-      const section = workflow.slice(start).split(/\n(?=  \S)/u)[0]!;
-      strict.ok(!/^    if:/mu.test(section), `${job} must not exclude pull requests`);
+      const section = workflow.slice(start).split(/\n(?= {2}\S)/u)[0]!;
+      strict.ok(!/^ {4}if:/mu.test(section), `${job} must not exclude pull requests`);
     }
     strict.ok(workflow.includes("needs: [packed-real-databases, editor-artifacts]"));
     strict.ok(workflow.includes("pnpm e2e:packed"));

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -1,4 +1,6 @@
-import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, it, strict } from "poku";
 
@@ -39,11 +41,60 @@ await describe("CI evidence lanes", async () => {
   });
 
   await it("writes only structured identifiers and environment-owned run metadata", async () => {
-    const writer = await readFile(join(workspace, "scripts/write-ci-evidence.mjs"), "utf8");
-    strict.ok(writer.includes("TYPED_SQL_MATRIX_TARGET"));
-    strict.ok(writer.includes("GITHUB_SHA"));
-    for (const sensitive of ["process.env.DATABASE", "process.env.PG", "process.env.MYSQL", "process.env.TOKEN"])
-      strict.ok(!writer.includes(sensitive));
+    const directory = await mkdtemp(join(tmpdir(), "typed-sql-ci-evidence-"));
+    try {
+      const path = join(directory, "nested", "evidence.json");
+      const script = join(workspace, "scripts/write-ci-evidence.mjs");
+      const environment = {
+        ...process.env,
+        TYPED_SQL_MATRIX_TARGET: "test-target",
+        GITHUB_SHA: "test-revision",
+        GITHUB_RUN_ID: "123",
+        GITHUB_RUN_ATTEMPT: "2",
+        DATABASE_URL: "secret-database-url",
+        PGPASSWORD: "secret-postgres-password",
+        MYSQL_PWD: "secret-mysql-password",
+        TOKEN: "secret-token",
+      };
+      execFileSync(
+        process.execPath,
+        [
+          script,
+          "--lane",
+          "pull-request",
+          "--output",
+          path,
+          "--gate",
+          "packed-consumer",
+          "--gate",
+          "api",
+          "--gate",
+          "api",
+        ],
+        { env: environment },
+      );
+      const content = await readFile(path, "utf8");
+      strict.deepStrictEqual(JSON.parse(content), {
+        formatVersion: 1,
+        lane: "pull-request",
+        target: "test-target",
+        revision: "test-revision",
+        run: "123",
+        attempt: "2",
+        gates: ["api", "packed-consumer"],
+      });
+      strict.ok(!content.includes("secret-"));
+      for (const args of [
+        [],
+        ["--lane", "INVALID", "--output", path, "--gate", "api"],
+        ["--lane", "pull-request", "--output", path, "--gate", "INVALID"],
+      ]) {
+        strict.throws(() => execFileSync(process.execPath, [script, ...args], { env: environment, stdio: "pipe" }));
+        strict.strictEqual(await readFile(path, "utf8"), content, "invalid requests cannot overwrite valid evidence");
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   await it("prepares clean-checkout runtime lanes before executing package entrypoints", async () => {

--- a/test/helpers/deferred.ts
+++ b/test/helpers/deferred.ts
@@ -1,0 +1,16 @@
+export interface Deferred<Value> {
+  readonly promise: Promise<Value>;
+  reject(reason: unknown): void;
+  resolve(value: Value): void;
+}
+
+/** Deterministically hold a fake operation until the test chooses success or failure. */
+export function deferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}


### PR DESCRIPTION
## Summary

Closes #120.

- Extract the duplicated deferred-operation fixture used by MySQL lifecycle and PostgreSQL pipeline failure tests.
- Keep adapter-specific fakes and transaction expectations local, preserving test readability.
- Replace CI evidence source-text checks with subprocess behavior checks: exact artifact shape, canonical gate ordering/deduplication, exclusion of secret environment fields, invalid input rejection and preservation of existing evidence.

## Verification

jscpd confirms the shared deferred clone before extraction; repeat detection and focused lifecycle/pipeline/CI contracts after extraction. This is a deliberately selective cleanup, not a mechanical consolidation of all similar test code.
