### PR TITLE
chore(deps): patch vulnerable qs and mysql2 dependency paths

### DIFF
--- a/benchmarks/runtime-comparison/package.json
+++ b/benchmarks/runtime-comparison/package.json
@@ -22,7 +22,7 @@
     "@typed-sql/postgres": "link:../../packages/postgres",
     "drizzle-orm": "0.45.2",
     "kysely": "0.29.5",
-    "mysql2": "3.24.1",
+    "mysql2": "3.24.3",
     "pg": "8.23.0",
     "pg-copy-streams": "7.0.0",
     "typeorm": "1.1.0"
@@ -37,7 +37,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@prisma/config@7.10.0>deepmerge-ts": "8.0.2"
+      "@prisma/config@7.10.0>deepmerge-ts": "8.0.2",
+      "mysql2@>=3 <3.24.3": "3.24.3"
     }
   }
 }

--- a/benchmarks/runtime-comparison/pnpm-lock.yaml
+++ b/benchmarks/runtime-comparison/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@prisma/config@7.10.0>deepmerge-ts': 8.0.2
+  mysql2@>=3 <3.24.3: 3.24.3
 
 importers:
 
@@ -16,7 +17,7 @@ importers:
         version: 7.10.0
       '@prisma/client':
         specifier: 7.10.0
-        version: 7.10.0(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+        version: 7.10.0(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       '@typed-sql/mysql':
         specifier: link:../../packages/mysql
         version: link:../../packages/mysql
@@ -25,13 +26,13 @@ importers:
         version: link:../../packages/postgres
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.3)(@prisma/client@7.10.0(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.23.1)(kysely@0.29.5)(mysql2@3.24.1(@types/node@24.13.3))(pg@8.23.0)(postgres@3.4.7)(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+        version: 0.45.2(@electric-sql/pglite@0.4.3)(@prisma/client@7.10.0(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.23.1)(kysely@0.29.5)(mysql2@3.24.3(@types/node@24.13.3))(pg@8.23.0)(postgres@3.4.7)(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       kysely:
         specifier: 0.29.5
         version: 0.29.5
       mysql2:
-        specifier: 3.24.1
-        version: 3.24.1(@types/node@24.13.3)
+        specifier: 3.24.3
+        version: 3.24.3(@types/node@24.13.3)
       pg:
         specifier: 8.23.0
         version: 8.23.0
@@ -40,7 +41,7 @@ importers:
         version: 7.0.0
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(mysql2@3.24.1(@types/node@24.13.3))(pg@8.23.0)
+        version: 1.1.0(mysql2@3.24.3(@types/node@24.13.3))(pg@8.23.0)
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -53,7 +54,7 @@ importers:
         version: 1.2.5
       prisma:
         specifier: 7.10.0
-        version: 7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        version: 7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       tsx:
         specifier: 4.23.12
         version: 4.23.12
@@ -711,10 +712,6 @@ packages:
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
-
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -748,7 +745,7 @@ packages:
       gel: '>=2'
       knex: '*'
       kysely: '*'
-      mysql2: '>=2'
+      mysql2: 3.24.3
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
@@ -946,12 +943,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  mysql2@3.15.3:
-    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
-    engines: {node: '>= 8.0'}
-
-  mysql2@3.24.1:
-    resolution: {integrity: sha512-zhab6WaWL9mCp74DegK/IS9PW9ydKav6BBY7JZU8SqjQGBBmz2FlsY62mNKTofY1a0pWA2N/9IZAbb6lQpUDEg==}
+  mysql2@3.24.3:
+    resolution: {integrity: sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==}
     engines: {node: '>= 8.0'}
     peerDependencies:
       '@types/node': '>= 8'
@@ -1107,9 +1100,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  seq-queue@0.0.5:
-    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1136,10 +1126,6 @@ packages:
   sql-highlight@6.1.0:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
     engines: {node: '>=14'}
-
-  sqlstring@2.3.3:
-    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
-    engines: {node: '>= 0.6'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1179,7 +1165,7 @@ packages:
       ioredis: ^5.0.4
       mongodb: ^7.0.0
       mssql: ^12.0.0
-      mysql2: ^3.15.3
+      mysql2: 3.24.3
       oracledb: ^6.3.0 || ^7.0.0
       pg: ^8.5.1
       pg-native: ^3.0.0
@@ -1365,11 +1351,11 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.10.0': {}
 
-  '@prisma/client@7.10.0(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
+  '@prisma/client@7.10.0(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)':
     dependencies:
       '@prisma/client-runtime-utils': 7.10.0
     optionalDependencies:
-      prisma: 7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+      prisma: 7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       typescript: 7.0.2
 
   '@prisma/config@7.10.0':
@@ -1824,22 +1810,20 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
-  denque@2.1.0: {}
-
   destr@2.0.5: {}
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@prisma/client@7.10.0(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.23.1)(kysely@0.29.5)(mysql2@3.24.1(@types/node@24.13.3))(pg@8.23.0)(postgres@3.4.7)(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@prisma/client@7.10.0(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.23.1)(kysely@0.29.5)(mysql2@3.24.3(@types/node@24.13.3))(pg@8.23.0)(postgres@3.4.7)(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.3
-      '@prisma/client': 7.10.0(prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
+      '@prisma/client': 7.10.0(prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       '@types/pg': 8.23.1
       kysely: 0.29.5
-      mysql2: 3.24.1(@types/node@24.13.3)
+      mysql2: 3.24.3(@types/node@24.13.3)
       pg: 8.23.0
       postgres: 3.4.7
-      prisma: 7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+      prisma: 7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
 
   effect@3.20.0:
     dependencies:
@@ -1961,19 +1945,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mysql2@3.15.3:
-    dependencies:
-      aws-ssl-profiles: 1.1.2
-      denque: 2.1.0
-      generate-function: 2.3.1
-      iconv-lite: 0.7.3
-      long: 5.3.2
-      lru.min: 1.1.4
-      named-placeholders: 1.1.6
-      seq-queue: 0.0.5
-      sqlstring: 2.3.3
-
-  mysql2@3.24.1(@types/node@24.13.3):
+  mysql2@3.24.3(@types/node@24.13.3):
     dependencies:
       '@types/node': 24.13.3
       aws-ssl-profiles: 1.1.2
@@ -2055,17 +2027,18 @@ snapshots:
 
   postgres@3.4.7: {}
 
-  prisma@7.10.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  prisma@7.10.0(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@prisma/config': 7.10.0
       '@prisma/dev': 0.24.17(typescript@7.0.2)
       '@prisma/engines': 7.10.0
       '@prisma/studio-core': 0.33.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      mysql2: 3.15.3
+      mysql2: 3.24.3(@types/node@24.13.3)
       postgres: 3.4.7
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
+      - '@types/node'
       - '@types/react'
       - '@types/react-dom'
       - magicast
@@ -2114,8 +2087,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  seq-queue@0.0.5: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2131,8 +2102,6 @@ snapshots:
   sql-escaper@1.5.1: {}
 
   sql-highlight@6.1.0: {}
-
-  sqlstring@2.3.3: {}
 
   std-env@3.10.0: {}
 
@@ -2164,7 +2133,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typeorm@1.1.0(mysql2@3.24.1(@types/node@24.13.3))(pg@8.23.0):
+  typeorm@1.1.0(mysql2@3.24.3(@types/node@24.13.3))(pg@8.23.0):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
@@ -2177,7 +2146,7 @@ snapshots:
       tslib: 2.8.1
       yargs: 18.1.0
     optionalDependencies:
-      mysql2: 3.24.1(@types/node@24.13.3)
+      mysql2: 3.24.3(@types/node@24.13.3)
       pg: 8.23.0
     transitivePeerDependencies:
       - babel-plugin-macros

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -45,7 +45,7 @@ The report excludes setting values, schema expressions, source text, credentials
 | PostgreSQL | PostgreSQL 14–18 grammar and catalog provider; patch-compatible within each major | PostgreSQL 14.24, 15.19, 16.15, 17.11, and 18.6; PostgreSQL 19beta3 as a non-blocking canary |
 | `pg` | Application-owned driver loaded by `@typed-sql/postgres/pg` | `pg` 8.23.0 |
 | MySQL | MySQL 8.4 and 9.7 LTS grammar and catalog provider; patch-compatible within each LTS series | MySQL 8.4.11 and 9.7.2 across default, lexical-mode, and unsigned-arithmetic profiles; MySQL 26.7.0 as a non-blocking innovation canary |
-| `mysql2` | Application-owned driver loaded by `@typed-sql/mysql/mysql2` | `mysql2` 3.24.1 |
+| `mysql2` | Application-owned driver loaded by `@typed-sql/mysql/mysql2` | `mysql2` 3.24.3 |
 | SQLite | SQLite 3.39.0–3.53.4 grammar and PRAGMA catalog provider; unknown newer libraries are conservative | Source-built SQLite 3.39.0 and 3.53.4, every supported Node line's bundled library, and a non-blocking 3.54.0 canary |
 | `node:sqlite` | Built-in adapter loaded by `@typed-sql/sqlite/node-sqlite`; Node 22.13+, 24, and 26 | Node 22.13.0 and current Node 22, 24, and 26 lines |
 

--- a/e2e/mysql/package.json
+++ b/e2e/mysql/package.json
@@ -16,7 +16,7 @@
     "@typed-sql/core": "workspace:*",
     "@typed-sql/mysql": "workspace:*",
     "@typed-sql/ts-bridge": "workspace:*",
-    "mysql2": "3.24.1"
+    "mysql2": "3.24.3"
   },
   "devDependencies": {
     "poku": "4.5.0",

--- a/e2e/mysql/test/developer-flow.e2e.test.ts
+++ b/e2e/mysql/test/developer-flow.e2e.test.ts
@@ -271,7 +271,7 @@ try {
       const adapter: ConformanceLiveAdapter = {
         grammar: "mysql",
         driver: "mysql2",
-        driverVersion: "3.24.1",
+        driverVersion: "3.24.3",
         async server() {
           return {
             version: server.version,
@@ -343,7 +343,7 @@ try {
             grammarVersion: selectedDialect.grammarVersion,
             databaseVersion: server.version,
             driver: "mysql2",
-            driverVersion: "3.24.1",
+            driverVersion: "3.24.3",
             runtime: "node",
             runtimeVersion: process.version,
             typescriptVersion: "7.0.2",

--- a/e2e/packed/test/packed-real.e2e.test.ts
+++ b/e2e/packed/test/packed-real.e2e.test.ts
@@ -225,7 +225,7 @@ await describe(`${consumerSource} real-database consumers`, async () => {
       const driverLinks = registryOnly
         ? {
             pg: "8.23.0",
-            mysql2: "3.24.1",
+            mysql2: "3.24.3",
             valibot: "1.4.2",
             zod: "4.5.2",
             tsx: "4.23.12",

--- a/examples/mysql/package.json
+++ b/examples/mysql/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@typed-sql/core": "workspace:*",
     "@typed-sql/mysql": "workspace:*",
-    "mysql2": "3.24.1",
+    "mysql2": "3.24.3",
     "valibot": "1.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@typed-sql/postgres": "workspace:*",
     "@types/node": "^24.3.0",
     "@types/pg": "8.23.1",
-    "mysql2": "3.24.1",
+    "mysql2": "3.24.3",
     "pg": "8.23.0",
     "poku": "4.5.0",
     "tsx": "4.23.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   vitepress>vite: 6.4.3
+  qs@>=6 <6.16.0: 6.16.0
 
 importers:
 
@@ -39,8 +40,8 @@ importers:
         specifier: 8.23.1
         version: 8.23.1
       mysql2:
-        specifier: 3.24.1
-        version: 3.24.1(@types/node@24.13.3)
+        specifier: 3.24.3
+        version: 3.24.3(@types/node@24.13.3)
       pg:
         specifier: 8.23.0
         version: 8.23.0
@@ -72,8 +73,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ts-bridge
       mysql2:
-        specifier: 3.24.1
-        version: 3.24.1(@types/node@24.13.3)
+        specifier: 3.24.3
+        version: 3.24.3(@types/node@24.13.3)
     devDependencies:
       poku:
         specifier: 4.5.0
@@ -180,8 +181,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/mysql
       mysql2:
-        specifier: 3.24.1
-        version: 3.24.1(@types/node@24.13.3)
+        specifier: 3.24.3
+        version: 3.24.3(@types/node@24.13.3)
       valibot:
         specifier: 1.4.2
         version: 1.4.2(typescript@7.0.2)
@@ -2577,8 +2578,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  mysql2@3.24.1:
-    resolution: {integrity: sha512-zhab6WaWL9mCp74DegK/IS9PW9ydKav6BBY7JZU8SqjQGBBmz2FlsY62mNKTofY1a0pWA2N/9IZAbb6lQpUDEg==}
+  mysql2@3.24.3:
+    resolution: {integrity: sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==}
     engines: {node: '>= 8.0'}
     peerDependencies:
       '@types/node': '>= 8'
@@ -2792,8 +2793,8 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -5401,7 +5402,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  mysql2@3.24.1(@types/node@24.13.3):
+  mysql2@3.24.3(@types/node@24.13.3):
     dependencies:
       '@types/node': 24.13.3
       aws-ssl-profiles: 1.1.2
@@ -5614,7 +5615,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -5973,7 +5974,7 @@ snapshots:
 
   typed-rest-client@1.8.11:
     dependencies:
-      qs: 6.15.3
+      qs: 6.16.0
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
 
 overrides:
   vitepress>vite: 6.4.3
+  qs@>=6 <6.16.0: 6.16.0

--- a/scripts/mysql-matrix-probe.mjs
+++ b/scripts/mysql-matrix-probe.mjs
@@ -267,7 +267,7 @@ try {
       actualSeries,
       support,
       driver: "mysql2",
-      driverVersion: "3.24.1",
+      driverVersion: "3.24.3",
       runtime: "node",
       runtimeVersion: process.version,
     },

--- a/test/contracts/examples.test.ts
+++ b/test/contracts/examples.test.ts
@@ -31,7 +31,7 @@ const examples = [
   {
     directory: "mysql",
     dialect: "mysql",
-    driver: ["mysql2", "3.24.1"],
+    driver: ["mysql2", "3.24.3"],
     documentation: "mysql",
     databaseFiles: ["Containerfile", ".containerignore", ".dockerignore", "compose.yaml"],
     capabilityFiles: [

--- a/test/contracts/package-graph.test.ts
+++ b/test/contracts/package-graph.test.ts
@@ -361,7 +361,7 @@ await describe("public package graph", async () => {
     const mysqlConsumer = JSON.parse(
       await readFile(join(workspace, "e2e", "mysql", "package.json"), "utf8"),
     ) as PackageManifest;
-    strict.strictEqual(mysqlConsumer.dependencies?.mysql2, "3.24.1");
+    strict.strictEqual(mysqlConsumer.dependencies?.mysql2, "3.24.3");
     strict.strictEqual(mysqlConsumer.dependencies?.["@typed-sql/mysql"], "workspace:*");
   });
 });


### PR DESCRIPTION
## Summary

Closes #128.

- Update mysql2 3.24.1 to 3.24.3 in workspace development, MySQL E2E/example and isolated benchmark inputs.
- Override the benchmark's vulnerable Prisma-transitive mysql2 3.15.3 with compatible 3.24.3.
- Update transitive qs 6.15.3 to 6.16.0 in VSIX tooling using a bounded same-major override.
- Regenerate both lockfiles without unrelated dependency upgrades.

The fixes address [qs advisory](https://github.com/ljharb/qs/security/advisories/GHSA-4mjr-xmp4-gh2g) and [mysql2 advisory](https://github.com/sidorares/node-mysql2/security/advisories/GHSA-3f6p-5ww8-9rcr). The runtime benchmark overlaps Dependabot PR #95; no unrelated Actions major updates are included.

## Verification

- Both frozen-lockfile installs pass.
- Isolated Prisma generation and benchmark typecheck pass.
- MySQL package tests and VSIX packaging verify affected driver/tooling consumers.
- No public package API, SQL semantics or supported driver-range changes; these are repository development/benchmark inputs, so no release Changeset is needed.
