### PR TITLE
test: share focused fixtures across grammar and compiler tests

### DIFF
--- a/packages/compiler/test/helpers/schema.ts
+++ b/packages/compiler/test/helpers/schema.ts
@@ -1,0 +1,17 @@
+import type { PostgresSchemaSnapshot } from "../../../postgres/src/index.js";
+
+export function usersSchema() {
+  return {
+    formatVersion: 1,
+    dialect: "postgres",
+    tables: {
+      users: {
+        name: "users",
+        columns: {
+          id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
+          email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
+        },
+      },
+    },
+  } as const satisfies PostgresSchemaSnapshot;
+}

--- a/packages/compiler/test/plans.test.ts
+++ b/packages/compiler/test/plans.test.ts
@@ -11,22 +11,11 @@ import {
   serializeQueryPlanArtifact,
   serializeQueryPlanReviewReport,
 } from "../src/index.js";
+import { usersSchema } from "./helpers/schema.js";
 
 const rootDir = "/portable/project";
 const file = `${rootDir}/src/queries.ts`;
-const snapshot: PostgresSchemaSnapshot = {
-  formatVersion: 1,
-  dialect: "postgres",
-  tables: {
-    users: {
-      name: "users",
-      columns: {
-        id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
-      },
-    },
-  },
-};
+const snapshot: PostgresSchemaSnapshot = usersSchema();
 const source = [
   'import { sql } from "@typed-sql/postgres";',
   "declare const id: bigint; declare const email: string;",

--- a/packages/compiler/test/verification.test.ts
+++ b/packages/compiler/test/verification.test.ts
@@ -9,20 +9,9 @@ import {
   serializeQueryVerificationProof,
   verifyQueryManifest,
 } from "../src/index.js";
+import { usersSchema } from "./helpers/schema.js";
 
-const schema: PostgresSchemaSnapshot = {
-  formatVersion: 1,
-  dialect: "postgres",
-  tables: {
-    users: {
-      name: "users",
-      columns: {
-        id: { name: "id", databaseType: "bigint", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "text", tsType: "string", nullable: false },
-      },
-    },
-  },
-};
+const schema: PostgresSchemaSnapshot = usersSchema();
 
 const source = [
   'import { sql } from "@typed-sql/postgres";',

--- a/packages/mysql/test/batch.test.ts
+++ b/packages/mysql/test/batch.test.ts
@@ -1,5 +1,6 @@
 import { type Query, type QueryResults, sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
+import { deferred } from "../../../test/helpers/deferred.js";
 import {
   createMySqlDatabase,
   type MySqlConnectionLike,
@@ -246,14 +247,8 @@ await describe("MySQL ordered batches", async () => {
 
   await it("exclusively owns a transaction connection while executing", async () => {
     const pool = new BatchPool();
-    let queryStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      queryStarted = resolve;
-    });
-    let resumeQuery!: () => void;
-    const resume = new Promise<void>((resolve) => {
-      resumeQuery = resolve;
-    });
+    const { promise: started, resolve: queryStarted } = deferred<void>();
+    const { promise: resume, resolve: resumeQuery } = deferred<void>();
     pool.connection.executeHook = async (index) => {
       if (index !== 0) return;
       queryStarted();
@@ -281,14 +276,8 @@ await describe("MySQL ordered batches", async () => {
 
   await it("snapshots the ordered query list before asynchronous work", async () => {
     const pool = new BatchPool();
-    let queryStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      queryStarted = resolve;
-    });
-    let resumeQuery!: () => void;
-    const resume = new Promise<void>((resolve) => {
-      resumeQuery = resolve;
-    });
+    const { promise: started, resolve: queryStarted } = deferred<void>();
+    const { promise: resume, resolve: resumeQuery } = deferred<void>();
     pool.connection.executeHook = async (index) => {
       if (index !== 0) return;
       queryStarted();
@@ -305,14 +294,8 @@ await describe("MySQL ordered batches", async () => {
 
   await it("stops an unawaited outer transaction batch before its second query and rolls back", async () => {
     const pool = new BatchPool();
-    let queryStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      queryStarted = resolve;
-    });
-    let resumeQuery!: () => void;
-    const resume = new Promise<void>((resolve) => {
-      resumeQuery = resolve;
-    });
+    const { promise: started, resolve: queryStarted } = deferred<void>();
+    const { promise: resume, resolve: resumeQuery } = deferred<void>();
     pool.connection.executeHook = async (index) => {
       if (index !== 0) return;
       queryStarted();
@@ -340,14 +323,8 @@ await describe("MySQL ordered batches", async () => {
 
   await it("stops an unawaited nested batch before outer finalization releases the connection", async () => {
     const pool = new BatchPool();
-    let queryStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      queryStarted = resolve;
-    });
-    let resumeQuery!: () => void;
-    const resume = new Promise<void>((resolve) => {
-      resumeQuery = resolve;
-    });
+    const { promise: started, resolve: queryStarted } = deferred<void>();
+    const { promise: resume, resolve: resumeQuery } = deferred<void>();
     pool.connection.executeHook = async (index) => {
       if (index !== 0) return;
       queryStarted();

--- a/packages/mysql/test/fragment-list-conformance.test.ts
+++ b/packages/mysql/test/fragment-list-conformance.test.ts
@@ -1,5 +1,6 @@
 import { assertFragmentListConformance } from "@typed-sql/conformance";
 import { describe, it, strict } from "poku";
+import { fragmentListCases, fragmentRows as rows } from "../../../test/helpers/fragment-list.js";
 import { type MySqlSchemaSnapshot, mysql, sql } from "../src/index.js";
 import { mysqlRenderer } from "../src/runtime.js";
 
@@ -18,13 +19,6 @@ const snapshot = {
   },
 } as const satisfies MySqlSchemaSnapshot;
 
-const rows = [
-  { id: 1n, email: "one@example.test" },
-  { id: 2n, email: "two@example.test" },
-  { id: 3n, email: "three@example.test" },
-  { id: 4n, email: "four@example.test" },
-  { id: 5n, email: "five@example.test" },
-] as const;
 const query = (cardinality: 1 | 2 | 5) =>
   sql`INSERT INTO users (id, email) VALUES ${rows
     .slice(0, cardinality)
@@ -52,13 +46,7 @@ await describe("MySQL fragment-list conformance", async () => {
         { index: 1, tsType: "bigint", nullable: false, databaseType: "bigint" },
         { index: 2, tsType: "string", nullable: false, databaseType: "text" },
       ],
-      renderCases: ([1, 2, 5] as const).map((cardinality) => ({
-        name: `${cardinality}-rows`,
-        cardinality,
-        query: query(cardinality),
-        expectedText: text(cardinality),
-        expectedValues: rows.slice(0, cardinality).flatMap(({ id, email }) => [id, email]),
-      })),
+      renderCases: fragmentListCases(query, text),
       diagnostics: [
         {
           name: "row-arity",

--- a/packages/mysql/test/routing.test.ts
+++ b/packages/mysql/test/routing.test.ts
@@ -1,5 +1,6 @@
-import { createDatabase, sql } from "@typed-sql/core";
+import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
+import { recordingDatabase } from "../../../test/helpers/recording-database.js";
 import {
   createMySqlQuerySemanticResolver,
   createMySqlRoutedDatabase,
@@ -22,13 +23,7 @@ const schema = {
 } as const;
 
 function database(name: string, calls: string[]) {
-  const executor = {
-    execute: async () => {
-      calls.push(name);
-      return [{ name }];
-    },
-  };
-  return createDatabase(executor, { placeholder: () => "?", quoteIdentifier: (value) => `\`${value}\`` });
+  return recordingDatabase(name, calls, { placeholder: () => "?", quoteIdentifier: (value) => `\`${value}\`` });
 }
 
 await describe("MySQL semantic routing adapter", async () => {

--- a/packages/postgres/test/fragment-list-conformance.test.ts
+++ b/packages/postgres/test/fragment-list-conformance.test.ts
@@ -1,5 +1,6 @@
 import { assertFragmentListConformance } from "@typed-sql/conformance";
 import { describe, it, strict } from "poku";
+import { fragmentListCases, fragmentRows as rows } from "../../../test/helpers/fragment-list.js";
 import { type PostgresSchemaSnapshot, postgres, sql } from "../src/index.js";
 import { postgresRenderer } from "../src/runtime.js";
 
@@ -18,13 +19,6 @@ const snapshot = {
   },
 } as const satisfies PostgresSchemaSnapshot;
 
-const rows = [
-  { id: 1n, email: "one@example.test" },
-  { id: 2n, email: "two@example.test" },
-  { id: 3n, email: "three@example.test" },
-  { id: 4n, email: "four@example.test" },
-  { id: 5n, email: "five@example.test" },
-] as const;
 const query = (cardinality: 1 | 2 | 5) =>
   sql`INSERT INTO users (id, email) VALUES ${rows
     .slice(0, cardinality)
@@ -55,13 +49,7 @@ await describe("PostgreSQL fragment-list conformance", async () => {
         { index: 1, tsType: "bigint", nullable: false, databaseType: "bigint" },
         { index: 2, tsType: "string", nullable: false, databaseType: "text" },
       ],
-      renderCases: ([1, 2, 5] as const).map((cardinality) => ({
-        name: `${cardinality}-rows`,
-        cardinality,
-        query: query(cardinality),
-        expectedText: text(cardinality),
-        expectedValues: rows.slice(0, cardinality).flatMap(({ id, email }) => [id, email]),
-      })),
+      renderCases: fragmentListCases(query, text),
       diagnostics: [
         {
           name: "row-arity",

--- a/packages/postgres/test/routing.test.ts
+++ b/packages/postgres/test/routing.test.ts
@@ -1,5 +1,6 @@
-import { createDatabase, sql } from "@typed-sql/core";
+import { sql } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
+import { recordingDatabase } from "../../../test/helpers/recording-database.js";
 import {
   createPostgresQuerySemanticResolver,
   createPostgresRoutedDatabase,
@@ -23,13 +24,10 @@ const schema = {
 } as const;
 
 function database(name: string, calls: string[]) {
-  const executor = {
-    execute: async () => {
-      calls.push(name);
-      return [{ name }];
-    },
-  };
-  return createDatabase(executor, { placeholder: (index) => `$${index}`, quoteIdentifier: (value) => `"${value}"` });
+  return recordingDatabase(name, calls, {
+    placeholder: (index) => `$${index}`,
+    quoteIdentifier: (value) => `"${value}"`,
+  });
 }
 
 await describe("PostgreSQL semantic routing adapter", async () => {

--- a/packages/sqlite/test/catalog.test.ts
+++ b/packages/sqlite/test/catalog.test.ts
@@ -2,34 +2,15 @@ import { parameterTypeLiteral, rowTypeLiteral } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import { normalizeSqliteDatabaseType, sqliteNumericOperands } from "../src/catalog/index.js";
 import { parseSqliteSchemaSnapshot, type SqliteSchemaSnapshot, sqlite } from "../src/index.js";
+import { accountTable, serverEvidence } from "./helpers/schema.js";
 
 const schema = parseSqliteSchemaSnapshot({
   formatVersion: 1,
   dialect: "sqlite",
   dialectVersion: "1.0.0",
-  version: "3.53.0",
-  server: {
-    product: "sqlite",
-    version: "3.53.0",
-    versionKey: "3.53.0",
-    features: [],
-    settings: {},
-  },
+  ...serverEvidence(),
   tables: {
-    account: {
-      schema: "main",
-      name: "account",
-      kind: "table",
-      strict: true,
-      withoutRowid: false,
-      indexes: [],
-      foreignKeys: [],
-      columns: {
-        id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
-        score: { name: "score", databaseType: "REAL", tsType: "number", nullable: true },
-      },
-    },
+    account: accountTable(),
   },
   functions: {},
 }) as SqliteSchemaSnapshot;

--- a/packages/sqlite/test/conformance.test.ts
+++ b/packages/sqlite/test/conformance.test.ts
@@ -8,34 +8,15 @@ import {
 import { runAdaptedGrammarConformanceV1 } from "@typed-sql/conformance/v2";
 import { describe, it, strict } from "poku";
 import { type SqliteSchemaSnapshot, sqlite } from "../src/index.js";
+import { accountTable, serverEvidence } from "./helpers/schema.js";
 
 const snapshot = {
   formatVersion: 1,
   dialect: "sqlite",
   dialectVersion: "1.0.0",
-  version: "3.53.0",
-  server: {
-    product: "sqlite",
-    version: "3.53.0",
-    versionKey: "3.53.0",
-    features: [],
-    settings: {},
-  },
+  ...serverEvidence(),
   tables: {
-    account: {
-      schema: "main",
-      name: "account",
-      kind: "table",
-      strict: true,
-      withoutRowid: false,
-      indexes: [],
-      foreignKeys: [],
-      columns: {
-        id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
-        score: { name: "score", databaseType: "REAL", tsType: "number", nullable: true },
-      },
-    },
+    account: accountTable(),
   },
   functions: {
     "slug/1": {

--- a/packages/sqlite/test/fragment-list-conformance.test.ts
+++ b/packages/sqlite/test/fragment-list-conformance.test.ts
@@ -1,5 +1,6 @@
 import { assertFragmentListConformance } from "@typed-sql/conformance";
 import { describe, it, strict } from "poku";
+import { fragmentListCases, fragmentRows as rows } from "../../../test/helpers/fragment-list.js";
 import { type SqliteSchemaSnapshot, sql, sqlite } from "../src/index.js";
 import { sqliteRenderer } from "../src/runtime.js";
 
@@ -32,13 +33,6 @@ const snapshot = {
   },
 } as const satisfies SqliteSchemaSnapshot;
 
-const rows = [
-  { id: 1n, email: "one@example.test" },
-  { id: 2n, email: "two@example.test" },
-  { id: 3n, email: "three@example.test" },
-  { id: 4n, email: "four@example.test" },
-  { id: 5n, email: "five@example.test" },
-] as const;
 const query = (cardinality: 1 | 2 | 5) =>
   sql`INSERT INTO users (id, email) VALUES ${rows
     .slice(0, cardinality)
@@ -66,13 +60,7 @@ await describe("SQLite fragment-list conformance", async () => {
         { index: 1, tsType: "bigint", nullable: false, databaseType: "INTEGER" },
         { index: 2, tsType: "string", nullable: false, databaseType: "TEXT" },
       ],
-      renderCases: ([1, 2, 5] as const).map((cardinality) => ({
-        name: `${cardinality}-rows`,
-        cardinality,
-        query: query(cardinality),
-        expectedText: text(cardinality),
-        expectedValues: rows.slice(0, cardinality).flatMap(({ id, email }) => [id, email]),
-      })),
+      renderCases: fragmentListCases(query, text),
       diagnostics: [
         {
           name: "row-arity",

--- a/packages/sqlite/test/helpers/schema.ts
+++ b/packages/sqlite/test/helpers/schema.ts
@@ -1,0 +1,26 @@
+import type { SqliteSchemaSnapshot } from "../../src/index.js";
+
+/** Fresh base table: scenario-specific columns remain explicit at each call site. */
+export function accountTable() {
+  return {
+    schema: "main",
+    name: "account",
+    kind: "table",
+    strict: true,
+    withoutRowid: false,
+    indexes: [],
+    foreignKeys: [],
+    columns: {
+      id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
+      email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
+      score: { name: "score", databaseType: "REAL", tsType: "number", nullable: true },
+    },
+  } as const satisfies SqliteSchemaSnapshot["tables"][string];
+}
+
+export function serverEvidence(version = "3.53.0") {
+  return {
+    version,
+    server: { product: "sqlite", version, versionKey: version, features: [], settings: {} },
+  } as const;
+}

--- a/packages/sqlite/test/performance.test.ts
+++ b/packages/sqlite/test/performance.test.ts
@@ -1,26 +1,14 @@
 import { measureGrammarPerformance } from "@typed-sql/conformance";
 import { describe, it, strict } from "poku";
 import { type SqliteSchemaSnapshot, sqlite } from "../src/index.js";
+import { accountTable } from "./helpers/schema.js";
 
 const snapshot = {
   formatVersion: 1,
   dialect: "sqlite",
   dialectVersion: "1.0.0",
   tables: {
-    account: {
-      schema: "main",
-      name: "account",
-      kind: "table",
-      strict: true,
-      withoutRowid: false,
-      indexes: [],
-      foreignKeys: [],
-      columns: {
-        id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
-        score: { name: "score", databaseType: "REAL", tsType: "number", nullable: true },
-      },
-    },
+    account: accountTable(),
   },
 } as const satisfies SqliteSchemaSnapshot;
 

--- a/packages/sqlite/test/soundness.test.ts
+++ b/packages/sqlite/test/soundness.test.ts
@@ -1,32 +1,18 @@
 import { parameterTypeLiteral, rowTypeLiteral } from "@typed-sql/core";
 import { describe, it, strict } from "poku";
 import { parseSqliteSchemaSnapshot, type SqliteSchemaSnapshot, sqlite } from "../src/index.js";
+import { accountTable, serverEvidence } from "./helpers/schema.js";
 
 const snapshot = parseSqliteSchemaSnapshot({
   formatVersion: 1,
   dialect: "sqlite",
   dialectVersion: "1.0.0",
-  version: "3.53.0",
-  server: {
-    product: "sqlite",
-    version: "3.53.0",
-    versionKey: "3.53.0",
-    features: [],
-    settings: {},
-  },
+  ...serverEvidence(),
   tables: {
     account: {
-      schema: "main",
-      name: "account",
-      kind: "table",
-      strict: true,
-      withoutRowid: false,
-      indexes: [],
-      foreignKeys: [],
+      ...accountTable(),
       columns: {
-        id: { name: "id", databaseType: "INTEGER", tsType: "bigint", nullable: false },
-        email: { name: "email", databaseType: "TEXT", tsType: "string", nullable: false },
-        score: { name: "score", databaseType: "REAL", tsType: "number", nullable: true },
+        ...accountTable().columns,
         generated: {
           name: "generated",
           databaseType: "TEXT",

--- a/test/helpers/fragment-list.ts
+++ b/test/helpers/fragment-list.ts
@@ -1,0 +1,20 @@
+export const fragmentRows = [
+  { id: 1n, email: "one@example.test" },
+  { id: 2n, email: "two@example.test" },
+  { id: 3n, email: "three@example.test" },
+  { id: 4n, email: "four@example.test" },
+  { id: 5n, email: "five@example.test" },
+] as const;
+
+export function fragmentListCases<Query>(
+  query: (cardinality: 1 | 2 | 5) => Query,
+  expectedText: (cardinality: number) => string,
+) {
+  return ([1, 2, 5] as const).map((cardinality) => ({
+    name: `${cardinality}-rows`,
+    cardinality,
+    query: query(cardinality),
+    expectedText: expectedText(cardinality),
+    expectedValues: fragmentRows.slice(0, cardinality).flatMap(({ id, email }) => [id, email]),
+  }));
+}

--- a/test/helpers/recording-database.ts
+++ b/test/helpers/recording-database.ts
@@ -1,0 +1,14 @@
+import { createDatabase, type SqlRenderer } from "@typed-sql/core";
+
+/** A fresh executor with a caller-owned event log; rendering policy stays in the test. */
+export function recordingDatabase(name: string, calls: string[], renderer: SqlRenderer) {
+  return createDatabase(
+    {
+      execute: async () => {
+        calls.push(name);
+        return [{ name }];
+      },
+    },
+    renderer,
+  );
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "../packages/*/test/**/*.test.ts",
+    "../packages/*/test/helpers/**/*.ts",
     "contracts/**/*.test.ts",
     "fuzz/**/*.ts",
     "grammar/**/*.ts",


### PR DESCRIPTION
Closes #135. Closes #136. Closes #137.

Reuse deferred batch controls, recording executors, package-local schemas and fragment-list case data. Keep dialect expectations, literal types and scenario differences explicit. Include package-local helpers in test typechecking.

Validation: 27 focused test files, typecheck and quality pass. Identical jscpd scan: 250 to 240 clone pairs, 6175 to 5992 reported duplicated lines. No production changes or published API changes.