### PR TITLE
test(vscode): verify packaged workspace trust boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,8 @@ jobs:
       - run: pnpm --filter @typed-sql/e2e-mysql generate:snapshot
       - run: pnpm exec poku packages/language-server/test/language-server.test.ts --reporter=compact --enforce
       - run: pnpm --filter ./editors/vscode package:vsix
+      - run: xvfb-run -a pnpm --filter ./editors/vscode test:host
+        timeout-minutes: 10
       - run: rustup target add wasm32-wasip2
       - run: cargo test --manifest-path editors/zed/Cargo.toml
       - run: pnpm editor:zed:build
@@ -487,7 +489,10 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: typed-sql-editor-artifacts
-          path: artifacts/
+          path: |
+            artifacts/
+            !artifacts/editor-host/downloads/**
+            !artifacts/editor-host/v-*/**
 
   pull-request-distribution:
     if: github.event_name == 'pull_request'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,26 @@ Neutral packages must not branch on a dialect id, package name, server, or drive
 [Author a custom SQL grammar](https://github.com/Lojhan/typed-sql/blob/main/docs/extending/custom-grammars.md)
 for the public contract and `AGENTS.md` for repository invariants.
 
+## Verify the packaged VS Code client
+
+Build the VSIX before running the isolated editor host suite:
+
+```sh
+pnpm --filter ./editors/vscode package:vsix
+pnpm --filter ./editors/vscode test:host
+```
+
+The suite downloads VS Code 1.134.0 and installs the VSIX into separate extension/profile
+directories for trusted, Restricted Mode and virtual-workspace scenarios. It uses a controlled
+server probe to assert whether the client executes workspace code; it does not prove SQL inference
+or complete editor-feature parity. No personal editor profile is used. Linux CI runs the suite
+under `xvfb-run -a`; its isolated Electron process uses `--no-sandbox` for hosted-runner compatibility.
+
+Downloads, profiles and result JSON normally live under `artifacts/editor-host/`. If the checkout
+path exceeds Unix socket limits, set `TYPED_SQL_HOST_DATA_ROOT` to a shorter user-owned directory.
+Result JSON is also copied into `artifacts/editor-host/results/`; CI excludes downloads and full
+profiles from artifact uploads. Runs preserve their unique directories for diagnosis.
+
 ## Investigate static-analysis findings
 
 The optional review toolchain runs ESLint cyclomatic complexity and selected correctness rules,

--- a/docs/guides/editors.md
+++ b/docs/guides/editors.md
@@ -71,6 +71,11 @@ and re-enable the built-in extension if you return to the ordinary TypeScript se
 Run **typed-sql: Show TypeScript Bridge Status** to inspect the pinned TypeScript version and the
 open/indexed document counts reported by each workspace server.
 
+The extension requires a trusted workspace because it executes the workspace-installed server and
+project configuration. It stays disabled in Restricted Mode and does not support virtual workspaces
+whose files are exposed through non-filesystem providers. This is distinct from running in a remote
+workspace extension host with filesystem access.
+
 ## Other LSP clients
 
 Start the installed server over standard input/output:

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,4 +1,5 @@
 src/**
+test/**
 tsconfig.json
 bundle/*.map
 dist/**

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # typed-sql
 
+## Unreleased
+
+- Declare the workspace trust requirement and unsupported virtual-workspace boundary explicitly.
+- Verify the packaged VSIX in isolated trusted, Restricted Mode and virtual-workspace hosts.
+
 ## 1.0.0
 
 ### Major Changes

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -27,6 +27,13 @@
   "extensionKind": [
     "workspace"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "typed-sql runs the workspace-installed language server and project configuration. Trust the workspace to enable it."
+    },
+    "virtualWorkspaces": false
+  },
   "main": "./bundle/extension.cjs",
   "activationEvents": [
     "onLanguage:typescript",
@@ -90,6 +97,7 @@
     }
   },
   "scripts": {
+    "test:host": "node test/run-host.mjs",
     "build:bundle": "esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=bundle/extension.cjs --external:vscode --external:tsx/* --sourcemap",
     "package:vsix": "node -e \"require('node:fs').mkdirSync('../../artifacts',{recursive:true})\" && pnpm build:bundle && vsce package --no-dependencies --out ../../artifacts/typed-sql-vscode.vsix"
   },
@@ -98,6 +106,7 @@
   },
   "devDependencies": {
     "@types/vscode": "1.134.0",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.2",
     "esbuild": "0.28.2"
   }

--- a/editors/vscode/test/harness/extension.cjs
+++ b/editors/vscode/test/harness/extension.cjs
@@ -1,0 +1,31 @@
+const vscode = require("vscode");
+const contents = Buffer.from("export const example = 1;\n");
+const readonly = () => {
+  throw vscode.FileSystemError.NoPermissions();
+};
+exports.activate = (context) => {
+  const changes = new vscode.EventEmitter();
+  context.subscriptions.push(
+    changes,
+    vscode.workspace.registerFileSystemProvider(
+      "typed-sql-test",
+      {
+        onDidChangeFile: changes.event,
+        watch: () => new vscode.Disposable(() => {}),
+        stat: (uri) => ({
+          type: uri.path.endsWith(".ts") ? vscode.FileType.File : vscode.FileType.Directory,
+          ctime: 0,
+          mtime: 0,
+          size: contents.length,
+        }),
+        readDirectory: () => [["query.ts", vscode.FileType.File]],
+        readFile: () => contents,
+        writeFile: readonly,
+        createDirectory: readonly,
+        delete: readonly,
+        rename: readonly,
+      },
+      { isReadonly: true },
+    ),
+  );
+};

--- a/editors/vscode/test/harness/package.json
+++ b/editors/vscode/test/harness/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "typed-sql-host-test-harness",
+  "publisher": "typed-sql-tests",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./extension.cjs",
+  "activationEvents": [
+    "onFileSystem:typed-sql-test"
+  ],
+  "engines": {
+    "vscode": "^1.134.0"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  }
+}

--- a/editors/vscode/test/host-suite.cjs
+++ b/editors/vscode/test/host-suite.cjs
@@ -1,0 +1,29 @@
+const assert = require("node:assert/strict");
+const { existsSync, writeFileSync } = require("node:fs");
+const vscode = require("vscode");
+
+exports.run = async () => {
+  const mode = process.env.TYPED_SQL_HOST_MODE;
+  const trusted = mode !== "untrusted";
+  assert.equal(vscode.workspace.isTrusted, trusted, "host must enter the intended trust mode");
+  assert.equal(vscode.workspace.workspaceFolders[0].uri.scheme === "file", mode !== "virtual");
+  const document = await vscode.workspace.openTextDocument(
+    vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "query.ts"),
+  );
+  await vscode.window.showTextDocument(document);
+  const target = vscode.extensions.getExtension("lojhan.typed-sql");
+  if (mode === "trusted") {
+    assert.ok(target, "packaged extension must be installed");
+    await target.activate();
+    assert.equal(target.isActive, true);
+    assert.ok(existsSync(process.env.TYPED_SQL_HOST_MARKER), "trusted activation must start the configured server");
+  } else {
+    assert.equal(
+      target,
+      undefined,
+      "unsupported extension must be excluded from the host registry, not merely awaiting activation",
+    );
+    assert.ok(!existsSync(process.env.TYPED_SQL_HOST_MARKER), "unsupported workspace must not execute its server");
+  }
+  writeFileSync(process.env.TYPED_SQL_HOST_REPORT, JSON.stringify({ mode, vscode: vscode.version, passed: true }));
+};

--- a/editors/vscode/test/probe-server.cjs
+++ b/editors/vscode/test/probe-server.cjs
@@ -1,0 +1,19 @@
+const { writeFileSync } = require("node:fs");
+writeFileSync(process.env.TYPED_SQL_HOST_MARKER, "started");
+let buffer = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  for (;;) {
+    const boundary = buffer.indexOf("\r\n\r\n");
+    if (boundary < 0) return;
+    const length = Number(/Content-Length:\s*(\d+)/i.exec(buffer.subarray(0, boundary).toString())[1]);
+    if (buffer.length < boundary + 4 + length) return;
+    const message = JSON.parse(buffer.subarray(boundary + 4, boundary + 4 + length));
+    buffer = buffer.subarray(boundary + 4 + length);
+    if (message.method === "exit") process.exit(0);
+    if (message.id === undefined) continue;
+    const result = message.method === "initialize" ? { capabilities: {} } : null;
+    const body = JSON.stringify({ jsonrpc: "2.0", id: message.id, result });
+    process.stdout.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+  }
+});

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -1,0 +1,88 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from "@vscode/test-electron";
+
+const execFile = promisify(execFileCallback);
+const directory = dirname(fileURLToPath(import.meta.url));
+const root = resolve(directory, "../../..");
+const artifacts = join(root, "artifacts/editor-host");
+await mkdir(artifacts, { recursive: true });
+const dataRoot = resolve(process.env.TYPED_SQL_HOST_DATA_ROOT ?? artifacts);
+await mkdir(dataRoot, { recursive: true });
+const run = await mkdtemp(join(dataRoot, "v-"));
+const executable = await downloadAndUnzipVSCode({
+  version: "1.134.0",
+  cachePath: join(artifacts, "downloads"),
+  timeout: 30_000,
+});
+const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable);
+for (const mode of ["trusted", "untrusted", "virtual"]) {
+  const base = join(run, mode[0]);
+  const workspace = join(base, "workspace");
+  const profile = join(base, "p");
+  if (process.platform !== "win32" && Buffer.byteLength(join(profile, "1.134-main.sock")) > 100) {
+    throw new Error(
+      "Set TYPED_SQL_HOST_DATA_ROOT to a shorter directory for editor IPC sockets (not a system temporary directory).",
+    );
+  }
+  const extensions = join(base, "extensions");
+  await mkdir(join(workspace, ".vscode"), { recursive: true });
+  await writeFile(join(workspace, "query.ts"), "export const example = 1;\n");
+  const workspaceFile = join(base, "virtual.code-workspace");
+  if (mode === "virtual")
+    await writeFile(
+      workspaceFile,
+      JSON.stringify({
+        folders: [{ uri: "typed-sql-test:/workspace" }],
+        settings: { "typedSql.serverPath": join(directory, "probe-server.cjs") },
+      }),
+    );
+  await writeFile(
+    join(workspace, ".vscode/settings.json"),
+    JSON.stringify({ "typedSql.serverPath": join(directory, "probe-server.cjs") }),
+  );
+  await mkdir(join(profile, "User"), { recursive: true });
+  await writeFile(
+    join(profile, "User/settings.json"),
+    JSON.stringify({ "security.workspace.trust.startupPrompt": "never", "extensions.autoUpdate": false }),
+  );
+  const isolated = ["--user-data-dir", profile, "--extensions-dir", extensions];
+  await execFile(cli, [...cliArgs, ...isolated, "--install-extension", join(root, "artifacts/typed-sql-vscode.vsix")], {
+    timeout: 60_000,
+  });
+  // test-electron's runTests adds --disable-workspace-trust unconditionally.
+  // Launch the documented extension-test entrypoint directly so Restricted Mode
+  // is genuinely exercised, rather than accidentally testing two trusted hosts.
+  await execFile(
+    executable,
+    [
+      mode === "virtual" ? workspaceFile : workspace,
+      ...isolated,
+      "--skip-welcome",
+      "--skip-release-notes",
+      ...(process.platform === "linux" ? ["--no-sandbox"] : []),
+      "--disable-extension",
+      "vscode.typescript-language-features",
+      `--extensionDevelopmentPath=${join(directory, "harness")}`,
+      `--extensionTestsPath=${join(directory, "host-suite.cjs")}`,
+      ...(mode !== "untrusted" ? ["--disable-workspace-trust"] : []),
+    ],
+    {
+      timeout: 90_000,
+      maxBuffer: 4 * 1024 * 1024,
+      env: {
+        ...process.env,
+        TYPED_SQL_HOST_MODE: mode,
+        TYPED_SQL_HOST_MARKER: join(base, "server-started"),
+        TYPED_SQL_HOST_REPORT: join(base, "result.json"),
+      },
+    },
+  );
+  const results = join(artifacts, "results", basename(run));
+  await mkdir(results, { recursive: true });
+  await writeFile(join(results, `${mode}.json`), await readFile(join(base, "result.json")));
+}
+console.log(`VS Code host evidence: ${run}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@types/vscode':
         specifier: 1.134.0
         version: 1.134.0
+      '@vscode/test-electron':
+        specifier: 3.1.0
+        version: 3.1.0
       '@vscode/vsce':
         specifier: 3.9.2
         version: 3.9.2
@@ -1682,6 +1685,10 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
+
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
     cpu: [arm64]
@@ -1966,6 +1973,14 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2001,6 +2016,9 @@ packages:
   copy-anything@4.1.0:
     resolution: {integrity: sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   crelt@1.0.7:
     resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
@@ -2089,6 +2107,9 @@ packages:
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2224,6 +2245,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2323,6 +2348,9 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -2358,6 +2386,10 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2365,9 +2397,20 @@ packages:
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2420,6 +2463,9 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -2435,6 +2481,9 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
@@ -2469,6 +2518,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -2548,6 +2601,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -2624,11 +2681,19 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
   p-limit@3.1.0:
@@ -2645,6 +2710,9 @@ packages:
 
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
@@ -2783,6 +2851,9 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -2815,6 +2886,9 @@ packages:
     resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
     engines: {node: '>=0.8'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -2836,6 +2910,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2854,6 +2932,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2881,6 +2962,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2972,9 +3056,20 @@ packages:
     resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4406,6 +4501,16 @@ snapshots:
       vite: 6.4.3(@types/node@24.13.3)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.41(typescript@7.0.2)
 
+  '@vscode/test-electron@3.1.0':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jszip: 3.10.1
+      ora: 8.2.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     optional: true
 
@@ -4747,6 +4852,12 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -4775,6 +4886,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   copy-anything@4.1.0: {}
+
+  core-util-is@1.0.3: {}
 
   crelt@1.0.7: {}
 
@@ -4861,6 +4974,8 @@ snapshots:
       version-range: 4.15.0
 
   emoji-regex-xs@1.0.0: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -5038,6 +5153,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5162,12 +5279,13 @@ snapshots:
 
   ignore@7.0.6: {}
 
+  immediate@3.0.6: {}
+
   import-meta-resolve@4.2.0: {}
 
   index-to-position@1.2.0: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
@@ -5186,13 +5304,21 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@2.0.0: {}
+
   is-number@7.0.0: {}
 
   is-property@1.0.2: {}
 
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -5250,6 +5376,13 @@ snapshots:
       ms: 2.1.3
       semver: 7.8.5
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -5273,6 +5406,10 @@ snapshots:
       shell-quote: 1.10.0
 
   leven@3.1.0: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   linkify-it@5.0.2:
     dependencies:
@@ -5299,6 +5436,11 @@ snapshots:
   lodash.truncate@4.4.2: {}
 
   lodash@4.18.1: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   long@5.3.2: {}
 
@@ -5379,6 +5521,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mimic-function@5.0.1: {}
+
   mimic-response@3.1.0:
     optional: true
 
@@ -5455,6 +5599,10 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-to-es@3.1.1:
     dependencies:
       emoji-regex-xs: 1.0.0
@@ -5468,6 +5616,18 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5479,6 +5639,8 @@ snapshots:
   p-map@7.0.6: {}
 
   package-manager-detector@1.8.0: {}
+
+  pako@1.0.11: {}
 
   parse-json@8.3.0:
     dependencies:
@@ -5605,6 +5767,8 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
+  process-nextick-args@2.0.1: {}
+
   property-information@7.2.0: {}
 
   pump@3.0.4:
@@ -5651,6 +5815,16 @@ snapshots:
     dependencies:
       mute-stream: 0.0.8
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -5671,6 +5845,11 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   reusify@1.1.0: {}
 
@@ -5714,6 +5893,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -5737,6 +5918,8 @@ snapshots:
   semver@5.7.2: {}
 
   semver@7.8.5: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5840,11 +6023,23 @@ snapshots:
 
   sql-escaper@1.5.1: {}
 
+  stdin-discarder@0.2.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -6050,8 +6245,7 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:

--- a/scripts/assert-editor-artifacts.mjs
+++ b/scripts/assert-editor-artifacts.mjs
@@ -39,6 +39,13 @@ assert.ok(
 const manifest = JSON.parse(await unzip("extension/package.json"));
 assert.equal(manifest.main, "./bundle/extension.cjs");
 assert.deepEqual(manifest.extensionKind, ["workspace"]);
+assert.equal(manifest.capabilities?.untrustedWorkspaces?.supported, false);
+assert.ok(manifest.capabilities.untrustedWorkspaces.description.length > 0);
+assert.equal(manifest.capabilities.virtualWorkspaces, false);
+assert.ok(
+  listing.every((path) => !path.startsWith("extension/test/")),
+  "VSIX must not ship host-test fixtures",
+);
 assert.deepEqual(manifest.activationEvents, [
   "onLanguage:typescript",
   "onLanguage:typescriptreact",

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -43,6 +43,19 @@ await describe("external editor distribution", async () => {
     strict.ok((await text("editors/zed/Cargo.toml")).includes('version = "0.1.0"'));
   });
 
+  await it("requires trust and a filesystem workspace for project executable loading", async () => {
+    const manifest = JSON.parse(await text("editors/vscode/package.json")) as {
+      capabilities: { untrustedWorkspaces: { supported: boolean; description: string }; virtualWorkspaces: boolean };
+    };
+    strict.strictEqual(manifest.capabilities.untrustedWorkspaces.supported, false);
+    strict.ok(manifest.capabilities.untrustedWorkspaces.description.includes("workspace-installed"));
+    strict.strictEqual(manifest.capabilities.virtualWorkspaces, false);
+    strict.ok((await text("editors/vscode/.vscodeignore")).includes("test/**"));
+    strict.ok(
+      (await text(".github/workflows/ci.yml")).includes("xvfb-run -a pnpm --filter ./editors/vscode test:host"),
+    );
+  });
+
   await it("resolves Zed's application-local package before development fallbacks", async () => {
     const source = await text("editors/zed/src/lib.rs");
     const installed = source.indexOf("node_modules/@typed-sql/language-server");


### PR DESCRIPTION
## Summary
- Declare unsupported untrusted and virtual workspaces explicitly.
- Exercise the actual packaged VSIX in isolated VS Code 1.134.0 hosts: trusted activation, Restricted Mode exclusion, and virtual-workspace exclusion.
- Add Linux CI host verification and retain compact evidence without uploading downloaded editors or profiles.
- Document the trust boundary and maintainer verification procedure.

## Verification
- Frozen dependency installation and pnpm quality passed.
- Editor distribution, documentation, and package graph contracts passed.
- Packaged VSIX artifact smoke checks passed.
- All three real macOS ARM64 host scenarios passed with a controlled protocol probe.

## Scope
Part of #169 and #153. The probe verifies client activation boundaries, not complete TypeScript or SQL feature parity. Startup recovery and broader host coverage remain outstanding. The extension is private and Changesets-ignored; its changelog records the change without changing stable library versions.