### PR TITLE
refactor(core): share PostgreSQL and MySQL bulk producer lifecycle

### DIFF
--- a/.changeset/shared-bulk-producer.md
+++ b/.changeset/shared-bulk-producer.md
@@ -1,0 +1,7 @@
+---
+"@typed-sql/core": minor
+"@typed-sql/mysql": patch
+"@typed-sql/postgres": patch
+---
+
+Share backpressured bulk producer mechanics while preserving grammar-specific SQL, encoding and transport behavior.

--- a/packages/core/src/bulk.ts
+++ b/packages/core/src/bulk.ts
@@ -1,0 +1,142 @@
+import { type ExecutionOptions, QueryCancelledError } from "./execution.js";
+import { bindQueryRenderSkeleton, compileQueryRenderSkeleton, type Query, type SqlRenderer } from "./query.js";
+
+export interface BulkRowProgress {
+  readonly rows: number;
+  readonly bytes: number;
+}
+export interface BulkRowOptions extends ExecutionOptions {
+  readonly onProgress?: (progress: BulkRowProgress) => void;
+}
+/** The adapter validates chunkBytes and owns all SQL and value encoding policy. */
+export interface BulkRowPolicy {
+  readonly renderer: SqlRenderer;
+  readonly chunkBytes: number;
+  readonly shapeError: string;
+  readonly statement: (text: string, parameterCount: number) => string;
+  readonly encodeRow: (values: readonly unknown[]) => Uint8Array;
+  readonly transfer: (statement: string, chunks: AsyncIterable<Uint8Array>, options: ExecutionOptions) => Promise<void>;
+}
+
+function cancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) throw new QueryCancelledError("signal", { cause: signal.reason });
+}
+
+function asyncIterator<Value>(values: Iterable<Value> | AsyncIterable<Value>): AsyncIterator<Value> {
+  if (Symbol.asyncIterator in Object(values)) return (values as AsyncIterable<Value>)[Symbol.asyncIterator]();
+  const iterator = (values as Iterable<Value>)[Symbol.iterator]();
+  return {
+    next: async () => iterator.next(),
+    ...(iterator.return === undefined ? {} : { return: async () => iterator.return!() }),
+  };
+}
+
+function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!;
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+/** Runs a bounded, backpressured producer without depending on any database driver. */
+export async function executeBulkRows<Input, Row, Params extends readonly unknown[]>(
+  rowQuery: (input: Input) => Query<Row, Params>,
+  rows: Iterable<Input> | AsyncIterable<Input>,
+  options: BulkRowOptions,
+  policy: BulkRowPolicy,
+): Promise<BulkRowProgress> {
+  cancelled(options.signal);
+  const iterator = asyncIterator(rows);
+  let iteratorClosed = false;
+  const closeIterator = async (): Promise<void> => {
+    if (iteratorClosed || iterator.return === undefined) return;
+    iteratorClosed = true;
+    await iterator.return();
+  };
+  let first: IteratorResult<Input>;
+  try {
+    first = await iterator.next();
+  } catch (error) {
+    try {
+      await closeIterator();
+    } catch {
+      /* Preserve the producer failure. */
+    }
+    throw error;
+  }
+  if (first.done === true) return Object.freeze({ rows: 0, bytes: 0 });
+
+  let firstQuery: Query<Row, Params>;
+  let compiled: ReturnType<typeof compileQueryRenderSkeleton<Row, Params>>;
+  let statement: string;
+  try {
+    firstQuery = rowQuery(first.value);
+    compiled = compileQueryRenderSkeleton(firstQuery, policy.renderer);
+    statement = policy.statement(compiled.rendered.text, compiled.rendered.values.length);
+  } catch (error) {
+    try {
+      await closeIterator();
+    } catch {
+      /* Preserve the query compilation failure. */
+    }
+    throw error;
+  }
+  let rowCount = 0;
+  let byteCount = 0;
+  let inputComplete = false;
+
+  const chunks = (async function* (): AsyncGenerator<Uint8Array> {
+    let pending: Uint8Array[] = [];
+    let pendingBytes = 0;
+    let current: IteratorResult<Input> = first;
+    try {
+      while (current.done !== true) {
+        cancelled(options.signal);
+        const query = rowCount === 0 ? firstQuery : rowQuery(current.value);
+        const rendered = rowCount === 0 ? compiled.rendered : bindQueryRenderSkeleton(query, compiled.skeleton);
+        if (rendered === undefined) throw new TypeError(policy.shapeError);
+        const encoded = policy.encodeRow(rendered.values);
+        if (pendingBytes > 0 && pendingBytes + encoded.byteLength > policy.chunkBytes) {
+          const chunk = concatenate(pending, pendingBytes);
+          byteCount += chunk.byteLength;
+          options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+          yield chunk;
+          pending = [];
+          pendingBytes = 0;
+        }
+        pending.push(encoded);
+        pendingBytes += encoded.byteLength;
+        rowCount += 1;
+        current = await iterator.next();
+      }
+      inputComplete = true;
+      if (pendingBytes > 0) {
+        const chunk = concatenate(pending, pendingBytes);
+        byteCount += chunk.byteLength;
+        options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
+        yield chunk;
+      }
+    } finally {
+      if (current.done !== true) await closeIterator();
+    }
+  })();
+
+  try {
+    await policy.transfer(statement, chunks, options);
+  } catch (error) {
+    if (!inputComplete) {
+      try {
+        await closeIterator();
+      } catch {
+        /* Preserve the transport, producer, or database failure. */
+      }
+    }
+    throw error;
+  }
+  if (!inputComplete) await closeIterator();
+  return Object.freeze({ rows: rowCount, bytes: byteCount });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,8 @@ export {
   parseArtifactCompatibilityIdentity,
   serializeArtifactCompatibilityIdentity,
 } from "./artifact-compatibility.js";
+export type { BulkRowOptions, BulkRowPolicy, BulkRowProgress } from "./bulk.js";
+export { executeBulkRows } from "./bulk.js";
 export type {
   DebugEvent,
   DebugEventInput,

--- a/packages/core/test/bulk.test.ts
+++ b/packages/core/test/bulk.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, strict } from "poku";
+import { type BulkRowPolicy, executeBulkRows, QueryCancelledError, sql } from "../src/index.js";
+
+const rowQuery = (id: number) => sql`INSERT INTO account (id) VALUES (${id})`;
+const encoder = new TextEncoder();
+function policy(overrides: Partial<BulkRowPolicy> = {}) {
+  const chunks: Uint8Array[] = [];
+  const value: BulkRowPolicy = {
+    renderer: { placeholder: () => "?", quoteIdentifier: (name) => name },
+    chunkBytes: 4,
+    shapeError: "changed shape",
+    statement: (text) => text,
+    encodeRow: (values) => encoder.encode(`${values[0]}\n`),
+    transfer: async (_statement, source) => {
+      for await (const chunk of source) chunks.push(chunk);
+    },
+    ...overrides,
+  };
+  return { value, chunks };
+}
+
+await describe("neutral bulk producer", async () => {
+  await it("packs bounded chunks, reports progress and supports oversized rows", async () => {
+    const { value, chunks } = policy();
+    const progress: unknown[] = [];
+    strict.deepStrictEqual(
+      await executeBulkRows(rowQuery, [1, 2, 33333], { onProgress: (p) => progress.push(p) }, value),
+      { rows: 3, bytes: 10 },
+    );
+    strict.deepStrictEqual(
+      chunks.map((chunk) => new TextDecoder().decode(chunk)),
+      ["1\n2\n", "33333\n"],
+    );
+    strict.deepStrictEqual(progress, [
+      { rows: 2, bytes: 4 },
+      { rows: 3, bytes: 10 },
+    ]);
+    const empty = policy({
+      transfer: async () => {
+        throw new Error("no transfer");
+      },
+    });
+    strict.deepStrictEqual(await executeBulkRows(rowQuery, [], {}, empty.value), { rows: 0, bytes: 0 });
+  });
+
+  await it("closes synchronous producers once after early transfer success", async () => {
+    let closed = 0;
+    function* rows() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        closed++;
+      }
+    }
+    const { value } = policy({ transfer: async () => undefined });
+    await executeBulkRows(rowQuery, rows(), {}, value);
+    strict.strictEqual(closed, 1);
+  });
+
+  await it("preserves producer, compilation and transport errors when cleanup also fails", async () => {
+    for (const phase of ["next", "compile", "transport"] as const) {
+      const failure = new Error(phase);
+      let closed = 0;
+      const rows: AsyncIterable<number> = {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            if (phase === "next") throw failure;
+            return { done: false, value: 1 };
+          },
+          return: async () => {
+            closed++;
+            throw new Error("cleanup");
+          },
+        }),
+      };
+      const { value } = policy({
+        transfer: async () => {
+          throw failure;
+        },
+      });
+      await strict.rejects(
+        () =>
+          executeBulkRows(
+            (id) => {
+              if (phase === "compile") throw failure;
+              return rowQuery(id);
+            },
+            rows,
+            {},
+            value,
+          ),
+        (error) => error === failure,
+      );
+      strict.strictEqual(closed, 1);
+    }
+  });
+
+  await it("handles async input, structural changes, encoding failures and cancellation", async () => {
+    let closed = 0;
+    async function* rows() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        closed++;
+      }
+    }
+    await executeBulkRows(rowQuery, rows(), {}, policy().value);
+    strict.strictEqual(closed, 1);
+    await strict.rejects(
+      () => executeBulkRows((id) => (id === 1 ? rowQuery(id) : sql`SELECT ${id}`), rows(), {}, policy().value),
+      /changed shape/,
+    );
+    const failure = new Error("encode");
+    await strict.rejects(
+      () =>
+        executeBulkRows(
+          rowQuery,
+          rows(),
+          {},
+          policy({
+            encodeRow: () => {
+              throw failure;
+            },
+          }).value,
+        ),
+      (error) => error === failure,
+    );
+    const controller = new AbortController();
+    controller.abort("stopped");
+    await strict.rejects(
+      () => executeBulkRows(rowQuery, rows(), { signal: controller.signal }, policy().value),
+      QueryCancelledError,
+    );
+    const mid = new AbortController();
+    async function* cancelledRows() {
+      yield 1;
+      mid.abort("mid");
+      yield 2;
+    }
+    await strict.rejects(
+      () => executeBulkRows(rowQuery, cancelledRows(), { signal: mid.signal }, policy().value),
+      QueryCancelledError,
+    );
+  });
+
+  await it("closes incomplete inputs without a return method and propagates success-path cleanup failures", async () => {
+    const noReturn: Iterable<number> = { [Symbol.iterator]: () => ({ next: () => ({ done: false, value: 1 }) }) };
+    await executeBulkRows(rowQuery, noReturn, {}, policy({ transfer: async () => undefined }).value);
+    const failure = new Error("return failed");
+    const broken: AsyncIterable<number> = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => ({ done: false, value: 1 }),
+        return: async () => {
+          throw failure;
+        },
+      }),
+    };
+    await strict.rejects(
+      () => executeBulkRows(rowQuery, broken, {}, policy({ transfer: async () => undefined }).value),
+      (error) => error === failure,
+    );
+  });
+});

--- a/packages/mysql/src/bulk.ts
+++ b/packages/mysql/src/bulk.ts
@@ -1,10 +1,8 @@
 import {
-  bindQueryRenderSkeleton,
-  compileQueryRenderSkeleton,
   defineAdapterCapability,
   type ExecutionOptions,
+  executeBulkRows,
   type Query,
-  QueryCancelledError,
   type SqlRenderer,
 } from "@typed-sql/core";
 import { parseStatement } from "./parser/index.js";
@@ -126,30 +124,6 @@ function loadDataStatement(text: string, parameterCount: number): string {
   return `LOAD DATA LOCAL INFILE 'typed-sql-stream' INTO TABLE ${table} CHARACTER SET utf8mb4 FIELDS TERMINATED BY X'09' ESCAPED BY X'5C' LINES TERMINATED BY X'0A' (${columns})`;
 }
 
-function cancelled(signal: AbortSignal | undefined): void {
-  if (signal?.aborted === true) throw new QueryCancelledError("signal", { cause: signal.reason });
-}
-
-function asyncIterator<Value>(values: Iterable<Value> | AsyncIterable<Value>): AsyncIterator<Value> {
-  if (Symbol.asyncIterator in Object(values)) return (values as AsyncIterable<Value>)[Symbol.asyncIterator]();
-  const iterator = (values as Iterable<Value>)[Symbol.iterator]();
-  return {
-    next: async () => iterator.next(),
-    ...(iterator.return === undefined ? {} : { return: async () => iterator.return!() }),
-  };
-}
-
-function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array {
-  if (chunks.length === 1) return chunks[0]!;
-  const result = new Uint8Array(length);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
-}
-
 export function createMySqlBulkCapability(transport: MySqlBulkTransport): MySqlBulkCapability {
   return Object.freeze({
     async loadData<Input, Row, Params extends readonly unknown[]>(
@@ -157,98 +131,14 @@ export function createMySqlBulkCapability(transport: MySqlBulkTransport): MySqlB
       rows: Iterable<Input> | AsyncIterable<Input>,
       options: MySqlLoadDataOptions = {},
     ): Promise<MySqlBulkResult> {
-      const preferredChunkBytes = chunkSize(options.chunkBytes);
-      cancelled(options.signal);
-      const iterator = asyncIterator(rows);
-      let iteratorClosed = false;
-      const closeIterator = async (): Promise<void> => {
-        if (iteratorClosed || iterator.return === undefined) return;
-        iteratorClosed = true;
-        await iterator.return();
-      };
-      let first: IteratorResult<Input>;
-      try {
-        first = await iterator.next();
-      } catch (error) {
-        try {
-          await closeIterator();
-        } catch {
-          /* Preserve the producer failure. */
-        }
-        throw error;
-      }
-      if (first.done === true) return Object.freeze({ rows: 0, bytes: 0 });
-
-      let firstQuery: Query<Row, Params>;
-      let compiled: ReturnType<typeof compileQueryRenderSkeleton<Row, Params>>;
-      let statement: string;
-      try {
-        firstQuery = rowQuery(first.value);
-        compiled = compileQueryRenderSkeleton(firstQuery, mysqlRenderer);
-        statement = loadDataStatement(compiled.rendered.text, compiled.rendered.values.length);
-      } catch (error) {
-        try {
-          await closeIterator();
-        } catch {
-          /* Preserve the query compilation failure. */
-        }
-        throw error;
-      }
-      let rowCount = 0;
-      let byteCount = 0;
-      let inputComplete = false;
-
-      const chunks = (async function* (): AsyncGenerator<Uint8Array> {
-        let pending: Uint8Array[] = [];
-        let pendingBytes = 0;
-        let current: IteratorResult<Input> = first;
-        try {
-          while (current.done !== true) {
-            cancelled(options.signal);
-            const query = rowCount === 0 ? firstQuery : rowQuery(current.value);
-            const rendered = rowCount === 0 ? compiled.rendered : bindQueryRenderSkeleton(query, compiled.skeleton);
-            if (rendered === undefined)
-              throw new TypeError("MySQL LOAD DATA row query changed its structural SQL shape");
-            const encoded = encodedRow(rendered.values);
-            if (pendingBytes > 0 && pendingBytes + encoded.byteLength > preferredChunkBytes) {
-              const chunk = concatenate(pending, pendingBytes);
-              byteCount += chunk.byteLength;
-              options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
-              yield chunk;
-              pending = [];
-              pendingBytes = 0;
-            }
-            pending.push(encoded);
-            pendingBytes += encoded.byteLength;
-            rowCount += 1;
-            current = await iterator.next();
-          }
-          inputComplete = true;
-          if (pendingBytes > 0) {
-            const chunk = concatenate(pending, pendingBytes);
-            byteCount += chunk.byteLength;
-            options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
-            yield chunk;
-          }
-        } finally {
-          if (current.done !== true) await closeIterator();
-        }
-      })();
-
-      try {
-        await transport.loadData(statement, chunks, options);
-      } catch (error) {
-        if (!inputComplete) {
-          try {
-            await closeIterator();
-          } catch {
-            /* Preserve the transport, producer, or database failure. */
-          }
-        }
-        throw error;
-      }
-      if (!inputComplete) await closeIterator();
-      return Object.freeze({ rows: rowCount, bytes: byteCount });
+      return executeBulkRows(rowQuery, rows, options, {
+        renderer: mysqlRenderer,
+        chunkBytes: chunkSize(options.chunkBytes),
+        shapeError: "MySQL LOAD DATA row query changed its structural SQL shape",
+        statement: loadDataStatement,
+        encodeRow: encodedRow,
+        transfer: (statement, chunks, options) => transport.loadData(statement, chunks, options),
+      });
     },
   });
 }

--- a/packages/postgres/src/bulk.ts
+++ b/packages/postgres/src/bulk.ts
@@ -1,8 +1,8 @@
 import {
-  bindQueryRenderSkeleton,
   compileQueryRenderSkeleton,
   defineAdapterCapability,
   type ExecutionOptions,
+  executeBulkRows,
   type Query,
   QueryCancelledError,
   type QueryStream,
@@ -147,26 +147,6 @@ function cancelled(signal: AbortSignal | undefined): void {
   if (signal?.aborted === true) throw new QueryCancelledError("signal", { cause: signal.reason });
 }
 
-function asyncIterator<Value>(values: Iterable<Value> | AsyncIterable<Value>): AsyncIterator<Value> {
-  if (Symbol.asyncIterator in Object(values)) return (values as AsyncIterable<Value>)[Symbol.asyncIterator]();
-  const iterator = (values as Iterable<Value>)[Symbol.iterator]();
-  return {
-    next: async () => iterator.next(),
-    ...(iterator.return === undefined ? {} : { return: async () => iterator.return!() }),
-  };
-}
-
-function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array {
-  if (chunks.length === 1) return chunks[0]!;
-  const result = new Uint8Array(length);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
-}
-
 export function createPostgresCopyCapability(transport: PostgresCopyTransport): PostgresCopyCapability {
   return Object.freeze({
     async copyFrom<Input, Row, Params extends readonly unknown[]>(
@@ -174,99 +154,14 @@ export function createPostgresCopyCapability(transport: PostgresCopyTransport): 
       rows: Iterable<Input> | AsyncIterable<Input>,
       options: PostgresCopyFromOptions = {},
     ): Promise<PostgresCopyResult> {
-      const preferredChunkBytes = chunkSize(options.chunkBytes);
-      cancelled(options.signal);
-      const iterator = asyncIterator(rows);
-      let iteratorClosed = false;
-      const closeIterator = async (): Promise<void> => {
-        if (iteratorClosed || iterator.return === undefined) return;
-        iteratorClosed = true;
-        await iterator.return();
-      };
-      let first: IteratorResult<Input>;
-      try {
-        first = await iterator.next();
-      } catch (error) {
-        try {
-          await closeIterator();
-        } catch {
-          /* Preserve the producer failure. */
-        }
-        throw error;
-      }
-      if (first.done === true) return Object.freeze({ rows: 0, bytes: 0 });
-
-      let firstQuery: Query<Row, Params>;
-      let compiled: ReturnType<typeof compileQueryRenderSkeleton<Row, Params>>;
-      let statement: string;
-      try {
-        firstQuery = rowQuery(first.value);
-        compiled = compileQueryRenderSkeleton(firstQuery, postgresRenderer);
-        statement = copyFromStatement(compiled.rendered.text, compiled.rendered.values.length);
-      } catch (error) {
-        try {
-          await closeIterator();
-        } catch {
-          /* Preserve the query compilation failure. */
-        }
-        throw error;
-      }
-      let rowCount = 0;
-      let byteCount = 0;
-      let inputComplete = false;
-
-      const chunks = (async function* (): AsyncGenerator<Uint8Array> {
-        let pending: Uint8Array[] = [];
-        let pendingBytes = 0;
-        let current: IteratorResult<Input> = first;
-        try {
-          while (current.done !== true) {
-            cancelled(options.signal);
-            const query = rowCount === 0 ? firstQuery : rowQuery(current.value);
-            const rendered = rowCount === 0 ? compiled.rendered : bindQueryRenderSkeleton(query, compiled.skeleton);
-            if (rendered === undefined) {
-              throw new TypeError("PostgreSQL COPY row query changed its structural SQL shape");
-            }
-            const encoded = csvRow(rendered.values);
-            if (pendingBytes > 0 && pendingBytes + encoded.byteLength > preferredChunkBytes) {
-              const chunk = concatenate(pending, pendingBytes);
-              byteCount += chunk.byteLength;
-              options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
-              yield chunk;
-              pending = [];
-              pendingBytes = 0;
-            }
-            pending.push(encoded);
-            pendingBytes += encoded.byteLength;
-            rowCount += 1;
-            current = await iterator.next();
-          }
-          inputComplete = true;
-          if (pendingBytes > 0) {
-            const chunk = concatenate(pending, pendingBytes);
-            byteCount += chunk.byteLength;
-            options.onProgress?.(Object.freeze({ rows: rowCount, bytes: byteCount }));
-            yield chunk;
-          }
-        } finally {
-          if (current.done !== true) await closeIterator();
-        }
-      })();
-
-      try {
-        await transport.copyFrom(statement, chunks, options);
-      } catch (error) {
-        if (!inputComplete) {
-          try {
-            await closeIterator();
-          } catch {
-            /* Preserve the transport, producer, or database failure. */
-          }
-        }
-        throw error;
-      }
-      if (!inputComplete) await closeIterator();
-      return Object.freeze({ rows: rowCount, bytes: byteCount });
+      return executeBulkRows(rowQuery, rows, options, {
+        renderer: postgresRenderer,
+        chunkBytes: chunkSize(options.chunkBytes),
+        shapeError: "PostgreSQL COPY row query changed its structural SQL shape",
+        statement: copyFromStatement,
+        encodeRow: csvRow,
+        transfer: (statement, chunks, options) => transport.copyFrom(statement, chunks, options),
+      });
     },
 
     copyTo<Row>(query: Query<Row, readonly []>, options: PostgresCopyToOptions = {}): QueryStream<Uint8Array> {

--- a/test/contracts/public-api.test.ts
+++ b/test/contracts/public-api.test.ts
@@ -879,6 +879,7 @@ const expectedRuntimeExports = {
     "executionDeadline",
     "getAdapterCapability",
     "hasAdapterCapability",
+    "executeBulkRows",
     "hasQueryResultValidator",
     "isTypedSqlDiagnosticCode",
     "mapQuerySemanticRanges",


### PR DESCRIPTION
Closes #139.

Extract neutral iterator/chunk/progress/cleanup mechanics to core executeBulkRows. Keep encoding, SQL validation, chunk-size errors, transport and PostgreSQL COPY TO in grammar adapters. New direct tests cover sync/async input, early transfer exit, error precedence, cancellation, wide rows, progress and structural drift.

Validation: clean build/typecheck, both grammar bulk suites and public API tests pass; core and both grammar coverage gates pass. New helper has 100% lines and 96.15% branches. Existing budgets and release boundaries unchanged; additive core minor and adapter patch Changesets.