### PR TITLE
refactor: share compiler traversal and CLI candidate preparation

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,7 @@ import {
   parseQueryManifest,
   parseQueryPlanArtifact,
   parseQueryVerificationProof,
+  type QueryManifest,
   reviewQueryPlans,
   serializeQueryManifest,
   serializeQueryPlanArtifact,
@@ -25,7 +26,7 @@ import {
   typeScriptCompilerVersionSupport,
   verifyQueryManifest,
 } from "@typed-sql/compiler";
-import { fromConfig, loadConfig } from "@typed-sql/config";
+import { fromConfig, type LoadedConfig, loadConfig } from "@typed-sql/config";
 import {
   createDebugEvent,
   createSupportBundle,
@@ -313,6 +314,30 @@ function reportPlans(
       process.stderr.write(`  ${violation.kind}: expected ${violation.expected}, actual ${violation.actual}\n`);
     }
   }
+}
+
+async function loadVerificationCandidates(
+  loaded: LoadedConfig,
+  schemaFile: string,
+  manifest: QueryManifest,
+  project: string | undefined,
+) {
+  const { config, directory } = loaded;
+  const dialect = config.dialect;
+  const schema = await readSnapshot(schemaFile, (value) => dialect.validateSnapshot(value));
+  const { projects, sources } = await projectSources(directory, config.projects, project);
+  return collectQueryVerificationCandidates({
+    manifest,
+    rootDir: directory,
+    sources,
+    projects,
+    dialect,
+    schema,
+    typePolicy: config.typePolicy ?? dialect.defaultTypePolicy,
+    ...(config.compiler?.maxStructuralVariants === undefined
+      ? {}
+      : { maxStructuralVariants: config.compiler.maxStructuralVariants }),
+  });
 }
 
 async function main(): Promise<void> {
@@ -634,20 +659,7 @@ async function main(): Promise<void> {
       const verifier = config.verification?.live;
       if (verifier === undefined)
         throw new Error("typed-sql verify --live requires verification.live in typed-sql.config.ts");
-      const schema = await readSnapshot(schemaFile, (value) => dialect.validateSnapshot(value));
-      const { projects, sources } = await projectSources(loaded.directory, config.projects, parsed.options.project);
-      const candidates = collectQueryVerificationCandidates({
-        manifest,
-        rootDir: loaded.directory,
-        sources,
-        projects,
-        dialect,
-        schema,
-        typePolicy: policy,
-        ...(config.compiler?.maxStructuralVariants === undefined
-          ? {}
-          : { maxStructuralVariants: config.compiler.maxStructuralVariants }),
-      });
+      const candidates = await loadVerificationCandidates(loaded, schemaFile, manifest, parsed.options.project);
       try {
         const result = await verifyQueryManifest({
           manifest,
@@ -708,20 +720,7 @@ async function main(): Promise<void> {
             JSON.parse(await readFile(fromConfig(loaded.directory, compareOption), "utf8")) as unknown,
           );
     const manifest = parseQueryManifest(JSON.parse(await readFile(manifestFile, "utf8")) as unknown);
-    const schema = await readSnapshot(schemaFile, (value) => dialect.validateSnapshot(value));
-    const { projects, sources } = await projectSources(loaded.directory, config.projects, parsed.options.project);
-    const candidates = collectQueryVerificationCandidates({
-      manifest,
-      rootDir: loaded.directory,
-      sources,
-      projects,
-      dialect,
-      schema,
-      typePolicy: policy,
-      ...(config.compiler?.maxStructuralVariants === undefined
-        ? {}
-        : { maxStructuralVariants: config.compiler.maxStructuralVariants }),
-    });
+    const candidates = await loadVerificationCandidates(loaded, schemaFile, manifest, parsed.options.project);
     try {
       const result = await captureQueryPlans({
         manifest,

--- a/packages/compiler/src/scanner.ts
+++ b/packages/compiler/src/scanner.ts
@@ -907,15 +907,9 @@ export function extractStaticQueries(
   return queries;
 }
 
-/** Locates explicit `sql.dynamic(...)` escape hatches without reading their runtime value. */
-export function extractDynamicQueries(
-  source: string,
-  sqlModules: readonly string[] = ["@typed-sql/core"],
-): readonly ExtractedDynamicQuery[] {
-  const names = importedSqlNames(source, new Set(sqlModules));
-  if (names.size === 0) return [];
-  const queries: ExtractedDynamicQuery[] = [];
-  let index = 0;
+/** Find code identifiers without treating quoted text or comments as member calls. */
+function nextCodeIdentifier(source: string, start: number): ReturnType<typeof identifierAt> {
+  let index = start;
   while (index < source.length) {
     const char = source[index];
     if (char === '"' || char === "'" || char === "`") {
@@ -935,6 +929,23 @@ export function extractDynamicQueries(
       index += 1;
       continue;
     }
+    return tag;
+  }
+  return undefined;
+}
+
+/** Locates explicit `sql.dynamic(...)` escape hatches without reading their runtime value. */
+export function extractDynamicQueries(
+  source: string,
+  sqlModules: readonly string[] = ["@typed-sql/core"],
+): readonly ExtractedDynamicQuery[] {
+  const names = importedSqlNames(source, new Set(sqlModules));
+  if (names.size === 0) return [];
+  const queries: ExtractedDynamicQuery[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const tag = nextCodeIdentifier(source, index);
+    if (tag === undefined) break;
     index = tag.end;
     if (!names.has(tag.value)) continue;
     let cursor = skipTrivia(source, tag.end);
@@ -967,24 +978,8 @@ export function extractAppendFragments(
   const fragments: ExtractedAppendFragment[] = [];
   let index = 0;
   while (index < source.length) {
-    const char = source[index];
-    if (char === '"' || char === "'" || char === "`") {
-      index = skipQuoted(source, index, char);
-      continue;
-    }
-    if (char === "/" && source[index + 1] === "/") {
-      index = skipLineComment(source, index);
-      continue;
-    }
-    if (char === "/" && source[index + 1] === "*") {
-      index = skipBlockComment(source, index);
-      continue;
-    }
-    const tag = identifierAt(source, index);
-    if (tag === undefined) {
-      index += 1;
-      continue;
-    }
+    const tag = nextCodeIdentifier(source, index);
+    if (tag === undefined) break;
     index = tag.end;
     if (!names.has(tag.value)) continue;
     let cursor = skipTrivia(source, tag.end);

--- a/packages/compiler/test/scanner-traversal.test.ts
+++ b/packages/compiler/test/scanner-traversal.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, strict } from "poku";
+import { extractAppendFragments, extractDynamicQueries } from "../src/scanner.js";
+
+await describe("shared code-identifier traversal", async () => {
+  await it("ignores quoted and commented calls, retaining aliases and exact dynamic spans", () => {
+    const source = [
+      'import { sql as q } from "@typed-sql/core";',
+      '"q.dynamic(ignored)";',
+      "'q.dynamic(ignored)';",
+      "`q.dynamic(ignored)`;",
+      "// q.dynamic(ignored)",
+      "/* q.dynamic(ignored) */",
+      'q /* gap */ . dynamic /* gap */ ("actual");',
+      "q.dynamic(",
+    ].join("\n");
+    const found = extractDynamicQueries(source);
+    strict.strictEqual(found.length, 2);
+    strict.strictEqual(
+      source.slice(found[0]!.range.start, found[0]!.range.end),
+      'q /* gap */ . dynamic /* gap */ ("actual")',
+    );
+    strict.strictEqual(source.slice(found[1]!.range.start, found[1]!.range.end), "q.dynamic");
+    strict.deepStrictEqual(extractDynamicQueries(source), found);
+  });
+
+  await it("keeps append-specific incomplete-call behavior and fragment ranges", () => {
+    const source = [
+      'import { sql } from "@typed-sql/core";',
+      "const base = sql`SELECT 1`;",
+      '"sql.append(base, ignored)"; /* sql.append(base, ignored) */',
+      "sql /* gap */ .append(base, sql.fragment` WHERE TRUE`);",
+      "sql.append(base",
+    ].join("\n");
+    const found = extractAppendFragments(source, (index) => `$${index}`);
+    strict.strictEqual(found.length, 1);
+    strict.strictEqual(found[0]!.fragment.sql, " WHERE TRUE");
+    const range = found[0]!.fragment.range;
+    strict.strictEqual(source.slice(range.start, range.end), "sql.fragment` WHERE TRUE`");
+    strict.deepStrictEqual(
+      extractAppendFragments(source, (index) => `$${index}`),
+      found,
+    );
+  });
+});


### PR DESCRIPTION
Closes #140.

Share code-identifier traversal between dynamic/append extraction while keeping incomplete-call differences and range construction local. Share CLI candidate loading for live verification and plans, preserving command-specific errors and cleanup.

Validation: clean build/typecheck, compiler+CLI suites, compiler coverage and new direct quoted/commented/aliased/incomplete/repeated-call span regressions pass. No public API or intended behavior change.