### PR TITLE
refactor: remove unnecessary internal helper exports

### DIFF
--- a/packages/compiler/src/scanner.ts
+++ b/packages/compiler/src/scanner.ts
@@ -325,7 +325,7 @@ function cookedEscape(source: string, start: number): { readonly text: string; r
   return { text: escaped, end: start + 2 };
 }
 
-export function extractTemplate(
+function extractTemplate(
   source: string,
   tagName: string,
   tagStart: number,

--- a/packages/mysql/src/decoding.ts
+++ b/packages/mysql/src/decoding.ts
@@ -74,7 +74,7 @@ function compileValueDecoder(
 }
 
 /** Compiles immutable field metadata into a decoder plan shared by buffered and streamed rows. */
-function compileMySqlRowDecoders(
+export function compileMySqlRowDecoders(
   fields: readonly MySqlFieldLike[],
   typePolicy: MySqlRuntimeTypePolicy,
   decimal?: (value: string) => unknown,

--- a/packages/mysql/src/decoding.ts
+++ b/packages/mysql/src/decoding.ts
@@ -74,7 +74,7 @@ function compileValueDecoder(
 }
 
 /** Compiles immutable field metadata into a decoder plan shared by buffered and streamed rows. */
-export function compileMySqlRowDecoders(
+function compileMySqlRowDecoders(
   fields: readonly MySqlFieldLike[],
   typePolicy: MySqlRuntimeTypePolicy,
   decimal?: (value: string) => unknown,

--- a/packages/mysql/src/prepared.ts
+++ b/packages/mysql/src/prepared.ts
@@ -32,7 +32,7 @@ export interface MySqlPreparedQueryState {
   readonly queries: WeakMap<object, MySqlPreparedQueryMetadata>;
 }
 
-export const defaultMySqlPreparedStatementLimit = 16_000;
+const defaultMySqlPreparedStatementLimit = 16_000;
 
 export function createMySqlPreparedQueryState(
   capacity = defaultMySqlPreparedStatementLimit,

--- a/packages/sqlite/src/catalog/coercions.ts
+++ b/packages/sqlite/src/catalog/coercions.ts
@@ -35,7 +35,7 @@ export function normalizeSqliteDatabaseType(databaseType: string): string {
     .replace(/\(.*/u, "");
 }
 
-export function isSqliteNumericDatabaseType(databaseType: string | undefined): boolean {
+function isSqliteNumericDatabaseType(databaseType: string | undefined): boolean {
   return databaseType !== undefined && SQLITE_NUMERIC_DATABASE_TYPES.has(normalizeSqliteDatabaseType(databaseType));
 }
 

--- a/packages/sqlite/src/schema-sql.ts
+++ b/packages/sqlite/src/schema-sql.ts
@@ -72,7 +72,7 @@ function tableBody(definition: string): string | undefined {
   return span === undefined ? undefined : definition.slice(span.start, span.end);
 }
 
-export function sqliteColumnDefinition(definition: string | undefined, column: string): string | undefined {
+function sqliteColumnDefinition(definition: string | undefined, column: string): string | undefined {
   if (definition === undefined) return undefined;
   const body = tableBody(definition);
   if (body === undefined) return undefined;


### PR DESCRIPTION
Closes #146.

Four module-private helper exports removed; implementations and public facades unchanged. The fifth candidate, compileMySqlRowDecoders, remains exported because CI identified a compiled-output performance consumer. Static-review tooling now models those consumers.

Validation: clean build/typecheck, owning suites, public API, and full performance budgets pass.