### PR TITLE
test(editors): share grammar scenarios and host evidence matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ pnpm --filter ./editors/vscode test:host
 The suite downloads VS Code 1.134.0 and installs the VSIX into separate extension/profile
 directories for trusted, Restricted Mode, virtual-workspace and real-overlay scenarios. The first
 three use a controlled server probe to assert whether the client executes workspace code. The
-overlay scenario uses built workspace packages and the real language server with the pinned
+overlay matrix uses PostgreSQL, MySQL, SQLite and the synthetic third-party grammar, built workspace
+packages and the real language server with the pinned
 upstream TypeScript LSP: it checks inferred row hover/completion, TypeScript errors, source-mapped
 navigation and unsaved query refresh through VS Code APIs. The built-in TypeScript extension is
 disabled in these isolated profiles so it cannot mask missing providers. This is not proof of
@@ -74,6 +75,26 @@ Downloads, profiles and result JSON normally live under `artifacts/editor-host/`
 path exceeds Unix socket limits, set `TYPED_SQL_HOST_DATA_ROOT` to a shorter user-owned directory.
 Result JSON is also copied into `artifacts/editor-host/results/`; CI excludes downloads and full
 profiles from artifact uploads. Runs preserve their unique directories for diagnosis.
+
+### Shared editor/grammar hub
+
+`test/editor-hub/` owns grammar-specific snapshots, source programs, expected types and shared
+interface assertions. Host adapters supply observed hover, completion, diagnostic, definition
+and unsaved-edit behavior. Add cases here rather than copying grammar expectations into editor
+adapters. These are representative integration fixtures, not all syntax or server-version coverage.
+
+Each run writes `matrix.json` beside individual results, crossing VS Code/Zed, four grammars and
+the interface inventory. Missing and unimplemented cells stay `not-run`; protocol evidence is
+rejected as host evidence. Failures remain failures and prevent the host command from passing.
+The current VS Code host executes seven checks per grammar plus three independent trust scenarios.
+
+Run `pnpm editor:zed:fixtures` after building to prepare the same four projects and workspace-local
+Zed settings under a unique `artifacts/editor-hub/zed-*` directory. This only prepares fixtures:
+it does not install extensions, launch Zed or assert host behavior. Its matrix remains not run.
+Actual Zed execution needs an isolated profile, the built dev extension, a host adapter and exact
+version/platform evidence before any Zed cell can pass. See the official
+[CLI reference](https://zed.dev/docs/reference/cli) and
+[extension development guide](https://zed.dev/docs/extensions/developing-extensions).
 
 ## Investigate static-analysis findings
 

--- a/editors/vscode/test/overlay-suite.cjs
+++ b/editors/vscode/test/overlay-suite.cjs
@@ -2,21 +2,22 @@ const assert = require("node:assert/strict");
 const { writeFileSync } = require("node:fs");
 const vscode = require("vscode");
 
-async function eventually(label, check) {
-  const deadline = Date.now() + 25_000;
-  let last;
-  do {
-    try {
-      return await check();
-    } catch (error) {
-      last = error;
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-  } while (Date.now() < deadline);
-  throw new Error(`${label}: ${last?.stack ?? last}`);
-}
-
 exports.run = async () => {
+  const { grammarCases, interfaces } = await import("../../../test/editor-hub/cases.mjs");
+  const { runScenario } = await import("../../../test/editor-hub/scenario.mjs");
+  const spec = grammarCases.find((item) => item.id === process.env.TYPED_SQL_HOST_GRAMMAR);
+  assert.ok(spec, "the host must select an explicit grammar case");
+  const report = {
+    mode: "overlays",
+    editor: "vscode",
+    grammar: spec.id,
+    vscode: vscode.version,
+    evidence: "actual-host",
+    passed: false,
+    checks: Object.fromEntries(interfaces.map((id) => [id, { status: "not-run" }])),
+  };
+  const save = () => writeFileSync(process.env.TYPED_SQL_HOST_REPORT, JSON.stringify(report));
+  save();
   assert.equal(vscode.workspace.isTrusted, true);
   assert.equal(vscode.extensions.getExtension("vscode.typescript-language-features"), undefined);
   const uri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "query.ts");
@@ -30,92 +31,62 @@ exports.run = async () => {
     assert.notEqual(index, -1, needle);
     return document.positionAt(index + offset);
   };
-  const hover = async (needle, offset = 0) => {
-    const result = await vscode.commands.executeCommand("vscode.executeHoverProvider", uri, position(needle, offset));
-    return (result ?? []).flatMap((item) => item.contents.map((content) => content.value ?? content)).join("\n");
-  };
-  await eventually("inferred row member hover", async () => {
-    assert.match(await hover("return row.name", "return row.".length), /name.*string/s);
-  });
-  await eventually("inferred row completion", async () => {
-    const result = await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      uri,
-      position("return row.name", "return row.".length),
-      undefined,
-      10,
-    );
-    const labels = result.items.map((item) => (typeof item.label === "string" ? item.label : item.label.label));
-    assert.ok(labels.includes("id") && labels.includes("name"), JSON.stringify(labels));
-  });
-  await eventually("mapped TypeScript diagnostic", async () => {
-    const diagnostics = vscode.languages
-      .getDiagnostics(uri)
-      .filter((item) => item.severity === vscode.DiagnosticSeverity.Error);
-    assert.ok(
-      diagnostics.some((item) => item.range.start.line === 7 && /string.*number/s.test(item.message)),
-      JSON.stringify(diagnostics),
-    );
-    assert.ok(!diagnostics.some((item) => item.range.start.line === 6), "correct assignment must not fail");
-  });
-  const definitions = await vscode.commands.executeCommand(
-    "vscode.executeDefinitionProvider",
-    uri,
-    position("void ordinary.count", "void ".length),
+  await runScenario(
+    spec,
+    {
+      async hover(needle, offset) {
+        const result = await vscode.commands.executeCommand(
+          "vscode.executeHoverProvider",
+          uri,
+          position(needle, offset),
+        );
+        return (result ?? []).flatMap((item) => item.contents.map((content) => content.value ?? content)).join("\n");
+      },
+      async completions(needle, offset) {
+        const result = await vscode.commands.executeCommand(
+          "vscode.executeCompletionItemProvider",
+          uri,
+          position(needle, offset),
+          undefined,
+          10,
+        );
+        return (result?.items ?? []).map((item) => (typeof item.label === "string" ? item.label : item.label.label));
+      },
+      async diagnostics() {
+        return vscode.languages.getDiagnostics(uri).map((item) => ({
+          error: item.severity === vscode.DiagnosticSeverity.Error,
+          line: item.range.start.line,
+          source: item.source,
+          message: item.message,
+        }));
+      },
+      async definitions(needle, offset) {
+        const result = await vscode.commands.executeCommand(
+          "vscode.executeDefinitionProvider",
+          uri,
+          position(needle, offset),
+        );
+        return (result ?? []).map((item) => ({
+          ownDocument: (item.targetUri ?? item.uri).toString() === uri.toString(),
+          text: document.getText(item.targetSelectionRange ?? item.range),
+        }));
+      },
+      async replace(source) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+          uri,
+          new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length)),
+          source,
+        );
+        assert.equal(await vscode.workspace.applyEdit(edit), true);
+        assert.equal(document.isDirty, true, "refresh must exercise an unsaved editor change");
+      },
+    },
+    (id, status, error) => {
+      report.checks[id] = { status, ...(error === undefined ? {} : { error }) };
+      save();
+    },
   );
-  assert.ok(
-    definitions.some((item) => {
-      const range = item.targetSelectionRange ?? item.range;
-      return (item.targetUri ?? item.uri).toString() === uri.toString() && document.getText(range) === "ordinary";
-    }),
-    "ordinary definition after same-line SQL overlay must map to original source",
-  );
-  assert.match(await hover("ordinary.count", "ordinary.".length), /number/);
-
-  const edit = new vscode.WorkspaceEdit();
-  const start = position("id, name FROM");
-  edit.replace(uri, new vscode.Range(start, start.translate(0, "id, name".length)), "id, age AS name");
-  assert.equal(await vscode.workspace.applyEdit(edit), true);
-  assert.equal(document.isDirty, true, "overlay refresh must use an unsaved editor change");
-  await eventually("unsaved query invalidates inferred type", async () => {
-    const value = await hover("return row.name", "return row.".length);
-    assert.match(value, /name.*number/s);
-    assert.match(value, /null/);
-    assert.doesNotMatch(value, /name.*string/s);
-  });
-  await eventually("diagnostics follow refreshed overlay", async () => {
-    assert.ok(
-      vscode.languages
-        .getDiagnostics(uri)
-        .some((item) => item.range.start.line === 6 && /number|nullable|null/.test(item.message)),
-    );
-  });
-  const invalid = new vscode.WorkspaceEdit();
-  const age = position("age AS name");
-  invalid.replace(uri, new vscode.Range(age, age.translate(0, 3)), "not_a_column");
-  assert.equal(await vscode.workspace.applyEdit(invalid), true);
-  await eventually("SQL diagnostics survive pull delivery", async () => {
-    const diagnostics = vscode.languages.getDiagnostics(uri);
-    assert.ok(
-      diagnostics.some((item) => item.source === "typed-sql" && /not_a_column/.test(item.message)),
-      JSON.stringify(diagnostics),
-    );
-  });
-  writeFileSync(
-    process.env.TYPED_SQL_HOST_REPORT,
-    JSON.stringify({
-      mode: "overlays",
-      vscode: vscode.version,
-      passed: true,
-      checks: [
-        "row-hover",
-        "row-completion",
-        "typescript-diagnostic",
-        "source-definition",
-        "ordinary-hover",
-        "unsaved-query-refresh",
-        "sql-diagnostic",
-      ],
-    }),
-  );
+  report.passed = true;
+  save();
 };

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -4,6 +4,8 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from "@vscode/test-electron";
+import { grammarCases } from "../../../test/editor-hub/cases.mjs";
+import { buildMatrix } from "../../../test/editor-hub/matrix.mjs";
 import { prepareOverlayWorkspace } from "./setup-overlays.mjs";
 
 const execFile = promisify(execFileCallback);
@@ -20,8 +22,17 @@ const executable = await downloadAndUnzipVSCode({
   timeout: 30_000,
 });
 const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable);
-for (const mode of ["trusted", "untrusted", "virtual", "overlays"]) {
-  const base = join(run, mode[0]);
+const scenarios = [
+  ...["trusted", "untrusted", "virtual"].map((mode) => ({ mode, id: mode })),
+  ...grammarCases.map((spec) => ({ mode: "overlays", id: spec.id, spec })),
+];
+const reports = [];
+const failures = [];
+const results = join(artifacts, "results", basename(run));
+await mkdir(results, { recursive: true });
+await writeFile(join(results, "matrix.json"), JSON.stringify(buildMatrix(reports), null, 2));
+for (const [index, { mode, id, spec }] of scenarios.entries()) {
+  const base = join(run, String(index));
   const workspace = join(base, "workspace");
   const profile = join(base, "p");
   if (process.platform !== "win32" && Buffer.byteLength(join(profile, "1.134-main.sock")) > 100) {
@@ -45,7 +56,7 @@ for (const mode of ["trusted", "untrusted", "virtual", "overlays"]) {
     join(workspace, ".vscode/settings.json"),
     JSON.stringify({ "typedSql.serverPath": join(directory, "probe-server.cjs") }),
   );
-  if (mode === "overlays") await prepareOverlayWorkspace(workspace, root);
+  if (mode === "overlays") await prepareOverlayWorkspace(workspace, root, spec);
   await mkdir(join(profile, "User"), { recursive: true });
   await writeFile(
     join(profile, "User/settings.json"),
@@ -58,33 +69,55 @@ for (const mode of ["trusted", "untrusted", "virtual", "overlays"]) {
   // test-electron's runTests adds --disable-workspace-trust unconditionally.
   // Launch the documented extension-test entrypoint directly so Restricted Mode
   // is genuinely exercised, rather than accidentally testing two trusted hosts.
-  await execFile(
-    executable,
-    [
-      mode === "virtual" ? workspaceFile : workspace,
-      ...isolated,
-      "--skip-welcome",
-      "--skip-release-notes",
-      ...(process.platform === "linux" ? ["--no-sandbox"] : []),
-      "--disable-extension",
-      "vscode.typescript-language-features",
-      `--extensionDevelopmentPath=${join(directory, "harness")}`,
-      `--extensionTestsPath=${join(directory, mode === "overlays" ? "overlay-suite.cjs" : "host-suite.cjs")}`,
-      ...(mode !== "untrusted" ? ["--disable-workspace-trust"] : []),
-    ],
-    {
-      timeout: 90_000,
-      maxBuffer: 4 * 1024 * 1024,
-      env: {
-        ...process.env,
-        TYPED_SQL_HOST_MODE: mode,
-        TYPED_SQL_HOST_MARKER: join(base, "server-started"),
-        TYPED_SQL_HOST_REPORT: join(base, "result.json"),
+  let failure;
+  try {
+    await execFile(
+      executable,
+      [
+        mode === "virtual" ? workspaceFile : workspace,
+        ...isolated,
+        "--skip-welcome",
+        "--skip-release-notes",
+        ...(process.platform === "linux" ? ["--no-sandbox"] : []),
+        "--disable-extension",
+        "vscode.typescript-language-features",
+        `--extensionDevelopmentPath=${join(directory, "harness")}`,
+        `--extensionTestsPath=${join(directory, mode === "overlays" ? "overlay-suite.cjs" : "host-suite.cjs")}`,
+        ...(mode !== "untrusted" ? ["--disable-workspace-trust"] : []),
+      ],
+      {
+        timeout: 90_000,
+        maxBuffer: 4 * 1024 * 1024,
+        env: {
+          ...process.env,
+          TYPED_SQL_HOST_MODE: mode,
+          TYPED_SQL_HOST_GRAMMAR: spec?.id ?? "",
+          TYPED_SQL_HOST_MARKER: join(base, "server-started"),
+          TYPED_SQL_HOST_REPORT: join(base, "result.json"),
+        },
       },
-    },
-  );
-  const results = join(artifacts, "results", basename(run));
-  await mkdir(results, { recursive: true });
-  await writeFile(join(results, `${mode}.json`), await readFile(join(base, "result.json")));
+    );
+  } catch (error) {
+    failure = error;
+    failures.push(id);
+  }
+  let report;
+  try {
+    report = JSON.parse(await readFile(join(base, "result.json"), "utf8"));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  if (failure !== undefined || report?.passed !== true) {
+    if (!failures.includes(id)) failures.push(id);
+    report = {
+      ...report,
+      passed: false,
+      hostError: String(failure ?? "Host did not write a passing report").slice(0, 4000),
+    };
+  }
+  await writeFile(join(results, `${id}.json`), JSON.stringify(report, null, 2));
+  if (report?.grammar !== undefined) reports.push(report);
+  await writeFile(join(results, "matrix.json"), JSON.stringify(buildMatrix(reports), null, 2));
 }
 console.log(`VS Code host evidence: ${run}`);
+if (failures.length > 0) throw new Error(`Host scenarios failed: ${failures.join(", ")}. Evidence: ${results}`);

--- a/editors/vscode/test/setup-overlays.mjs
+++ b/editors/vscode/test/setup-overlays.mjs
@@ -1,48 +1,14 @@
-import { copyFile, symlink, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { prepareWorkspace } from "../../../test/editor-hub/workspace.mjs";
 
-export async function prepareOverlayWorkspace(workspace, root) {
-  // Real built packages, not a protocol probe. Packed dependency installation is
-  // independently exercised by the packed-consumer suite.
-  await symlink(join(root, "node_modules"), join(workspace, "node_modules"), "junction");
-  await writeFile(join(workspace, "package.json"), JSON.stringify({ type: "module", private: true }));
-  await writeFile(
-    join(workspace, "tsconfig.json"),
-    JSON.stringify({
-      compilerOptions: { strict: true, noEmit: true, target: "ES2024", module: "NodeNext", skipLibCheck: true },
-      include: ["query.ts", "database.ts"],
-    }),
-  );
-  for (const file of ["schema.json", "database.ts"])
-    await copyFile(join(root, "test/fixtures/success", file), join(workspace, file));
-  await writeFile(
-    join(workspace, "typed-sql.config.ts"),
-    'import { postgres } from "@typed-sql/postgres";\nexport default { dialect: postgres(), schema: { file: "schema.json" }, outDir: "generated", projects: ["tsconfig.json"] };\n',
-  );
+export async function prepareOverlayWorkspace(workspace, root, spec) {
+  const settings = await prepareWorkspace(workspace, root, spec);
   await writeFile(
     join(workspace, ".vscode/settings.json"),
     JSON.stringify({
       "typedSql.serverPath": join(root, "packages/language-server/dist/packages/language-server/src/server.js"),
-      "typedSql.configPath": join(workspace, "typed-sql.config.ts"),
-      "typedSql.schemaPath": join(workspace, "schema.json"),
-      "typedSql.projectFile": join(workspace, "tsconfig.json"),
+      ...Object.fromEntries(Object.entries(settings).map(([key, value]) => [`typedSql.${key}`, value])),
     }),
-  );
-  await writeFile(
-    join(workspace, "query.ts"),
-    [
-      'import { sql } from "@typed-sql/postgres";',
-      'import { db } from "./database.js";',
-      "const query = sql`SELECT id, name FROM users`; const ordinary = { count: 1 }; void ordinary.count;",
-      "async function verify() {",
-      "  const rows = await db.execute(query);",
-      "  const row = rows[0]!;",
-      "  const correct: string = row.name;",
-      "  const wrong: number = row.name;",
-      "  return row.name;",
-      "}",
-      "void verify;",
-      "",
-    ].join("\n"),
   );
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mysql:catalog:check": "node scripts/generate-mysql-catalog.mjs --check",
     "docs:serve": "pnpm --filter typed-sql-docs serve",
     "editor:artifacts:smoke": "node scripts/assert-editor-artifacts.mjs",
+    "editor:zed:fixtures": "node test/editor-hub/prepare-zed.mjs",
     "editor:promotion:review": "node scripts/review-editor-promotion.mjs",
     "editor:zed:build": "node scripts/build-zed-artifact.mjs",
     "test:pack": "poku test/contracts/packed-consumer.test.ts --reporter=compact --enforce",

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -58,8 +58,9 @@ await describe("external editor distribution", async () => {
 
   await it("runs real overlay host verification alongside probe-only trust checks", async () => {
     const runner = await text("editors/vscode/test/run-host.mjs");
-    strict.ok(runner.includes('"trusted", "untrusted", "virtual", "overlays"'));
-    strict.ok(runner.includes("prepareOverlayWorkspace(workspace, root)"));
+    strict.ok(runner.includes('"trusted", "untrusted", "virtual"'));
+    strict.ok(runner.includes("grammarCases.map"));
+    strict.ok(runner.includes("prepareOverlayWorkspace(workspace, root, spec)"));
     strict.ok(runner.includes('"overlay-suite.cjs"'));
     strict.ok((await text("CONTRIBUTING.md")).includes("not proof of"));
   });

--- a/test/contracts/editor-hub.test.ts
+++ b/test/contracts/editor-hub.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, strict } from "poku";
+import { grammarCases, interfaces, sourceFor } from "../editor-hub/cases.mjs";
+import { buildMatrix, pendingInterfaces } from "../editor-hub/matrix.mjs";
+
+await describe("editor grammar evidence hub", async () => {
+  await it("covers owned grammars and the external grammar without homogenizing semantics", () => {
+    strict.deepStrictEqual(
+      grammarCases.map((item) => item.id),
+      ["postgres", "mysql", "sqlite", "synthetic"],
+    );
+    for (const spec of grammarCases) {
+      strict.strictEqual(spec.schema.dialect, spec.id);
+      strict.ok(sourceFor(spec).includes(spec.packageName));
+      strict.ok(sourceFor(spec, spec.changed).includes(spec.changed.query));
+      strict.notStrictEqual(spec.initial.type, spec.changed.type);
+      strict.notStrictEqual(spec.initial.query, spec.invalidQuery);
+    }
+    strict.strictEqual(grammarCases[3]!.initial.member, "value");
+    strict.strictEqual(grammarCases[3]!.changed.member, "label");
+  });
+  await it("starts every editor/grammar/interface cell as not run", () => {
+    const matrix = buildMatrix([]);
+    strict.strictEqual(matrix.cells.length, 2 * 4 * (interfaces.length + pendingInterfaces.length));
+    strict.ok(matrix.cells.every((cell) => cell.status === "not-run"));
+  });
+  await it("does not promote partial, protocol or duplicate evidence into full host coverage", () => {
+    const report = {
+      editor: "vscode",
+      grammar: "postgres",
+      evidence: "actual-host",
+      vscode: "1.134.0",
+      checks: {
+        "row-hover": { status: "passed" },
+        "row-completion": { status: "failed", error: "missing name" },
+      },
+    };
+    const matrix = buildMatrix([report]);
+    strict.strictEqual(matrix.cells.filter((cell) => cell.status === "passed").length, 1);
+    strict.strictEqual(matrix.cells.filter((cell) => cell.status === "failed").length, 1);
+    strict.ok(matrix.cells.filter((cell) => cell.editor === "zed").every((cell) => cell.status === "not-run"));
+    strict.throws(() => buildMatrix([{ ...report, evidence: "protocol" }]), /protocol evidence/);
+    strict.throws(() => buildMatrix([report, report]), /duplicate/);
+    strict.throws(() => buildMatrix([{ ...report, grammar: "unknown" }]), /unknown grammar/);
+    strict.throws(() => buildMatrix([{ ...report, checks: { invented: { status: "passed" } } }]), /unknown interface/);
+    strict.throws(() => buildMatrix([{ ...report, checks: { "row-hover": { status: "skipped" } } }]), /unknown status/);
+  });
+});

--- a/test/editor-hub/cases.d.mts
+++ b/test/editor-hub/cases.d.mts
@@ -1,0 +1,20 @@
+export interface Variant {
+  query: string;
+  member: string;
+  type: string;
+}
+export interface GrammarCase {
+  id: string;
+  packageName: string;
+  packageDirectory: string;
+  factory: string;
+  schema: Record<string, unknown>;
+  initial: Variant & { completions: string[] };
+  changed: Variant;
+  wrongType: string;
+  invalidQuery: string;
+  diagnosticPattern: string;
+}
+export const grammarCases: GrammarCase[];
+export const interfaces: string[];
+export function sourceFor(spec: GrammarCase, variant?: Variant): string;

--- a/test/editor-hub/cases.mjs
+++ b/test/editor-hub/cases.mjs
@@ -1,0 +1,91 @@
+// Grammar syntax and type-policy expectations live here, never in host adapters.
+const column = (name, databaseType, tsType, nullable = false) => ({ name, databaseType, tsType, nullable });
+const sqlCase = (id, version, types) => ({
+  id,
+  packageName: `@typed-sql/${id}`,
+  packageDirectory: `packages/${id}`,
+  factory: id,
+  schema: {
+    formatVersion: 1,
+    dialect: id,
+    dialectVersion: "1.0.0",
+    version,
+    tables: {
+      users: {
+        name: "users",
+        ...(id === "sqlite"
+          ? { schema: "main", kind: "table", strict: true, withoutRowid: false, indexes: [], foreignKeys: [] }
+          : {}),
+        columns: {
+          id: column("id", types.id, id === "sqlite" ? "bigint" : "number"),
+          name: column("name", types.text, "string"),
+          age: column("age", types.age, "number", true),
+        },
+      },
+    },
+  },
+  initial: { query: "SELECT id, name FROM users", member: "name", type: "string", completions: ["id", "name"] },
+  changed: { query: "SELECT id, age AS name FROM users", member: "name", type: "number | null" },
+  wrongType: "number",
+  invalidQuery: "SELECT not_a_column FROM users",
+  diagnosticPattern: "not_a_column",
+});
+
+export const grammarCases = [
+  sqlCase("postgres", "16", { id: "integer", text: "text", age: "real" }),
+  sqlCase("mysql", "8.4.0", { id: "int", text: "varchar", age: "double" }),
+  sqlCase("sqlite", "3.51.0", { id: "INTEGER", text: "TEXT", age: "REAL" }),
+  {
+    id: "synthetic",
+    packageName: "@typed-sql/example-synthetic-grammar",
+    packageDirectory: "examples/synthetic-grammar",
+    factory: "synthetic",
+    schema: {
+      formatVersion: 1,
+      dialect: "synthetic",
+      dialectVersion: "1.0.0",
+      version: "1.0.0",
+      tables: {
+        widgets: {
+          name: "widgets",
+          columns: {
+            value: column("value", "scalar", "number"),
+            label: column("label", "text", "string", true),
+          },
+        },
+      },
+    },
+    initial: { query: "SELECT value FROM widgets", member: "value", type: "number", completions: ["value"] },
+    changed: { query: "SELECT label FROM widgets", member: "label", type: "string | null" },
+    wrongType: "string",
+    invalidQuery: "UNSUPPORTED",
+    diagnosticPattern: "does not support",
+  },
+];
+
+export const interfaces = [
+  "row-hover",
+  "row-completion",
+  "typescript-diagnostic",
+  "source-definition",
+  "ordinary-hover",
+  "unsaved-query-refresh",
+  "sql-diagnostic",
+];
+
+export function sourceFor(spec, variant = spec.initial) {
+  return [
+    `import { sql } from ${JSON.stringify(spec.packageName)};`,
+    'import { db } from "./database.js";',
+    `const query = sql\`${variant.query}\`; const ordinary = { count: 1 }; void ordinary.count;`,
+    "async function verify() {",
+    "  const rows = await db.execute(query);",
+    "  const row = rows[0]!;",
+    `  const correct: ${spec.initial.type} = row.${variant.member};`,
+    `  const wrong: ${spec.wrongType} = row.${variant.member};`,
+    `  return row.${variant.member};`,
+    "}",
+    "void verify;",
+    "",
+  ].join("\n");
+}

--- a/test/editor-hub/matrix.d.mts
+++ b/test/editor-hub/matrix.d.mts
@@ -1,0 +1,14 @@
+export interface HostReport {
+  editor: string;
+  grammar: string;
+  evidence: string;
+  vscode?: string;
+  hostVersion?: string;
+  checks: Record<string, { status: string; error?: string }>;
+}
+export const pendingInterfaces: string[];
+export function buildMatrix(reports: HostReport[]): {
+  formatVersion: number;
+  scope: string;
+  cells: { editor: string; grammar: string; interface: string; status: string; reason?: string }[];
+};

--- a/test/editor-hub/matrix.mjs
+++ b/test/editor-hub/matrix.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { grammarCases, interfaces } from "./cases.mjs";
+
+export const pendingInterfaces = [
+  "schema-file-refresh",
+  "restart-recovery",
+  "multi-root",
+  "tsx",
+  "sql-hover",
+  "sql-completion",
+  "parameter-inference",
+  "references",
+  "rename",
+  "formatting",
+  "code-actions",
+  "semantic-tokens",
+  "packed-server-install",
+  "builtin-coexistence",
+];
+
+export function buildMatrix(reports) {
+  const inventory = [...interfaces, ...pendingInterfaces];
+  const seen = new Set();
+  for (const report of reports) {
+    assert.ok(["vscode", "zed"].includes(report.editor), "unknown editor");
+    assert.ok(
+      grammarCases.some((spec) => spec.id === report.grammar),
+      "unknown grammar",
+    );
+    assert.equal(report.evidence, "actual-host", "protocol evidence cannot prove host behavior");
+    const key = `${report.editor}/${report.grammar}`;
+    assert.ok(!seen.has(key), "duplicate host report");
+    seen.add(key);
+    for (const [id, check] of Object.entries(report.checks)) {
+      assert.ok(inventory.includes(id), "unknown interface");
+      assert.ok(["passed", "failed", "not-run"].includes(check.status), "unknown status");
+    }
+  }
+  return {
+    formatVersion: 1,
+    scope: "actual-host baseline; not full grammar or editor-feature conformance",
+    cells: ["vscode", "zed"].flatMap((editor) =>
+      grammarCases.flatMap((spec) => {
+        const report = reports.find((item) => item.editor === editor && item.grammar === spec.id);
+        return inventory.map((id) => ({
+          editor,
+          grammar: spec.id,
+          interface: id,
+          status: report?.checks[id]?.status ?? "not-run",
+          ...(report === undefined
+            ? { reason: "No actual-host evidence supplied" }
+            : {
+                hostVersion: report.vscode ?? report.hostVersion,
+                ...(report.checks[id] === undefined ? { reason: "Scenario not implemented" } : report.checks[id]),
+              }),
+        }));
+      }),
+    ),
+  };
+}

--- a/test/editor-hub/prepare-zed.mjs
+++ b/test/editor-hub/prepare-zed.mjs
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { grammarCases } from "./cases.mjs";
+import { buildMatrix } from "./matrix.mjs";
+import { prepareWorkspace } from "./workspace.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const artifacts = join(root, "artifacts/editor-hub");
+await mkdir(artifacts, { recursive: true });
+const run = await mkdtemp(join(artifacts, "zed-"));
+const workspaces = [];
+for (const spec of grammarCases) {
+  const directory = join(run, spec.id);
+  const settings = await prepareWorkspace(directory, root, spec);
+  await mkdir(join(directory, ".zed"), { recursive: true });
+  await writeFile(
+    join(directory, ".zed/settings.json"),
+    JSON.stringify(
+      {
+        languages: { TypeScript: { language_servers: ["typed-sql"] }, TSX: { language_servers: ["typed-sql"] } },
+        lsp: {
+          "typed-sql": {
+            binary: {
+              path: process.execPath,
+              arguments: [
+                join(root, "packages/language-server/dist/packages/language-server/src/server.js"),
+                "--stdio",
+              ],
+            },
+            settings,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  workspaces.push({ grammar: spec.id, directory, file: join(directory, "query.ts") });
+}
+await writeFile(
+  join(run, "manifest.json"),
+  JSON.stringify(
+    {
+      status: "prepared-only",
+      extension: join(root, "editors/zed"),
+      workspaces,
+      warning:
+        "No Zed process launched and no host assertion executed. Install the dev extension into an isolated profile before host validation.",
+    },
+    null,
+    2,
+  ),
+);
+await writeFile(join(run, "matrix.json"), JSON.stringify(buildMatrix([]), null, 2));
+console.log(`Prepared shared Zed fixtures (not host evidence): ${run}`);

--- a/test/editor-hub/scenario.mjs
+++ b/test/editor-hub/scenario.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { interfaces, sourceFor } from "./cases.mjs";
+
+async function eventually(label, check) {
+  const deadline = Date.now() + 25_000;
+  let last;
+  do {
+    try {
+      return await check();
+    } catch (error) {
+      last = error;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  } while (Date.now() < deadline);
+  throw new Error(`${label}: ${last?.stack ?? last}`);
+}
+
+function assertType(hover, member, type) {
+  assert.ok(hover.includes(member), hover);
+  for (const part of type.split(" | ")) assert.match(hover, new RegExp(`\\b${part}\\b`));
+  assert.doesNotMatch(hover, /\b(any|unknown)\b/);
+}
+
+// Host adapters supply observed editor values, not expected grammar semantics.
+export async function runScenario(spec, host, record) {
+  const check = async (id, run) => {
+    assert.ok(interfaces.includes(id));
+    try {
+      await run();
+      record(id, "passed");
+    } catch (error) {
+      record(id, "failed", String(error));
+      throw error;
+    }
+  };
+  const marker = (variant) => `return row.${variant.member}`;
+  const memberOffset = "return row.".length;
+  await check("row-hover", () =>
+    eventually("row hover", async () =>
+      assertType(await host.hover(marker(spec.initial), memberOffset), spec.initial.member, spec.initial.type),
+    ),
+  );
+  await check("row-completion", () =>
+    eventually("row completion", async () => {
+      const labels = await host.completions(marker(spec.initial), memberOffset);
+      for (const name of spec.initial.completions) assert.ok(labels.includes(name), JSON.stringify(labels));
+    }),
+  );
+  await check("typescript-diagnostic", () =>
+    eventually("TypeScript diagnostic", async () => {
+      const errors = (await host.diagnostics()).filter((item) => item.error);
+      assert.ok(
+        errors.some((item) => item.line === 7 && /not assignable/.test(item.message)),
+        JSON.stringify(errors),
+      );
+      assert.ok(!errors.some((item) => item.line === 6), JSON.stringify(errors));
+    }),
+  );
+  await check("source-definition", async () =>
+    assert.ok(
+      (await host.definitions("void ordinary.count", "void ".length)).some(
+        (item) => item.ownDocument && item.text === "ordinary",
+      ),
+      "definition after same-line overlay must locate original identifier",
+    ),
+  );
+  await check("ordinary-hover", async () =>
+    assert.match(await host.hover("ordinary.count", "ordinary.".length), /number/),
+  );
+  await check("unsaved-query-refresh", async () => {
+    await host.replace(sourceFor(spec, spec.changed));
+    await eventually("unsaved inference", async () =>
+      assertType(await host.hover(marker(spec.changed), memberOffset), spec.changed.member, spec.changed.type),
+    );
+    await eventually("refreshed diagnostic", async () =>
+      assert.ok(
+        (await host.diagnostics()).some((item) => item.error && item.line === 6 && /not assignable/.test(item.message)),
+      ),
+    );
+  });
+  await check("sql-diagnostic", async () => {
+    await host.replace(sourceFor(spec, { ...spec.changed, query: spec.invalidQuery }));
+    await eventually("SQL diagnostic", async () =>
+      assert.ok(
+        (await host.diagnostics()).some(
+          (item) => item.source === "typed-sql" && new RegExp(spec.diagnosticPattern).test(item.message),
+        ),
+      ),
+    );
+  });
+}

--- a/test/editor-hub/workspace.mjs
+++ b/test/editor-hub/workspace.mjs
@@ -1,0 +1,32 @@
+import { copyFile, mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { sourceFor } from "./cases.mjs";
+
+export async function prepareWorkspace(workspace, root, spec) {
+  await mkdir(join(workspace, "node_modules/@typed-sql"), { recursive: true });
+  for (const [name, directory] of [
+    ["@typed-sql/core", "packages/core"],
+    [spec.packageName, spec.packageDirectory],
+  ])
+    await symlink(join(root, directory), join(workspace, "node_modules", name), "junction");
+  await writeFile(join(workspace, "package.json"), JSON.stringify({ type: "module", private: true }));
+  await writeFile(
+    join(workspace, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { strict: true, noEmit: true, target: "ES2024", module: "NodeNext", skipLibCheck: true },
+      include: ["query.ts", "database.ts"],
+    }),
+  );
+  await copyFile(join(root, "test/fixtures/success/database.ts"), join(workspace, "database.ts"));
+  await writeFile(join(workspace, "schema.json"), JSON.stringify(spec.schema));
+  await writeFile(
+    join(workspace, "typed-sql.config.ts"),
+    `import { ${spec.factory} } from ${JSON.stringify(spec.packageName)};\nexport default { dialect: ${spec.factory}(), schema: { file: "schema.json" }, outDir: "generated", projects: ["tsconfig.json"] };\n`,
+  );
+  await writeFile(join(workspace, "query.ts"), sourceFor(spec));
+  return {
+    configPath: join(workspace, "typed-sql.config.ts"),
+    schemaPath: join(workspace, "schema.json"),
+    projectFile: join(workspace, "tsconfig.json"),
+  };
+}


### PR DESCRIPTION
## Outcome
- Editor-neutral fixture and assertion hub covers PostgreSQL, MySQL, SQLite and the synthetic third-party grammar without modifying grammar semantics.
- VS Code adapter observes editor APIs; seven shared interface checks execute per grammar through the actual packaged VSIX and real built language server.
- Matrix reports cross two editors, four grammars and 21 interfaces. Missing, failed and not-run evidence is explicit; protocol evidence cannot count as host proof.
- Preserve three independent trust scenarios, retain per-check failure evidence, and continue across launched host failures while returning a failing exit status.
- Prepare identical Zed projects and workspace-local configuration through editor:zed:fixtures; no personal profiles, extension installation or Zed launch is performed.

## Verification
- Seven real VS Code 1.134.0 host scenarios pass locally on macOS ARM64: three trust boundaries plus four grammar runs.
- Matrix: 28 passed cells, zero failed, 140 not-run. No Zed cell is advertised as passed.
- Typecheck, quality, focused Poku hub/distribution/documentation/package-graph contracts and Zed fixture preparation pass.

## Limits
Representative TypeScript integration fixtures, not exhaustive grammar syntax, server-version coverage, driver execution or full editor parity. Zed actual-host automation remains #182. Built dependencies are linked; packed server installation is separate. Test/maintainer tooling only, no production package behavior or dependency changes and no Changeset required.

Closes #181. Part of #153 and #155. Prepares #182 without closing it.