### PR TITLE
fix(lsp): preserve source versions in mapped document edits

### DIFF
--- a/.changeset/map-typescript-document-versions.md
+++ b/.changeset/map-typescript-document-versions.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Translate versioned workspace edits between generated and original documents, rejecting stale source snapshots instead of forwarding mismatched version numbers.

--- a/packages/language-server/src/protocol-mapping.ts
+++ b/packages/language-server/src/protocol-mapping.ts
@@ -6,6 +6,7 @@ interface Position {
 interface CoordinateMapper<State> {
   readonly lookup: (uri: string) => State | undefined;
   readonly position: (state: State, position: Position) => Position;
+  readonly version?: (state: State, version: number) => number;
 }
 
 function object(value: unknown): value is Record<string, unknown> {
@@ -36,6 +37,12 @@ export function mapProtocolCoordinates<State>(
       // Completion, code-action, hierarchy and diagnostic resolution data belongs
       // to its producer. It must survive the client/server round trip unchanged.
       if (key === "data") return [key, item];
+      if (key === "textDocument" && object(item) && typeof item.uri === "string" && typeof item.version === "number") {
+        const owner = mapper.lookup(item.uri);
+        if (owner !== undefined && mapper.version !== undefined) {
+          return [key, { ...item, version: mapper.version(owner, item.version) }];
+        }
+      }
       if (key === "changes" && object(item)) {
         return [
           key,

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -354,6 +354,14 @@ function mapProtocolValue(value: unknown, direction: MappingDirection, fallback?
     {
       lookup: (uri) => documents.get(uri) ?? virtualDocuments.get(uri),
       position: (state, position) => mapPosition(state, position, direction),
+      version: (state, version) => {
+        ensureStateCurrent(state);
+        const expected = direction === "source-to-virtual" ? state.original.version : state.virtualVersion;
+        if (version !== expected) {
+          throw new ResponseError(LSP_CONTENT_MODIFIED, "Document version does not match the mapped source snapshot");
+        }
+        return direction === "source-to-virtual" ? state.virtualVersion : state.original.version;
+      },
     },
     fallback,
   );

--- a/packages/language-server/test/protocol-mapping.test.ts
+++ b/packages/language-server/test/protocol-mapping.test.ts
@@ -84,4 +84,40 @@ await describe("cross-document LSP coordinates", async () => {
     strict.deepStrictEqual(mapped.range, shifted(3));
     strict.strictEqual(mapped.data, data);
   });
+
+  await it("translates owned numeric document versions without touching null or opaque versions", () => {
+    const versions = { ...mapper, version: (shift: number, version: number) => version + shift };
+    const input = {
+      documentChanges: [
+        { textDocument: { uri: first, version: 10 }, edits: [{ range, newText: "a" }] },
+        { textDocument: { uri: second, version: 20 }, edits: [{ range, newText: "b" }] },
+        { textDocument: { uri: external, version: 30 }, edits: [] },
+        { textDocument: { uri: first, version: null }, edits: [] },
+      ],
+      data: { textDocument: { uri: first, version: 10 } },
+    };
+    const result = mapProtocolCoordinates(input, versions) as typeof input;
+    strict.deepStrictEqual(
+      result.documentChanges.map((edit) => edit.textDocument.version),
+      [13, 27, 30, null],
+    );
+    strict.strictEqual(result.data, input.data);
+    strict.deepStrictEqual(result.documentChanges[0]?.edits[0]?.range, shifted(3));
+    const reversed = mapProtocolCoordinates(result, {
+      ...versions,
+      position: (shift, position) => ({ ...position, line: position.line + shift }),
+      version: (shift, version) => version - shift,
+    });
+    strict.deepStrictEqual(reversed, input);
+    strict.throws(
+      () =>
+        mapProtocolCoordinates(input, {
+          ...versions,
+          version: () => {
+            throw new Error("stale version");
+          },
+        }),
+      /stale version/u,
+    );
+  });
 });

--- a/packages/language-server/test/upstream-typescript.test.ts
+++ b/packages/language-server/test/upstream-typescript.test.ts
@@ -34,6 +34,7 @@ await describe("upstream TypeScript LSP integration", async () => {
       processId: process.pid,
       rootUri: pathToFileURL(workspace).href,
       capabilities: {
+        workspace: { workspaceEdit: { documentChanges: true } },
         textDocument: {
           semanticTokens: {
             requests: { range: true, full: { delta: true } },
@@ -113,11 +114,11 @@ await describe("upstream TypeScript LSP integration", async () => {
       ].join("\n");
       for (const client of [upstream, proxy]) {
         client.notify("textDocument/didChange", {
-          textDocument: { uri, version: 2 },
+          textDocument: { uri, version: 42 },
           contentChanges: [{ text: exported }],
         });
         client.notify("textDocument/didOpen", {
-          textDocument: { uri: databaseUri, languageId: "typescript", version: 1, text: databaseSource },
+          textDocument: { uri: databaseUri, languageId: "typescript", version: 17, text: databaseSource },
         });
         await client.request("textDocument/hover", {
           textDocument: { uri: databaseUri },
@@ -134,6 +135,17 @@ await describe("upstream TypeScript LSP integration", async () => {
         strict.ok(JSON.stringify(expected).includes(databaseUri), `${method} must include the other document`);
         strict.deepStrictEqual(await proxy.request(method, request), expected, `cross-file ${method}`);
       }
+      // The pinned upstream returns URI-keyed changes for rename even when the
+      // client supports documentChanges. Exercise the version guard explicitly;
+      // versioned response round trips are covered by the pure mapper fixtures.
+      await strict.rejects(
+        proxy.request("textDocument/rename", {
+          textDocument: { uri, version: 41 },
+          position: positionAt(exported, exported.lastIndexOf("shared")),
+          newName: "staleRename",
+        }),
+        /-32801: Document version does not match/u,
+      );
       const tokenRequest = { textDocument: { uri: databaseUri } };
       const nativeTokens = (await upstream.request("textDocument/semanticTokens/full", tokenRequest)) as SemanticTokens;
       const projected = (await proxy.request("textDocument/semanticTokens/full", tokenRequest)) as SemanticTokens;
@@ -165,7 +177,7 @@ await describe("upstream TypeScript LSP integration", async () => {
       strict.deepStrictEqual(unchanged.edits, []);
       const changedSource = `\n${databaseSource}`;
       proxy.notify("textDocument/didChange", {
-        textDocument: { uri: databaseUri, version: 2 },
+        textDocument: { uri: databaseUri, version: 88 },
         contentChanges: [{ text: changedSource }],
       });
       const delta = (await proxy.request("textDocument/semanticTokens/full/delta", {


### PR DESCRIPTION
## Summary
- Translate numeric textDocument versions using the owning source/virtual snapshot.
- Reject mismatched versions and stale known source states with ContentModified.
- Preserve null, unknown-file and opaque payload versions.

## Validation
- pnpm build and pnpm quality
- All 8 language-server test files
- Mapper fixtures prove both directions, cross-file versions, null/unknown handling and error propagation.
- Real upstream comparisons use nonconsecutive editor versions; a real proxy request proves stale version rejection. The pinned native server emits URI-keyed rename changes even when documentChanges is advertised, so numeric response mapping is covered by deterministic fixtures, not claimed as a native rename behavior.

Stacked on #160; retarget to main after its merge. Closes #161. Part of #155/#153.