### PR TITLE
perf(compiler): reuse stateless source-binding predicates

### DIFF
--- a/.changeset/reuse-source-predicates.md
+++ b/.changeset/reuse-source-predicates.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/compiler": patch
+---
+
+Reuse stateless character predicates during source binding scans without changing whitespace or range behavior.

--- a/packages/compiler/src/source-mapping.ts
+++ b/packages/compiler/src/source-mapping.ts
@@ -1,9 +1,16 @@
 import type { SourceAnalysisBinding, SourceAnalysisInsertion } from "./analysis.js";
 
+// These predicates are stateless: no global/sticky lastIndex can leak between calls.
+const whitespaceCharacter = /\s/u;
+const statementBoundary = /[;{}]/u;
+const identifierStart = /[A-Za-z_$]/u;
+const identifierPart = /[\w$]/u;
+
 /** Index declaration suffixes once rather than searching every source prefix. */
 export function sourceBindings(source: string): ReadonlyMap<number, SourceAnalysisBinding> {
   const bindings = new Map<number, SourceAnalysisBinding>();
-  const whitespace = (index: number): boolean => index >= 0 && index < source.length && /\s/u.test(source[index]!);
+  const whitespace = (index: number): boolean =>
+    index >= 0 && index < source.length && whitespaceCharacter.test(source[index]!);
   const skipWhitespace = (index: number): number => {
     while (whitespace(index)) index += 1;
     return index;
@@ -15,7 +22,7 @@ export function sourceBindings(source: string): ReadonlyMap<number, SourceAnalys
       newline ||= source[previous] === "\n";
       previous -= 1;
     }
-    if (newline || position === 0 || (previous >= 0 && /[;{}]/u.test(source[previous]!))) return true;
+    if (newline || position === 0 || (previous >= 0 && statementBoundary.test(source[previous]!))) return true;
     return (
       allowExport &&
       previous < position - 1 &&
@@ -29,9 +36,9 @@ export function sourceBindings(source: string): ReadonlyMap<number, SourceAnalys
     if (!boundary(match.index)) continue;
     const keywordEnd = match.index + match[0].length;
     const start = skipWhitespace(keywordEnd);
-    if (start === keywordEnd || start === source.length || !/[A-Za-z_$]/u.test(source[start]!)) continue;
+    if (start === keywordEnd || start === source.length || !identifierStart.test(source[start]!)) continue;
     let end = start + 1;
-    while (end < source.length && /[\w$]/u.test(source[end]!)) end += 1;
+    while (end < source.length && identifierPart.test(source[end]!)) end += 1;
     const equals = skipWhitespace(end);
     if (source[equals] !== "=") continue;
     bindings.set(skipWhitespace(equals + 1), { name: source.slice(start, end), range: { start, end } });

--- a/packages/compiler/test/source-mapping.test.ts
+++ b/packages/compiler/test/source-mapping.test.ts
@@ -2,6 +2,23 @@ import { describe, it, strict } from "poku";
 import { insertionOffsets, sourceBindings } from "../src/source-mapping.js";
 
 await describe("indexed source mapping", async () => {
+  await it("keeps Unicode whitespace and repeated predicate calls independent", () => {
+    const source = "export\u00a0const\u2003$query_1\uFEFF=\u2028sql;let\tother=sql";
+    const expected = [
+      [
+        source.indexOf("sql"),
+        { name: "$query_1", range: { start: source.indexOf("$query_1"), end: source.indexOf("$query_1") + 8 } },
+      ],
+      [
+        source.lastIndexOf("sql"),
+        { name: "other", range: { start: source.indexOf("other"), end: source.indexOf("other") + 5 } },
+      ],
+    ];
+    for (let iteration = 0; iteration < 20; iteration++) {
+      strict.deepStrictEqual([...sourceBindings(source)], expected);
+      strict.strictEqual(sourceBindings("const 123 = sql").size, 0);
+    }
+  });
   await it("handles large whitespace runs without regex backtracking", () => {
     const whitespace = "\n".repeat(100_000);
     strict.strictEqual(sourceBindings(whitespace).size, 0);


### PR DESCRIPTION
Closes #145.

Address four Biome useTopLevelRegex findings in frequently repeated character tests. Preserve Unicode whitespace and identifier semantics; keep the global keyword matcher local. Add repeated-call and Unicode span regression.

Focused tests/typecheck pass. Same-process alternating before/after microbenchmark uses 2000 declarations, 40 samples after warmup; raw data is retained in the review report. No blanket speedup claim or performance budget change.