### PR TITLE
ci: fail closed on skipped prerequisites without serializing verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,19 @@ jobs:
           fail-on-severity: high
 
   quality:
-    # The protected quality check cannot pass without representative runtime/artifact evidence.
-    needs: [packed-real-databases, editor-artifacts]
+    # A skipped required job can be accepted by branch protection. Always emit an explicit result.
+    if: always()
+    needs: [source-quality, packed-real-databases, editor-artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: node scripts/assert-ci-prerequisites.mjs
+        env:
+          TYPED_SQL_SOURCE_RESULT: ${{ needs.source-quality.result }}
+          TYPED_SQL_DATABASE_RESULT: ${{ needs.packed-real-databases.result }}
+          TYPED_SQL_EDITOR_RESULT: ${{ needs.editor-artifacts.result }}
+
+  source-quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/assert-ci-prerequisites.mjs
+++ b/scripts/assert-ci-prerequisites.mjs
@@ -1,0 +1,10 @@
+const prerequisites = {
+  source: process.env.TYPED_SQL_SOURCE_RESULT,
+  database: process.env.TYPED_SQL_DATABASE_RESULT,
+  editor: process.env.TYPED_SQL_EDITOR_RESULT,
+};
+
+const unsuccessful = Object.entries(prerequisites).filter(([, result]) => result !== "success");
+if (unsuccessful.length > 0) {
+  throw new Error(`CI prerequisites did not succeed: ${unsuccessful.map(([name]) => name).join(", ")}`);
+}

--- a/test/contracts/ci-lanes.test.ts
+++ b/test/contracts/ci-lanes.test.ts
@@ -46,9 +46,40 @@ await describe("CI evidence lanes", async () => {
       const section = workflow.slice(start).split(/\n(?= {2}\S)/u)[0]!;
       strict.ok(!/^ {4}if:/mu.test(section), `${job} must not exclude pull requests`);
     }
-    strict.ok(workflow.includes("needs: [packed-real-databases, editor-artifacts]"));
+    const quality = workflow.slice(workflow.indexOf("  quality:\n")).split(/\n(?= {2}\S)/u)[0]!;
+    strict.ok(quality.includes("if: always()"));
+    strict.ok(quality.includes("needs: [source-quality, packed-real-databases, editor-artifacts]"));
+    strict.ok(quality.includes("node scripts/assert-ci-prerequisites.mjs"));
+    for (const [variable, job] of [
+      ["TYPED_SQL_SOURCE_RESULT", "source-quality"],
+      ["TYPED_SQL_DATABASE_RESULT", "packed-real-databases"],
+      ["TYPED_SQL_EDITOR_RESULT", "editor-artifacts"],
+    ])
+      strict.ok(quality.includes(`${variable}: \${{ needs.${job}.result }}`));
     strict.ok(workflow.includes("pnpm e2e:packed"));
     strict.ok(workflow.includes("pnpm editor:artifacts:smoke"));
+  });
+
+  await it("fails the protected summary for failed, cancelled, skipped, missing or unknown prerequisites", () => {
+    const script = join(workspace, "scripts/assert-ci-prerequisites.mjs");
+    const successful = {
+      TYPED_SQL_SOURCE_RESULT: "success",
+      TYPED_SQL_DATABASE_RESULT: "success",
+      TYPED_SQL_EDITOR_RESULT: "success",
+    };
+    strict.doesNotThrow(() => execFileSync(process.execPath, [script], { env: successful, stdio: "pipe" }));
+    for (const variable of Object.keys(successful)) {
+      for (const result of ["failure", "cancelled", "skipped", "", "unknown", undefined]) {
+        strict.throws(
+          () =>
+            execFileSync(process.execPath, [script], {
+              env: { ...successful, [variable]: result },
+              stdio: "pipe",
+            }),
+          `${variable}=${String(result)} must fail closed`,
+        );
+      }
+    }
   });
 
   await it("writes only structured identifiers and environment-owned run metadata", async () => {


### PR DESCRIPTION
## Summary

Closes #119 (reopened after final failure-path audit of #129).

GitHub may accept a skipped required check after its prerequisite fails. See [GitHub's guidance](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks).

- Preserve the protected `quality` check name and always run its final summary.
- Explicitly require successful source, packed real-database and packaged editor results; failure, cancellation, skips, missing and unknown statuses fail closed.
- Run source verification in parallel with database/editor lanes, shortening the critical path without dropping any verification.
- Keep release evidence dependencies and artifact names intact.

## Verification

Behavioral tests execute the summary guard for success and every non-success status in each prerequisite. Workflow contracts verify its `always()` condition, complete `needs` list and environment wiring. This PR must pass the actual protected summary, all prerequisites and CodeQL.
