### PR TITLE
fix(lsp): preserve upstream TypeScript capabilities

### DIFF
--- a/.changeset/preserve-typescript-lsp-capabilities.md
+++ b/.changeset/preserve-typescript-lsp-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Preserve upstream TypeScript LSP completion resolution, trigger characters and code-action options while adding SQL capabilities.

--- a/packages/language-server/src/capabilities.ts
+++ b/packages/language-server/src/capabilities.ts
@@ -1,0 +1,32 @@
+/** Add SQL features without narrowing the upstream TypeScript LSP contract. */
+export function extendTypeScriptCapabilities(value: unknown): Record<string, unknown> {
+  const upstream = options(value);
+  const completion = options(upstream.completionProvider);
+  const actions = options(upstream.codeActionProvider);
+  return {
+    ...upstream,
+    completionProvider: {
+      ...completion,
+      triggerCharacters: [...new Set([...strings(completion.triggerCharacters), "."])],
+    },
+    definitionProvider: upstream.definitionProvider || true,
+    codeActionProvider:
+      Object.keys(actions).length === 0
+        ? true
+        : {
+            ...actions,
+            // An omitted list means all kinds; do not narrow that to quickfix.
+            ...(Array.isArray(actions.codeActionKinds)
+              ? { codeActionKinds: [...new Set([...strings(actions.codeActionKinds), "quickfix"])] }
+              : {}),
+          },
+  };
+}
+
+function options(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function strings(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -15,6 +15,7 @@ import {
   ResponseError,
 } from "vscode-jsonrpc/node";
 import { TextDocument, type TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
+import { extendTypeScriptCapabilities } from "./capabilities.js";
 import {
   negotiateTypedSqlProtocol,
   settingsFrom,
@@ -524,12 +525,7 @@ client.onRequest("initialize", async (rawParams) => {
   const result = await nativeRequest<JsonObject>("initialize", params);
   return {
     ...result,
-    capabilities: {
-      ...(isObject(result.capabilities) ? result.capabilities : {}),
-      completionProvider: { triggerCharacters: ["."] },
-      definitionProvider: true,
-      codeActionProvider: true,
-    },
+    capabilities: extendTypeScriptCapabilities(result.capabilities),
     serverInfo: {
       name: "typed-sql + TypeScript preview",
       version: TYPESCRIPT_PREVIEW_VERSION,

--- a/packages/language-server/test/capabilities.test.ts
+++ b/packages/language-server/test/capabilities.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, strict } from "poku";
+import { extendTypeScriptCapabilities } from "../src/capabilities.js";
+
+await describe("additive TypeScript LSP capabilities", async () => {
+  await it("preserves upstream options and unrelated features without mutation", () => {
+    const upstream = Object.freeze({
+      completionProvider: Object.freeze({
+        resolveProvider: true,
+        triggerCharacters: Object.freeze(['"', "."]),
+        allCommitCharacters: Object.freeze([";"]),
+        completionItem: Object.freeze({ labelDetailsSupport: true }),
+      }),
+      codeActionProvider: Object.freeze({
+        resolveProvider: true,
+        codeActionKinds: Object.freeze(["refactor", "source.organizeImports"]),
+      }),
+      definitionProvider: Object.freeze({ workDoneProgress: true }),
+      renameProvider: Object.freeze({ prepareProvider: true }),
+      referencesProvider: true,
+      documentFormattingProvider: true,
+      semanticTokensProvider: Object.freeze({ full: { delta: true }, legend: { tokenTypes: [], tokenModifiers: [] } }),
+      experimental: Object.freeze({ customTypeScriptFeature: true }),
+    });
+    const extended = extendTypeScriptCapabilities(upstream);
+    strict.deepStrictEqual(extended, {
+      ...upstream,
+      codeActionProvider: {
+        ...upstream.codeActionProvider,
+        codeActionKinds: ["refactor", "source.organizeImports", "quickfix"],
+      },
+    });
+    strict.notStrictEqual(extended.completionProvider, upstream.completionProvider);
+    strict.deepStrictEqual(upstream.codeActionProvider.codeActionKinds, ["refactor", "source.organizeImports"]);
+  });
+
+  await it("adds SQL providers when upstream does not provide them", () => {
+    const expected = {
+      completionProvider: { triggerCharacters: ["."] },
+      definitionProvider: true,
+      codeActionProvider: true,
+    };
+    strict.deepStrictEqual(extendTypeScriptCapabilities(undefined), expected);
+    strict.deepStrictEqual(
+      extendTypeScriptCapabilities({ definitionProvider: false, codeActionProvider: false }),
+      expected,
+    );
+  });
+
+  await it("does not restrict unrestricted action kinds or duplicate quickfix", () => {
+    strict.deepStrictEqual(
+      extendTypeScriptCapabilities({ codeActionProvider: { resolveProvider: true } }).codeActionProvider,
+      { resolveProvider: true },
+    );
+    strict.deepStrictEqual(
+      extendTypeScriptCapabilities({ codeActionProvider: { codeActionKinds: ["quickfix"] } }).codeActionProvider,
+      { codeActionKinds: ["quickfix"] },
+    );
+    strict.deepStrictEqual(
+      extendTypeScriptCapabilities({ completionProvider: { triggerCharacters: ["@"] } }).completionProvider,
+      { triggerCharacters: ["@", "."] },
+    );
+  });
+});

--- a/packages/language-server/test/upstream-typescript.test.ts
+++ b/packages/language-server/test/upstream-typescript.test.ts
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, it, strict } from "poku";
+import { ProtocolClient, positionAt } from "../../../test/helpers/protocol-client.js";
+import { typescriptPreviewCliPath } from "../../ts-bridge/src/native-lsp.js";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const fixture = join(workspace, "test/fixtures/success");
+const server = join(workspace, "packages/language-server/dist/packages/language-server/src/server.js");
+
+await describe("upstream TypeScript LSP integration", async () => {
+  await it("retains upstream advertised options through the actual initialization proxy", async () => {
+    const upstream = new ProtocolClient(process.execPath, [typescriptPreviewCliPath(), "--lsp", "--stdio"], workspace);
+    const proxy = new ProtocolClient(process.execPath, [server, "--stdio"], workspace);
+    const params = {
+      processId: process.pid,
+      rootUri: pathToFileURL(workspace).href,
+      capabilities: {},
+      initializationOptions: {
+        configPath: join(workspace, "e2e/postgres/typed-sql.config.ts"),
+        schemaPath: join(fixture, "schema.json"),
+        projectFile: join(fixture, "tsconfig.json"),
+        nativePreview: true,
+      },
+    };
+    try {
+      const native = (await upstream.request("initialize", params)) as { capabilities: Record<string, unknown> };
+      const extended = (await proxy.request("initialize", params)) as { capabilities: Record<string, unknown> };
+      for (const [key, value] of Object.entries(native.capabilities)) {
+        if (key === "completionProvider" || key === "codeActionProvider") {
+          if (value !== null && typeof value === "object") {
+            for (const [option, expected] of Object.entries(value)) {
+              const actual = (extended.capabilities[key] as Record<string, unknown>)[option];
+              if (Array.isArray(expected)) {
+                strict.ok(Array.isArray(actual), `${key}.${option}`);
+                for (const item of expected)
+                  strict.ok(Array.isArray(actual) && actual.includes(item), `${key}.${option}: ${String(item)}`);
+              } else strict.deepStrictEqual(actual, expected, `${key}.${option}`);
+            }
+          }
+        } else strict.deepStrictEqual(extended.capabilities[key], value, key);
+      }
+      const source = await readFile(join(fixture, "query.ts"), "utf8");
+      const uri = pathToFileURL(join(fixture, "query.ts")).href;
+      upstream.notify("initialized", {});
+      proxy.notify("initialized", {});
+      const document = { uri, languageId: "typescript", version: 1, text: source };
+      upstream.notify("textDocument/didOpen", { textDocument: document });
+      proxy.notify("textDocument/didOpen", { textDocument: document });
+      // This symbol follows the injected SQL type overlay. Exact parity therefore
+      // checks source mapping as well as preserving ordinary TypeScript behavior.
+      const position = positionAt(source, source.indexOf("verify():"));
+      for (const method of ["textDocument/definition", "textDocument/references", "textDocument/rename"]) {
+        const request = {
+          textDocument: { uri },
+          position,
+          ...(method.endsWith("references") ? { context: { includeDeclaration: true } } : {}),
+          ...(method.endsWith("rename") ? { newName: "verifyAccount" } : {}),
+        };
+        const expected = await upstream.request(method, request);
+        strict.ok(expected !== null, `${method} must produce actual upstream evidence`);
+        strict.ok(JSON.stringify(expected).includes(uri), `${method} must locate the source document`);
+        if (method.endsWith("rename")) strict.ok(JSON.stringify(expected).includes("verifyAccount"));
+        strict.deepStrictEqual(await proxy.request(method, request), expected, method);
+      }
+    } finally {
+      await Promise.all([upstream.close(), proxy.close()]);
+    }
+  });
+});

--- a/test/helpers/protocol-client.ts
+++ b/test/helpers/protocol-client.ts
@@ -93,8 +93,8 @@ export class ProtocolClient {
   async close(): Promise<void> {
     if (this.#process.exitCode !== null) return;
     try {
-      await this.request("shutdown", null);
-      this.notify("exit", null);
+      await this.request("shutdown", undefined);
+      this.notify("exit", undefined);
       await new Promise<void>((resolveClose) => {
         const timeout = setTimeout(() => {
           this.#process.kill();


### PR DESCRIPTION
Closes #154. Part of #153; full feature/edit parity remains tracked by #155.

Preserve upstream completion resolution, trigger characters, completion-item options and code-action options when adding typed-sql capabilities. Other TypeScript capabilities pass through unchanged. Add immutable unit fixtures and a direct comparison against the real pinned TypeScript LSP, including nonempty same-file definitions, references and rename after an inferred SQL overlay. Use absent shutdown parameters in the shared protocol fixture to interoperate with the direct upstream server.

Validation: clean build, typecheck, pnpm quality, and all six language-server test files pass. This PR does not claim complete TypeScript feature parity or change editor setup modes.