### PR TITLE
perf(config): avoid rereading unchanged dependency graphs

### DIFF
--- a/.changeset/config-dependency-fingerprints.md
+++ b/.changeset/config-dependency-fingerprints.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/config": patch
+---
+
+Avoid rereading unchanged imported configuration files on every project reopen. Cache content hashes behind file identity, size and nanosecond modification/change timestamps; changed or deleted imports still invalidate the configuration.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, stat } from "node:fs/promises";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { assertDialectPlugin, type SchemaSnapshot, type TypedSqlConfig } from "@typed-sql/core";
@@ -14,11 +14,23 @@ const configNames = [
 ] as const;
 export const CONFIG_CACHE_LIMIT = 32;
 const configCache = new Map<string, Promise<LoadedConfig>>();
-const dependencyHashes = new WeakMap<LoadedConfig, ReadonlyMap<string, string>>();
+interface FileFingerprint {
+  readonly identity: string;
+  readonly hash: string;
+}
+const dependencyHashes = new WeakMap<LoadedConfig, Map<string, FileFingerprint>>();
 const hashFile = async (file: string): Promise<string> =>
   createHash("sha256")
     .update(await readFile(file))
     .digest("hex");
+
+async function fingerprint(file: string, previous?: FileFingerprint): Promise<FileFingerprint> {
+  const info = await stat(file, { bigint: true });
+  // ctime detects same-size edits even when tools restore mtime; inode detects replacement.
+  const identity = `${info.dev}:${info.ino}:${info.size}:${info.mtimeNs}:${info.ctimeNs}`;
+  if (previous?.identity === identity) return previous;
+  return { identity, hash: await hashFile(file) };
+}
 
 export interface LoadedConfig {
   readonly file: string;
@@ -77,10 +89,14 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Loade
   const cached = configCache.get(key);
   if (cached !== undefined) {
     const loaded = await cached;
+    const fingerprints = dependencyHashes.get(loaded)!;
     const unchanged = await Promise.all(
-      [...dependencyHashes.get(loaded)!].map(async ([path, previous]) => {
+      [...fingerprints].map(async ([path, previous]) => {
         try {
-          return (await hashFile(path)) === previous;
+          const current = await fingerprint(path, previous);
+          if (current.hash !== previous.hash) return false;
+          fingerprints.set(path, current);
+          return true;
         } catch {
           return false;
         }
@@ -110,7 +126,12 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Loade
       const loaded = { file, directory: dirname(file), config: module.default, dependencies: paths };
       dependencyHashes.set(
         loaded,
-        new Map(await Promise.all(paths.map(async (path) => [path, await hashFile(path)] as const))),
+        // The entry file was already content-hashed above; avoid a duplicate read on cache hits.
+        new Map(
+          await Promise.all(
+            paths.filter((path) => path !== file).map(async (path) => [path, await fingerprint(path)] as const),
+          ),
+        ),
       );
       return loaded;
     })

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, strict } from "poku";
@@ -21,7 +21,9 @@ await describe("typed-sql config", async () => {
       const first = await loadConfig({ file });
       strict.deepStrictEqual(first.config.typePolicy, { bigint: "string" });
       strict.ok(first.dependencies?.includes(helper));
+      const beforeEdit = await stat(helper);
       await writeFile(helper, 'export const policy = { bigint: "number" };');
+      await utimes(helper, beforeEdit.atime, beforeEdit.mtime);
       const second = await loadConfig({ file });
       strict.notStrictEqual(second, first);
       strict.deepStrictEqual(second.config.typePolicy, { bigint: "number" });

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, strict } from "poku";
@@ -13,6 +13,8 @@ await describe("typed-sql config", async () => {
     const helper = join(directory, "policy.mts");
     try {
       await writeFile(helper, 'export const policy = { bigint: "string" };');
+      const preservedTime = new Date("2020-01-01T00:00:00Z");
+      await utimes(helper, preservedTime, preservedTime);
       await writeFile(join(directory, "shared.mts"), 'export { policy } from "./policy.mts";');
       await writeFile(
         file,
@@ -21,10 +23,10 @@ await describe("typed-sql config", async () => {
       const first = await loadConfig({ file });
       strict.deepStrictEqual(first.config.typePolicy, { bigint: "string" });
       strict.ok(first.dependencies?.includes(helper));
-      const beforeEdit = await stat(helper);
       await writeFile(helper, 'export const policy = { bigint: "number" };');
-      await utimes(helper, beforeEdit.atime, beforeEdit.mtime);
-      const second = await loadConfig({ file });
+      await utimes(helper, preservedTime, preservedTime);
+      const [second, concurrent] = await Promise.all([loadConfig({ file }), loadConfig({ file })]);
+      strict.strictEqual(second, concurrent);
       strict.notStrictEqual(second, first);
       strict.deepStrictEqual(second.config.typePolicy, { bigint: "number" });
       const repeated = await Promise.all([loadConfig({ file }), loadConfig({ file })]);


### PR DESCRIPTION
## Summary

Closes #131.

- Retain dependency content hashes behind device/inode/size and nanosecond mtime/ctime fingerprints.
- Avoid rereading unchanged imported module graphs when projects reopen; still read the entry config's content on every load.
- Check ctime as well as mtime so same-size edits with restored modification timestamps invalidate correctly.
- Keep changed fingerprints out of the cached valid generation until reload, avoiding concurrent stale-cache acceptance.

## Verification

- Clean build and config coverage pass (100% lines, 93.87% branches).
- Dependency edit/deletion/recreation and restored-mtime regression tests pass.
- Full local performance gate passes; project lifecycle p50 is 4.37ms on Apple M3 Pro/Node 24.10 (not directly comparable to CI's Linux baseline).
- CI must pass the existing 15ms project-lifecycle budget; no budget changes.
