### PR TITLE
refactor(core): share batch validation across three adapters

### DIFF
--- a/.changeset/shared-batch-result-validation.md
+++ b/.changeset/shared-batch-result-validation.md
@@ -1,0 +1,8 @@
+---
+"@typed-sql/core": minor
+"@typed-sql/mysql": patch
+"@typed-sql/postgres": patch
+"@typed-sql/sqlite": patch
+---
+
+Share ordered batch result validation while preserving adapter fingerprints and the unvalidated fast path.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,6 +143,7 @@ export {
   hasQueryResultValidator,
   QueryResultValidationError,
   queryResultValidationSource,
+  validateQueryResultBatch,
   validateQueryResultRows,
   validateQueryResultStream,
 } from "./result-validation.js";

--- a/packages/core/src/result-validation.ts
+++ b/packages/core/src/result-validation.ts
@@ -1,4 +1,4 @@
-import type { QueryStream } from "./execution.js";
+import type { QueryBatch, QueryResults, QueryStream } from "./execution.js";
 import type { Query } from "./query.js";
 
 /** Structural Standard Typed V1 contract, copied from the dependency-free specification. */
@@ -251,6 +251,24 @@ export async function validateQueryResultRows<Row, Params extends readonly unkno
     validated.push(await validateValue<Row>(binding, rows[index], fingerprint, index));
   }
   return Object.freeze(validated);
+}
+
+/** Validate in query order, preserving the original result tuple on the fast path. */
+export async function validateQueryResultBatch<const Queries extends readonly unknown[]>(
+  queries: QueryBatch<Queries>,
+  results: QueryResults<Queries>,
+  fingerprint: (query: Query<unknown, readonly unknown[]>) => string,
+): Promise<QueryResults<Queries>> {
+  let validated: unknown[] | undefined;
+  const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
+  const resultList = results as readonly (readonly unknown[])[];
+  for (let index = 0; index < queryList.length; index += 1) {
+    const query = queryList[index]!;
+    if (!hasQueryResultValidator(query)) continue;
+    validated ??= [...resultList];
+    validated[index] = await validateQueryResultRows(query, resultList[index]!, fingerprint(query));
+  }
+  return (validated ?? results) as QueryResults<Queries>;
 }
 
 export function validateQueryResultStream<Row, Params extends readonly unknown[]>(

--- a/packages/core/test/batch-result-validation.test.ts
+++ b/packages/core/test/batch-result-validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, strict } from "poku";
+import {
+  type QueryResults,
+  QueryResultValidationError,
+  type StandardSchemaV1,
+  sql,
+  validateQueryResultBatch,
+} from "../src/index.js";
+
+type Row = { readonly id: number };
+function validated(validate: StandardSchemaV1<unknown, Row>["~standard"]["validate"]) {
+  const schema: StandardSchemaV1<unknown, Row> = {
+    "~standard": { version: 1, vendor: "batch-test", validate },
+  };
+  return sql.validateResult(sql<Row>`SELECT id`, schema);
+}
+
+await describe("ordered batch result validation", async () => {
+  await it("preserves unvalidated and empty result identity without fingerprint work", async () => {
+    const queries = [sql<Row>`SELECT id`, sql<{ name: string }>`SELECT name`] as const;
+    const rows: QueryResults<typeof queries> = [[{ id: 1 }], [{ name: "a" }]];
+    const unexpected = () => {
+      throw new Error("fingerprint should be lazy");
+    };
+    strict.strictEqual(await validateQueryResultBatch(queries, rows, unexpected), rows);
+    const empty = [] as const;
+    strict.strictEqual(await validateQueryResultBatch([], empty, unexpected), empty);
+  });
+
+  await it("copies only the outer tuple and validated rows, and awaits each validator", async () => {
+    const events: string[] = [];
+    const query = validated(async (value) => {
+      const row = value as Row;
+      events.push(`start:${row.id}`);
+      await Promise.resolve();
+      events.push(`end:${row.id}`);
+      return { value: { id: row.id + 1 } };
+    });
+    const ordinary = sql<{ name: string }>`SELECT name`;
+    const queries = [query, ordinary, query] as const;
+    const rows: QueryResults<typeof queries> = [[{ id: 1 }], [{ name: "a" }], [{ id: 2 }]];
+    let fingerprints = 0;
+    const result = await validateQueryResultBatch(queries, rows, () => {
+      fingerprints++;
+      return "test";
+    });
+    const typed: readonly [readonly Row[], readonly { name: string }[], readonly Row[]] = result;
+    strict.notStrictEqual(result, rows);
+    strict.strictEqual(typed[1], rows[1]);
+    strict.deepStrictEqual(result, [[{ id: 2 }], [{ name: "a" }], [{ id: 3 }]]);
+    strict.deepStrictEqual(rows[0], [{ id: 1 }]);
+    strict.deepStrictEqual(events, ["start:1", "end:1", "start:2", "end:2"]);
+    strict.strictEqual(fingerprints, 2);
+    const array: readonly Row[][] = [[{ id: 4 }]];
+    const queryArray = [query];
+    const homogeneous: readonly (readonly Row[])[] = await validateQueryResultBatch(queryArray, array, () => "array");
+    strict.deepStrictEqual(homogeneous, [[{ id: 5 }]]);
+  });
+
+  await it("stops at the first failed validator with its fingerprint and row index", async () => {
+    const query = validated(() => ({ issues: [{ message: "invalid" }] }));
+    const later = validated(() => {
+      throw new Error("must not run");
+    });
+    await strict.rejects(
+      () => validateQueryResultBatch([query, later], [[{ id: 1 }], [{ id: 2 }]], () => "first"),
+      (error: unknown) =>
+        error instanceof QueryResultValidationError && error.fingerprint === "first" && error.rowIndex === 0,
+    );
+    const failure = new Error("fingerprint failure");
+    await strict.rejects(
+      () =>
+        validateQueryResultBatch([query], [[{ id: 1 }]], () => {
+          throw failure;
+        }),
+      (error: unknown) => error === failure,
+    );
+  });
+});

--- a/packages/mysql/src/runtime.ts
+++ b/packages/mysql/src/runtime.ts
@@ -25,6 +25,7 @@ import {
   type StreamOptions,
   startDatabaseObservation,
   UnsupportedExecutionCapabilityError,
+  validateQueryResultBatch,
   validateQueryResultRows,
   validateQueryResultStream,
 } from "@typed-sql/core";
@@ -688,20 +689,7 @@ class MySqlDatabaseImplementation implements MySqlDatabase {
     queries: QueryBatch<Queries>,
     results: QueryResults<Queries>,
   ): Promise<QueryResults<Queries>> {
-    let validated: unknown[] | undefined;
-    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
-    const resultList = results as readonly (readonly unknown[])[];
-    for (let index = 0; index < queryList.length; index += 1) {
-      const query = queryList[index]!;
-      if (!hasQueryResultValidator(query)) continue;
-      validated ??= [...resultList];
-      validated[index] = await validateQueryResultRows(
-        query,
-        resultList[index]!,
-        mysqlQueryFingerprint(this.#observation, query),
-      );
-    }
-    return (validated ?? results) as QueryResults<Queries>;
+    return validateQueryResultBatch(queries, results, (query) => mysqlQueryFingerprint(this.#observation, query));
   }
 
   async #loadData(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {

--- a/packages/postgres/src/runtime.ts
+++ b/packages/postgres/src/runtime.ts
@@ -23,6 +23,7 @@ import {
   type SqlRenderer,
   type StreamOptions,
   startDatabaseObservation,
+  validateQueryResultBatch,
   validateQueryResultRows,
   validateQueryResultStream,
 } from "@typed-sql/core";
@@ -806,20 +807,7 @@ class PostgresDatabaseImplementation implements PostgresDatabase {
     queries: QueryBatch<Queries>,
     results: QueryResults<Queries>,
   ): Promise<QueryResults<Queries>> {
-    let validated: unknown[] | undefined;
-    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
-    const resultList = results as readonly (readonly unknown[])[];
-    for (let index = 0; index < queryList.length; index += 1) {
-      const query = queryList[index]!;
-      if (!hasQueryResultValidator(query)) continue;
-      validated ??= [...resultList];
-      validated[index] = await validateQueryResultRows(
-        query,
-        resultList[index]!,
-        postgresQueryFingerprint(this.#observation, query),
-      );
-    }
-    return (validated ?? results) as QueryResults<Queries>;
+    return validateQueryResultBatch(queries, results, (query) => postgresQueryFingerprint(this.#observation, query));
   }
 
   async #copyFrom(statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions): Promise<void> {

--- a/packages/sqlite/src/runtime.ts
+++ b/packages/sqlite/src/runtime.ts
@@ -13,6 +13,7 @@ import {
   renderQuery,
   type SqlRenderer,
   type StreamOptions,
+  validateQueryResultBatch,
   validateQueryResultRows,
   validateQueryResultStream,
 } from "@typed-sql/core";
@@ -297,16 +298,7 @@ class SqliteDatabaseImplementation implements SqliteDatabase, SqliteTransaction 
     queries: QueryBatch<Queries>,
     results: QueryResults<Queries>,
   ): Promise<QueryResults<Queries>> {
-    let validated: unknown[] | undefined;
-    const queryList = queries as unknown as readonly Query<unknown, readonly unknown[]>[];
-    const resultList = results as readonly (readonly unknown[])[];
-    for (let index = 0; index < queryList.length; index += 1) {
-      const query = queryList[index]!;
-      if (!hasQueryResultValidator(query)) continue;
-      validated ??= [...resultList];
-      validated[index] = await validateQueryResultRows(query, resultList[index]!, sqliteQueryFingerprint(query));
-    }
-    return (validated ?? results) as QueryResults<Queries>;
+    return validateQueryResultBatch(queries, results, (query) => sqliteQueryFingerprint(query));
   }
 
   prepare<Arguments extends readonly unknown[], Row, Params extends readonly unknown[]>(

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -907,6 +907,7 @@ const expectedRuntimeExports = {
     "serializeSupportBundle",
     "unknownQuerySemantics",
     "UnsafeReplicaRoutingError",
+    "validateQueryResultBatch",
     "validateQueryResultRows",
     "validateQueryResultStream",
   ],


### PR DESCRIPTION
Closes #138.

Share sequential lazy-copy batch result validation, with adapter-owned fingerprint callbacks. Preserve no-validator identity and exact tuple/array types. Add direct regressions for lazy fingerprints, mixed results, sequential async validation and failure ordering. Additive core minor Changeset and adapter patches.

Validation: clean build/typecheck, 56 focused files including all grammar tests and public API, core coverage and unchanged performance gates.