### PR TITLE
fix(lsp): retain source context through upstream resolve requests

### DIFF
--- a/.changeset/preserve-typescript-resolve-context.md
+++ b/.changeset/preserve-typescript-resolve-context.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Retain source snapshot identity through upstream completion, code action, inlay hint and code lens resolution. Preserve upstream opaque data and reject expired or stale resolve requests instead of mapping edits without an owning document.

--- a/packages/language-server/src/resolve-context.ts
+++ b/packages/language-server/src/resolve-context.ts
@@ -1,0 +1,78 @@
+const marker = "typed-sql/resolve/v1";
+const resolveMethods = new Map([
+  ["textDocument/completion", "completionItem/resolve"],
+  ["textDocument/codeAction", "codeAction/resolve"],
+  ["textDocument/inlayHint", "inlayHint/resolve"],
+  ["textDocument/codeLens", "codeLens/resolve"],
+]);
+
+function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface Context<State> {
+  readonly state: State;
+  readonly uri: string;
+  readonly method: string;
+}
+
+/** One bounded identity per result batch; upstream data stays opaque on the wire. */
+export class ResolveContexts<State> {
+  readonly #entries = new Map<string, Context<State>>();
+  #sequence = 0;
+
+  constructor(readonly limit = 256) {
+    if (!Number.isSafeInteger(limit) || limit <= 0) throw new RangeError("Resolve context limit must be positive");
+  }
+
+  response(method: string, result: unknown, uri: string, state: State): unknown {
+    const resolveMethod = resolveMethodFor(method);
+    if (resolveMethod === undefined) return result;
+    if (Array.isArray(result)) return this.wrap(result, resolveMethod, uri, state);
+    if (method === "textDocument/completion" && object(result) && Array.isArray(result.items)) {
+      const defaults = object(result.itemDefaults) ? result.itemDefaults : undefined;
+      const items = result.items.map((item: unknown) =>
+        object(item) && !Object.hasOwn(item, "data") && defaults !== undefined && Object.hasOwn(defaults, "data")
+          ? { ...item, data: defaults.data }
+          : item,
+      );
+      return { ...result, items: this.wrap(items, resolveMethod, uri, state) };
+    }
+    return result;
+  }
+
+  wrap(items: readonly unknown[], method: string, uri: string, state: State): unknown[] {
+    if (items.length === 0) return [];
+    while (this.#entries.size >= this.limit) {
+      const oldest = this.#entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.#entries.delete(oldest);
+    }
+    const id = String(++this.#sequence);
+    this.#entries.set(id, { method, uri, state });
+    return items.map((item) =>
+      !object(item)
+        ? item
+        : {
+            ...item,
+            data: { kind: marker, id, hasData: Object.hasOwn(item, "data"), upstream: item.data },
+          },
+    );
+  }
+
+  restore(item: unknown, method: string): { item: unknown; context?: Context<State>; expired?: true } {
+    if (!object(item) || !object(item.data) || item.data.kind !== marker) return { item };
+    const context = typeof item.data.id === "string" ? this.#entries.get(item.data.id) : undefined;
+    if (context === undefined || context.method !== method) return { item, expired: true };
+    const { data, ...rest } = item;
+    return { item: data.hasData === true ? { ...rest, data: data.upstream } : rest, context };
+  }
+
+  delete(uri: string): void {
+    for (const [id, context] of this.#entries) if (context.uri === uri) this.#entries.delete(id);
+  }
+}
+
+export function resolveMethodFor(method: string): string | undefined {
+  return resolveMethods.get(method);
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -27,6 +27,7 @@ import {
   type TypedSqlProtocolNegotiation,
 } from "./index.js";
 import { mapProtocolCoordinates } from "./protocol-mapping.js";
+import { ResolveContexts, resolveMethodFor } from "./resolve-context.js";
 import { projectSemanticTokens, SemanticTokenResults } from "./semantic-tokens.js";
 
 interface Position {
@@ -143,6 +144,7 @@ const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
 const semanticTokenResults = new SemanticTokenResults();
+const resolveContexts = new ResolveContexts<DocumentState>();
 const pendingDocuments = new Map<string, Promise<void>>();
 const latestDocumentVersions = new Map<string, number>();
 const documentAnalysisTokens = new Map<string, AnalysisCancellation>();
@@ -162,6 +164,12 @@ preview.stderr.on("data", (chunk: Buffer | string) => {
 
 async function nativeRequest<T = unknown>(method: string, params?: unknown, token?: CancellationToken): Promise<T> {
   if (previewFailure !== undefined) throw previewFailure;
+  if (resolveMethodFor(method) !== undefined && isObject(params)) {
+    // Keep resolvable items in the final result so every item receives a source
+    // identity. Otherwise partial-result progress could bypass context wrapping.
+    const { partialResultToken: _partial, ...completeParams } = params;
+    params = completeParams;
+  }
   let rejectFailure!: (error: Error) => void;
   const failure = new Promise<never>((_resolveFailure, reject) => {
     rejectFailure = reject;
@@ -367,6 +375,10 @@ function mapProtocolValue(value: unknown, direction: MappingDirection, fallback?
   );
 }
 
+function wrapResolveResults(method: string, result: unknown, state: DocumentState | undefined): unknown {
+  return state === undefined ? result : resolveContexts.response(method, result, state.original.uri, state);
+}
+
 async function createState(
   original: TextDocument,
   previous?: DocumentState,
@@ -379,6 +391,7 @@ async function createState(
     error.name = "AbortError";
     throw error;
   }
+  resolveContexts.delete(original.uri);
   const virtualVersion = previous === undefined ? original.version : previous.virtualVersion + 1;
   const transformed = TextDocument.create(
     original.uri,
@@ -572,7 +585,7 @@ client.onRequest("textDocument/completion", async (rawParams, token) => {
   const mapped = mapProtocolValue(params, "source-to-virtual", state);
   const result = await nativeRequest("textDocument/completion", mapped, token);
   ensureStateCurrent(state);
-  return mapProtocolValue(result, "virtual-to-source", state);
+  return wrapResolveResults("textDocument/completion", mapProtocolValue(result, "virtual-to-source", state), state);
 });
 
 client.onRequest("textDocument/definition", async (rawParams, token) => {
@@ -608,7 +621,11 @@ client.onRequest("textDocument/codeAction", async (rawParams, token) => {
   const native = await nativeRequest("textDocument/codeAction", mapped, token);
   ensureStateCurrent(state);
   const nativeActions = Array.isArray(native)
-    ? (mapProtocolValue(native, "virtual-to-source", state) as readonly unknown[])
+    ? (wrapResolveResults(
+        "textDocument/codeAction",
+        mapProtocolValue(native, "virtual-to-source", state),
+        state,
+      ) as readonly unknown[])
     : [];
   return [...typedActions, ...nativeActions];
 });
@@ -629,11 +646,16 @@ client.onRequest(TYPED_SQL_STATUS_REQUEST, async (): Promise<TypedSqlLanguageSer
   };
 });
 
-client.onRequest(async (method, params, token) => {
+client.onRequest(async (method, rawParams, token) => {
   await workspaceReady;
-  const uri = documentUri(params);
+  const restored = method.endsWith("/resolve") ? resolveContexts.restore(rawParams, method) : { item: rawParams };
+  if (restored.expired === true)
+    throw new ResponseError(LSP_CONTENT_MODIFIED, "Resolve context expired; request fresh items");
+  const params = restored.item;
+  const uri = restored.context?.uri ?? documentUri(params);
   if (uri !== undefined) await waitForDocument(uri, token);
-  const state = isObject(params) ? stateFor(params) : undefined;
+  const state = restored.context?.state ?? (isObject(params) ? stateFor(params) : undefined);
+  ensureStateCurrent(state);
   if (
     method === "textDocument/semanticTokens/full" ||
     method === "textDocument/semanticTokens/full/delta" ||
@@ -644,7 +666,10 @@ client.onRequest(async (method, params, token) => {
   const mappedParams = mapProtocolValue(params, "source-to-virtual", state);
   const result = await nativeRequest(method, mappedParams, token);
   ensureStateCurrent(state);
-  const mappedResult = mapProtocolValue(result, "virtual-to-source", state);
+  let mappedResult = mapProtocolValue(result, "virtual-to-source", state);
+  if (restored.context !== undefined && isObject(mappedResult)) {
+    mappedResult = resolveContexts.wrap([mappedResult], method, restored.context.uri, state!)[0];
+  } else mappedResult = wrapResolveResults(method, mappedResult, state);
   if (method !== "textDocument/diagnostic" || state === undefined || !isObject(mappedResult)) {
     return mappedResult;
   }
@@ -756,6 +781,7 @@ client.onNotification("textDocument/didChange", (rawParams) => {
 client.onNotification("textDocument/didClose", (rawParams) => {
   const params = rawParams as DidCloseParams;
   semanticTokenResults.delete(params.textDocument.uri);
+  resolveContexts.delete(params.textDocument.uri);
   sourceDocuments.delete(params.textDocument.uri);
   latestDocumentVersions.delete(params.textDocument.uri);
   documentAnalysisTokens.get(params.textDocument.uri)?.cancel();

--- a/packages/language-server/test/resolve-context.test.ts
+++ b/packages/language-server/test/resolve-context.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, strict } from "poku";
+import { mapProtocolCoordinates } from "../src/protocol-mapping.js";
+import { ResolveContexts } from "../src/resolve-context.js";
+
+await describe("upstream resolve context", async () => {
+  await it("restores opaque data and the exact source snapshot across all resolve routes", () => {
+    const cache = new ResolveContexts<object>();
+    const state = { version: 42 };
+    const data = { position: 900, nested: { line: 500, character: 2 } };
+    for (const [request, resolve] of [
+      ["textDocument/completion", "completionItem/resolve"],
+      ["textDocument/codeAction", "codeAction/resolve"],
+      ["textDocument/inlayHint", "inlayHint/resolve"],
+      ["textDocument/codeLens", "codeLens/resolve"],
+    ]) {
+      const input = { label: "item", data };
+      const [wrapped] = cache.response(request!, [input], "file:///one.ts", state) as unknown[];
+      const restored = cache.restore(wrapped, resolve!);
+      strict.deepStrictEqual(restored.item, input);
+      strict.strictEqual((restored.item as typeof input).data, data);
+      strict.strictEqual(restored.context?.state, state);
+      strict.strictEqual(restored.context?.uri, "file:///one.ts");
+      strict.strictEqual(cache.restore(wrapped, "other/resolve").expired, true);
+    }
+  });
+
+  await it("preserves missing, null and default completion data", () => {
+    const cache = new ResolveContexts<number>();
+    const response = cache.response(
+      "textDocument/completion",
+      {
+        isIncomplete: true,
+        itemDefaults: { data: { offset: 123 }, commitCharacters: ["."] },
+        items: [{ label: "inherited" }, { label: "null", data: null }],
+      },
+      "one",
+      1,
+    ) as { items: unknown[]; isIncomplete: boolean; itemDefaults: unknown };
+    strict.strictEqual(response.isIncomplete, true);
+    strict.deepStrictEqual(response.itemDefaults, { data: { offset: 123 }, commitCharacters: ["."] });
+    strict.deepStrictEqual(cache.restore(response.items[0], "completionItem/resolve").item, {
+      label: "inherited",
+      data: { offset: 123 },
+    });
+    strict.deepStrictEqual(cache.restore(response.items[1], "completionItem/resolve").item, {
+      label: "null",
+      data: null,
+    });
+    const [missing] = cache.wrap([{ label: "missing" }], "completionItem/resolve", "one", 1);
+    strict.deepStrictEqual(cache.restore(missing, "completionItem/resolve").item, { label: "missing" });
+    strict.deepStrictEqual(cache.restore({ data: { producer: true } }, "completionItem/resolve"), {
+      item: { data: { producer: true } },
+    });
+    strict.strictEqual(cache.response("textDocument/hover", null, "one", 1), null);
+  });
+
+  await it("bounds batches and expires closed or evicted identities", () => {
+    const cache = new ResolveContexts<number>(2);
+    const [first] = cache.wrap([{ label: "a" }, { label: "b" }], "completionItem/resolve", "one", 1);
+    const [second] = cache.wrap([{}], "completionItem/resolve", "two", 2);
+    strict.strictEqual(cache.restore(first, "completionItem/resolve").context?.state, 1);
+    cache.wrap([{}], "completionItem/resolve", "three", 3);
+    strict.strictEqual(cache.restore(first, "completionItem/resolve").expired, true);
+    cache.delete("two");
+    strict.strictEqual(cache.restore(second, "completionItem/resolve").expired, true);
+    strict.throws(() => new ResolveContexts(0), /positive/u);
+  });
+
+  await it("uses restored ownership for edit-bearing results without interpreting producer data", () => {
+    const cache = new ResolveContexts<number>();
+    const data = { fileName: "opaque", position: 900 };
+    const [wrapped] = cache.wrap([{ label: "x", data }], "completionItem/resolve", "one", 7);
+    const restored = cache.restore(wrapped, "completionItem/resolve");
+    const mapped = mapProtocolCoordinates(
+      {
+        data,
+        additionalTextEdits: [
+          { range: { start: { line: 2, character: 10 }, end: { line: 2, character: 12 } }, newText: "x" },
+        ],
+      },
+      {
+        lookup: () => undefined,
+        position: (shift: number, position) => ({ ...position, character: position.character - shift }),
+      },
+      restored.context?.state,
+    ) as { data: unknown; additionalTextEdits: { range: unknown }[] };
+    strict.strictEqual(mapped.data, data);
+    strict.deepStrictEqual(mapped.additionalTextEdits[0]?.range, {
+      start: { line: 2, character: 3 },
+      end: { line: 2, character: 5 },
+    });
+  });
+});

--- a/packages/language-server/test/upstream-typescript.test.ts
+++ b/packages/language-server/test/upstream-typescript.test.ts
@@ -110,7 +110,7 @@ await describe("upstream TypeScript LSP integration", async () => {
         await readFile(join(fixture, "database.ts"), "utf8"),
         'import { sql } from "@typed-sql/postgres";',
         'import { shared } from "./query.js";',
-        "const secondQuery = sql`SELECT id FROM users`; void shared;",
+        "const secondQuery = sql`SELECT id FROM users`; void shared; const local={x:1}; void local.x;",
       ].join("\n");
       for (const client of [upstream, proxy]) {
         client.notify("textDocument/didChange", {
@@ -146,6 +146,27 @@ await describe("upstream TypeScript LSP integration", async () => {
         }),
         /-32801: Document version does not match/u,
       );
+      const completionRequest = {
+        textDocument: { uri: databaseUri },
+        position: positionAt(databaseSource, databaseSource.lastIndexOf("local.x") + "local.".length),
+      };
+      const nativeCompletions = (await upstream.request("textDocument/completion", completionRequest)) as {
+        items: { label: string }[];
+      };
+      const proxyCompletions = (await proxy.request("textDocument/completion", completionRequest)) as {
+        items: { label: string }[];
+      };
+      const nativeItem = nativeCompletions.items.find((item) => item.label === "x");
+      const proxyItem = proxyCompletions.items.find((item) => item.label === "x");
+      strict.ok(nativeItem && proxyItem, "ordinary TypeScript member completion must remain available");
+      const nativeResolved = (await upstream.request("completionItem/resolve", nativeItem)) as { detail: string };
+      const proxyResolved = (await proxy.request("completionItem/resolve", proxyItem)) as { detail: string };
+      strict.ok(nativeResolved.detail.includes("number"));
+      strict.strictEqual(proxyResolved.detail, nativeResolved.detail, "upstream completion resolve details");
+      const formattingRequest = { textDocument: { uri: databaseUri }, options: { tabSize: 2, insertSpaces: true } };
+      const nativeFormatting = (await upstream.request("textDocument/formatting", formattingRequest)) as unknown[];
+      strict.ok(nativeFormatting.length > 0, "formatting comparison must produce actual edits");
+      strict.deepStrictEqual(await proxy.request("textDocument/formatting", formattingRequest), nativeFormatting);
       const tokenRequest = { textDocument: { uri: databaseUri } };
       const nativeTokens = (await upstream.request("textDocument/semanticTokens/full", tokenRequest)) as SemanticTokens;
       const projected = (await proxy.request("textDocument/semanticTokens/full", tokenRequest)) as SemanticTokens;
@@ -196,6 +217,9 @@ await describe("upstream TypeScript LSP integration", async () => {
         tokensAt(reconstructed, positionAt(changedSource, changedSource.lastIndexOf("shared"))),
         expectedTokens,
       );
+      await strict.rejects(proxy.request("completionItem/resolve", proxyItem), /-32801:/u);
+      proxy.notify("textDocument/didClose", { textDocument: { uri: databaseUri } });
+      await strict.rejects(proxy.request("completionItem/resolve", proxyItem), /Resolve context expired/u);
     } finally {
       await Promise.all([upstream.close(), proxy.close()]);
     }


### PR DESCRIPTION
## Summary
- Preserve opaque upstream data inside proxy-owned resolve envelopes; retain one bounded source identity per result batch.
- Restore ownership for completion, code action, inlay hint and code lens resolve requests; reject expired, wrong-method and stale identities.
- Respect completion item default data, omit optional partial-result tokens for these routes, and clear contexts on document refresh/close.
- Keep upstream TypeScript completion details and formatting behavior, with direct protocol comparisons.

## Validation
- pnpm build / pnpm quality
- All 9 language-server test files
- pnpm api:check
- Focused resolve/upstream tests repeated after adding refresh cleanup
- Deterministic edit-bearing fixtures prove mapping ownership; real upstream test proves member completion details, meaningful formatting edits, stale resolve rejection and close cleanup.

Cache: at most 256 result batches; upstream payloads are carried in client data, not retained by the cache. This does not yet prove all refactor-generated newText is safe; #155 remains open.

Closes #163. Part of #155 and #153.