### PR TITLE
fix(language-server): retain diagnostics in real VS Code overlay hosts

### DIFF
--- a/.changeset/quiet-overlays-diagnostics.md
+++ b/.changeset/quiet-overlays-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Keep combined TypeScript and SQL diagnostics visible in pull-diagnostic clients such as VS Code. Overlay refresh requests a fresh pull instead of overwriting the report with a SQL-only push; push-only clients retain their existing delivery path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,20 @@ for the public contract and `AGENTS.md` for repository invariants.
 Build the VSIX before running the isolated editor host suite:
 
 ```sh
+pnpm build
 pnpm --filter ./editors/vscode package:vsix
 pnpm --filter ./editors/vscode test:host
 ```
 
 The suite downloads VS Code 1.134.0 and installs the VSIX into separate extension/profile
-directories for trusted, Restricted Mode and virtual-workspace scenarios. It uses a controlled
-server probe to assert whether the client executes workspace code; it does not prove SQL inference
-or complete editor-feature parity. No personal editor profile is used. Linux CI runs the suite
+directories for trusted, Restricted Mode, virtual-workspace and real-overlay scenarios. The first
+three use a controlled server probe to assert whether the client executes workspace code. The
+overlay scenario uses built workspace packages and the real language server with the pinned
+upstream TypeScript LSP: it checks inferred row hover/completion, TypeScript errors, source-mapped
+navigation and unsaved query refresh through VS Code APIs. The built-in TypeScript extension is
+disabled in these isolated profiles so it cannot mask missing providers. This is not proof of
+all editor features or a packed language-server installation; packed consumers have separate
+verification. No personal editor profile is used. Linux CI runs the suite
 under `xvfb-run -a`; its isolated Electron process uses `--no-sandbox` for hosted-runner compatibility.
 
 Downloads, profiles and result JSON normally live under `artifacts/editor-host/`. If the checkout

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Verify real SQL overlays, inferred completions, TypeScript diagnostics and unsaved edits through an isolated packaged VS Code host.
+
 - Declare the workspace trust requirement and unsupported virtual-workspace boundary explicitly.
 - Verify the packaged VSIX in isolated trusted, Restricted Mode and virtual-workspace hosts.
 

--- a/editors/vscode/test/overlay-suite.cjs
+++ b/editors/vscode/test/overlay-suite.cjs
@@ -1,0 +1,121 @@
+const assert = require("node:assert/strict");
+const { writeFileSync } = require("node:fs");
+const vscode = require("vscode");
+
+async function eventually(label, check) {
+  const deadline = Date.now() + 25_000;
+  let last;
+  do {
+    try {
+      return await check();
+    } catch (error) {
+      last = error;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  } while (Date.now() < deadline);
+  throw new Error(`${label}: ${last?.stack ?? last}`);
+}
+
+exports.run = async () => {
+  assert.equal(vscode.workspace.isTrusted, true);
+  assert.equal(vscode.extensions.getExtension("vscode.typescript-language-features"), undefined);
+  const uri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "query.ts");
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+  const target = vscode.extensions.getExtension("lojhan.typed-sql");
+  assert.ok(target);
+  await target.activate();
+  const position = (needle, offset = 0) => {
+    const index = document.getText().indexOf(needle);
+    assert.notEqual(index, -1, needle);
+    return document.positionAt(index + offset);
+  };
+  const hover = async (needle, offset = 0) => {
+    const result = await vscode.commands.executeCommand("vscode.executeHoverProvider", uri, position(needle, offset));
+    return (result ?? []).flatMap((item) => item.contents.map((content) => content.value ?? content)).join("\n");
+  };
+  await eventually("inferred row member hover", async () => {
+    assert.match(await hover("return row.name", "return row.".length), /name.*string/s);
+  });
+  await eventually("inferred row completion", async () => {
+    const result = await vscode.commands.executeCommand(
+      "vscode.executeCompletionItemProvider",
+      uri,
+      position("return row.name", "return row.".length),
+      undefined,
+      10,
+    );
+    const labels = result.items.map((item) => (typeof item.label === "string" ? item.label : item.label.label));
+    assert.ok(labels.includes("id") && labels.includes("name"), JSON.stringify(labels));
+  });
+  await eventually("mapped TypeScript diagnostic", async () => {
+    const diagnostics = vscode.languages
+      .getDiagnostics(uri)
+      .filter((item) => item.severity === vscode.DiagnosticSeverity.Error);
+    assert.ok(
+      diagnostics.some((item) => item.range.start.line === 7 && /string.*number/s.test(item.message)),
+      JSON.stringify(diagnostics),
+    );
+    assert.ok(!diagnostics.some((item) => item.range.start.line === 6), "correct assignment must not fail");
+  });
+  const definitions = await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    uri,
+    position("void ordinary.count", "void ".length),
+  );
+  assert.ok(
+    definitions.some((item) => {
+      const range = item.targetSelectionRange ?? item.range;
+      return (item.targetUri ?? item.uri).toString() === uri.toString() && document.getText(range) === "ordinary";
+    }),
+    "ordinary definition after same-line SQL overlay must map to original source",
+  );
+  assert.match(await hover("ordinary.count", "ordinary.".length), /number/);
+
+  const edit = new vscode.WorkspaceEdit();
+  const start = position("id, name FROM");
+  edit.replace(uri, new vscode.Range(start, start.translate(0, "id, name".length)), "id, age AS name");
+  assert.equal(await vscode.workspace.applyEdit(edit), true);
+  assert.equal(document.isDirty, true, "overlay refresh must use an unsaved editor change");
+  await eventually("unsaved query invalidates inferred type", async () => {
+    const value = await hover("return row.name", "return row.".length);
+    assert.match(value, /name.*number/s);
+    assert.match(value, /null/);
+    assert.doesNotMatch(value, /name.*string/s);
+  });
+  await eventually("diagnostics follow refreshed overlay", async () => {
+    assert.ok(
+      vscode.languages
+        .getDiagnostics(uri)
+        .some((item) => item.range.start.line === 6 && /number|nullable|null/.test(item.message)),
+    );
+  });
+  const invalid = new vscode.WorkspaceEdit();
+  const age = position("age AS name");
+  invalid.replace(uri, new vscode.Range(age, age.translate(0, 3)), "not_a_column");
+  assert.equal(await vscode.workspace.applyEdit(invalid), true);
+  await eventually("SQL diagnostics survive pull delivery", async () => {
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    assert.ok(
+      diagnostics.some((item) => item.source === "typed-sql" && /not_a_column/.test(item.message)),
+      JSON.stringify(diagnostics),
+    );
+  });
+  writeFileSync(
+    process.env.TYPED_SQL_HOST_REPORT,
+    JSON.stringify({
+      mode: "overlays",
+      vscode: vscode.version,
+      passed: true,
+      checks: [
+        "row-hover",
+        "row-completion",
+        "typescript-diagnostic",
+        "source-definition",
+        "ordinary-hover",
+        "unsaved-query-refresh",
+        "sql-diagnostic",
+      ],
+    }),
+  );
+};

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -4,6 +4,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from "@vscode/test-electron";
+import { prepareOverlayWorkspace } from "./setup-overlays.mjs";
 
 const execFile = promisify(execFileCallback);
 const directory = dirname(fileURLToPath(import.meta.url));
@@ -19,7 +20,7 @@ const executable = await downloadAndUnzipVSCode({
   timeout: 30_000,
 });
 const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable);
-for (const mode of ["trusted", "untrusted", "virtual"]) {
+for (const mode of ["trusted", "untrusted", "virtual", "overlays"]) {
   const base = join(run, mode[0]);
   const workspace = join(base, "workspace");
   const profile = join(base, "p");
@@ -44,6 +45,7 @@ for (const mode of ["trusted", "untrusted", "virtual"]) {
     join(workspace, ".vscode/settings.json"),
     JSON.stringify({ "typedSql.serverPath": join(directory, "probe-server.cjs") }),
   );
+  if (mode === "overlays") await prepareOverlayWorkspace(workspace, root);
   await mkdir(join(profile, "User"), { recursive: true });
   await writeFile(
     join(profile, "User/settings.json"),
@@ -67,7 +69,7 @@ for (const mode of ["trusted", "untrusted", "virtual"]) {
       "--disable-extension",
       "vscode.typescript-language-features",
       `--extensionDevelopmentPath=${join(directory, "harness")}`,
-      `--extensionTestsPath=${join(directory, "host-suite.cjs")}`,
+      `--extensionTestsPath=${join(directory, mode === "overlays" ? "overlay-suite.cjs" : "host-suite.cjs")}`,
       ...(mode !== "untrusted" ? ["--disable-workspace-trust"] : []),
     ],
     {

--- a/editors/vscode/test/setup-overlays.mjs
+++ b/editors/vscode/test/setup-overlays.mjs
@@ -1,0 +1,48 @@
+import { copyFile, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function prepareOverlayWorkspace(workspace, root) {
+  // Real built packages, not a protocol probe. Packed dependency installation is
+  // independently exercised by the packed-consumer suite.
+  await symlink(join(root, "node_modules"), join(workspace, "node_modules"), "junction");
+  await writeFile(join(workspace, "package.json"), JSON.stringify({ type: "module", private: true }));
+  await writeFile(
+    join(workspace, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { strict: true, noEmit: true, target: "ES2024", module: "NodeNext", skipLibCheck: true },
+      include: ["query.ts", "database.ts"],
+    }),
+  );
+  for (const file of ["schema.json", "database.ts"])
+    await copyFile(join(root, "test/fixtures/success", file), join(workspace, file));
+  await writeFile(
+    join(workspace, "typed-sql.config.ts"),
+    'import { postgres } from "@typed-sql/postgres";\nexport default { dialect: postgres(), schema: { file: "schema.json" }, outDir: "generated", projects: ["tsconfig.json"] };\n',
+  );
+  await writeFile(
+    join(workspace, ".vscode/settings.json"),
+    JSON.stringify({
+      "typedSql.serverPath": join(root, "packages/language-server/dist/packages/language-server/src/server.js"),
+      "typedSql.configPath": join(workspace, "typed-sql.config.ts"),
+      "typedSql.schemaPath": join(workspace, "schema.json"),
+      "typedSql.projectFile": join(workspace, "tsconfig.json"),
+    }),
+  );
+  await writeFile(
+    join(workspace, "query.ts"),
+    [
+      'import { sql } from "@typed-sql/postgres";',
+      'import { db } from "./database.js";',
+      "const query = sql`SELECT id, name FROM users`; const ordinary = { count: 1 }; void ordinary.count;",
+      "async function verify() {",
+      "  const rows = await db.execute(query);",
+      "  const row = rows[0]!;",
+      "  const correct: string = row.name;",
+      "  const wrong: number = row.name;",
+      "  return row.name;",
+      "}",
+      "void verify;",
+      "",
+    ].join("\n"),
+  );
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -143,6 +143,8 @@ const sourceDocuments = new Map<string, TextDocument>();
 const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
+let pullDiagnostics = false;
+let diagnosticRefreshSupported = false;
 const semanticTokenResults = new SemanticTokenResults();
 const resolveContexts = new ResolveContexts<DocumentState>();
 const pendingDocuments = new Map<string, Promise<void>>();
@@ -450,6 +452,13 @@ async function combinedDiagnostics(state: DocumentState): Promise<readonly unkno
 
 async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
   if (latestDocumentVersions.get(state.original.uri) !== state.original.version) return;
+  if (pullDiagnostics) {
+    // A typed-sql-only push would replace the client's combined pull report and
+    // erase TypeScript errors. Ask it to pull again after overlay invalidation.
+    // Do not await: the new pull must be able to wait for this document queue.
+    if (diagnosticRefreshSupported) void client.sendRequest("workspace/diagnostic/refresh").catch(() => undefined);
+    return;
+  }
   const diagnostics = await combinedDiagnostics(state);
   if (
     latestDocumentVersions.get(state.original.uri) !== state.original.version ||
@@ -546,6 +555,15 @@ client.onRequest("initialize", async (rawParams) => {
   const roots = workspaceDirectories(params);
   await configureServices(roots, settingsFrom(params.initializationOptions));
   const result = await nativeRequest<JsonObject>("initialize", params);
+  const capabilities = isObject(params.capabilities) ? params.capabilities : {};
+  const textCapabilities = isObject(capabilities.textDocument) ? capabilities.textDocument : {};
+  const workspaceCapabilities = isObject(capabilities.workspace) ? capabilities.workspace : {};
+  pullDiagnostics =
+    isObject(textCapabilities.diagnostic) &&
+    isObject(result.capabilities) &&
+    isObject(result.capabilities.diagnosticProvider);
+  diagnosticRefreshSupported =
+    isObject(workspaceCapabilities.diagnostics) && workspaceCapabilities.diagnostics.refreshSupport === true;
   return {
     ...result,
     capabilities: extendTypeScriptCapabilities(result.capabilities),

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -56,6 +56,14 @@ await describe("external editor distribution", async () => {
     );
   });
 
+  await it("runs real overlay host verification alongside probe-only trust checks", async () => {
+    const runner = await text("editors/vscode/test/run-host.mjs");
+    strict.ok(runner.includes('"trusted", "untrusted", "virtual", "overlays"'));
+    strict.ok(runner.includes("prepareOverlayWorkspace(workspace, root)"));
+    strict.ok(runner.includes('"overlay-suite.cjs"'));
+    strict.ok((await text("CONTRIBUTING.md")).includes("not proof of"));
+  });
+
   await it("resolves Zed's application-local package before development fallbacks", async () => {
     const source = await text("editors/zed/src/lib.rs");
     const installed = source.indexOf("node_modules/@typed-sql/language-server");


### PR DESCRIPTION
## Outcome
Actual packaged VS Code host tests now exercise the real built language server and pinned upstream TypeScript LSP, not only a protocol probe. They exposed SQL-only push reports clearing combined TypeScript pull diagnostics. Negotiate pull delivery and request refresh without blocking document queues; preserve push-only behavior.

## Evidence
- Before the fix, row hover/completion worked but the real host diagnostic collection stayed empty for an invalid string-to-number assignment.
- After the fix, host assertions cover inferred row hover/completion, mapped TypeScript assignment errors, ordinary definition and hover after a same-line SQL overlay, unsaved query type changes, and SQL diagnostics.
- All four host scenarios pass locally on macOS ARM64 / VS Code 1.134.0; built-in TypeScript is disabled in isolated profiles to prove provider attribution.
- All nine language-server test files, focused Poku editor/documentation contracts, quality, build, VSIX packaging and artifact smoke checks pass.
- Patch Changeset included for the experimental language server.

## Limits
Uses a packaged VSIX and real built workspace dependencies, not a freshly packed language-server installation. No full parity claim: schema-file refresh, restart recovery, multi-root, TSX, remote hosts, coexistence and the complete refactor set still need actual-host evidence. Existing trust scenarios remain in CI.

Closes #178. Closes #179. Part of #153 and #155.