### PR TITLE
fix(language-server): clear project failures after schema recovery

### DIFF
--- a/.changeset/fresh-schema-recovery.md
+++ b/.changeset/fresh-schema-recovery.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Clear a previously published project-unavailable diagnostic after schema analysis recovers in pull-diagnostic clients. Preserve current TypeScript and SQL diagnostics by refreshing the combined pull report.

--- a/.changeset/fresh-schema-recovery.md
+++ b/.changeset/fresh-schema-recovery.md
@@ -2,4 +2,4 @@
 "@typed-sql/language-server": patch
 ---
 
-Clear a previously published project-unavailable diagnostic after schema analysis recovers in pull-diagnostic clients. Preserve current TypeScript and SQL diagnostics by refreshing the combined pull report.
+Return project-unavailable diagnostics through pull requests while schema analysis is unavailable, and clear the previously pushed failure after recovery. Preserve current TypeScript and SQL diagnostics by refreshing the combined pull report.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,8 @@ jobs:
       - run: cargo test --manifest-path editors/zed/Cargo.toml
       - run: pnpm editor:zed:build
       - run: pnpm editor:artifacts:smoke
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: typed-sql-editor-artifacts
           path: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,11 @@ adapters. These are representative integration fixtures, not all syntax or serve
 Each run writes `matrix.json` beside individual results, crossing VS Code/Zed, four grammars and
 the interface inventory. Missing and unimplemented cells stay `not-run`; protocol evidence is
 rejected as host evidence. Failures remain failures and prevent the host command from passing.
-The current VS Code host executes seven checks per grammar plus three independent trust scenarios.
+The current VS Code host executes eight checks per grammar plus three independent trust scenarios.
+Schema lifecycle checks write the actual snapshot file while leaving the source buffer unchanged.
+PostgreSQL/MySQL/SQLite verify nullability refresh; every grammar verifies incompatible-envelope
+rejection, fail-closed inference and recovery after restoring the snapshot. The synthetic fixture
+does not derive row types from column metadata, so it tests envelope/recovery behavior only.
 
 Run `pnpm editor:zed:fixtures` after building to prepare the same four projects and workspace-local
 Zed settings under a unique `artifacts/editor-hub/zed-*` directory. This only prepares fixtures:

--- a/editors/vscode/test/overlay-suite.cjs
+++ b/editors/vscode/test/overlay-suite.cjs
@@ -81,6 +81,14 @@ exports.run = async () => {
         assert.equal(await vscode.workspace.applyEdit(edit), true);
         assert.equal(document.isDirty, true, "refresh must exercise an unsaved editor change");
       },
+      async writeSchema(schema) {
+        const version = document.version;
+        await vscode.workspace.fs.writeFile(
+          vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema.json"),
+          Buffer.from(JSON.stringify(schema)),
+        );
+        assert.equal(document.version, version, "schema refresh must not edit the source buffer");
+      },
     },
     (id, status, error) => {
       report.checks[id] = { status, ...(error === undefined ? {} : { error }) };

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -116,6 +116,7 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
     };
   }
   await writeFile(join(results, `${id}.json`), JSON.stringify(report, null, 2));
+  if (report.passed !== true) console.error(`Host failure ${id}: ${JSON.stringify(report)}`);
   if (report?.grammar !== undefined) reports.push(report);
   await writeFile(join(results, "matrix.json"), JSON.stringify(buildMatrix(reports), null, 2));
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -688,7 +688,12 @@ client.onRequest(TYPED_SQL_STATUS_REQUEST, async (): Promise<TypedSqlLanguageSer
 });
 
 client.onRequest(async (method, rawParams, token) => {
-  await workspaceReady;
+  try {
+    await workspaceReady;
+  } catch (error) {
+    if (method === "textDocument/diagnostic") return { kind: "full", items: [projectFailureDiagnostic(error)] };
+    throw error;
+  }
   const restored = method.endsWith("/resolve") ? resolveContexts.restore(rawParams, method) : { item: rawParams };
   if (restored.expired === true)
     throw new ResponseError(LSP_CONTENT_MODIFIED, "Resolve context expired; request fresh items");

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -143,7 +143,7 @@ const sourceDocuments = new Map<string, TextDocument>();
 const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
-const projectFailureReports = new Set<string>();
+const projectFailureReports = new Map<string, JsonObject>();
 let pullDiagnostics = false;
 let diagnosticRefreshSupported = false;
 const semanticTokenResults = new SemanticTokenResults();
@@ -293,12 +293,14 @@ function queueDocument(uri: string, operation: () => Promise<void>): Promise<voi
     .catch(async (error: unknown) => {
       if (error instanceof Error && error.name === "AbortError") return;
       nativeDiagnostics.delete(uri);
-      if (sourceDocuments.has(uri)) projectFailureReports.add(uri);
+      const diagnostic = projectFailureDiagnostic(error);
+      if (sourceDocuments.has(uri)) projectFailureReports.set(uri, diagnostic);
       await client.sendNotification("textDocument/publishDiagnostics", {
         uri,
         ...(latestDocumentVersions.get(uri) === undefined ? {} : { version: latestDocumentVersions.get(uri) }),
-        diagnostics: [projectFailureDiagnostic(error)],
+        diagnostics: [diagnostic],
       });
+      requestDiagnosticRefresh();
     });
   pendingDocuments.set(uri, pending);
   return pending.finally(() => {
@@ -320,13 +322,15 @@ function queueWorkspace(operation: () => Promise<void>): Promise<void> {
     .catch(async (error: unknown) => {
       for (const [uri, state] of documents) {
         nativeDiagnostics.delete(uri);
-        if (sourceDocuments.has(uri)) projectFailureReports.add(uri);
+        const diagnostic = projectFailureDiagnostic(error);
+        if (sourceDocuments.has(uri)) projectFailureReports.set(uri, diagnostic);
         await client.sendNotification("textDocument/publishDiagnostics", {
           uri,
           version: state.original.version,
-          diagnostics: [projectFailureDiagnostic(error)],
+          diagnostics: [diagnostic],
         });
       }
+      requestDiagnosticRefresh();
     });
   return workspaceReady;
 }
@@ -453,6 +457,13 @@ async function combinedDiagnostics(state: DocumentState): Promise<readonly unkno
   ]);
 }
 
+function requestDiagnosticRefresh(): void {
+  // Never await a refresh from a document/workspace queue: the new pull waits
+  // for that queue to finish, including when schema analysis failed.
+  if (pullDiagnostics && diagnosticRefreshSupported)
+    void client.sendRequest("workspace/diagnostic/refresh").catch(() => undefined);
+}
+
 async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
   if (latestDocumentVersions.get(state.original.uri) !== state.original.version) return;
   if (pullDiagnostics) {
@@ -467,7 +478,7 @@ async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
     // A typed-sql-only push would replace the client's combined pull report and
     // erase TypeScript errors. Ask it to pull again after overlay invalidation.
     // Do not await: the new pull must be able to wait for this document queue.
-    if (diagnosticRefreshSupported) void client.sendRequest("workspace/diagnostic/refresh").catch(() => undefined);
+    requestDiagnosticRefresh();
     return;
   }
   const diagnostics = await combinedDiagnostics(state);
@@ -684,6 +695,11 @@ client.onRequest(async (method, rawParams, token) => {
   const params = restored.item;
   const uri = restored.context?.uri ?? documentUri(params);
   if (uri !== undefined) await waitForDocument(uri, token);
+  // Failed schema analysis must remain visible to pull clients as a diagnostic,
+  // not disappear when their pull report supersedes a pushed failure report.
+  const projectFailure = uri === undefined ? undefined : projectFailureReports.get(uri);
+  if (method === "textDocument/diagnostic" && projectFailure !== undefined)
+    return { kind: "full", items: [projectFailure] };
   const state = restored.context?.state ?? (isObject(params) ? stateFor(params) : undefined);
   ensureStateCurrent(state);
   if (

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -293,7 +293,7 @@ function queueDocument(uri: string, operation: () => Promise<void>): Promise<voi
     .catch(async (error: unknown) => {
       if (error instanceof Error && error.name === "AbortError") return;
       nativeDiagnostics.delete(uri);
-      projectFailureReports.add(uri);
+      if (sourceDocuments.has(uri)) projectFailureReports.add(uri);
       await client.sendNotification("textDocument/publishDiagnostics", {
         uri,
         ...(latestDocumentVersions.get(uri) === undefined ? {} : { version: latestDocumentVersions.get(uri) }),
@@ -320,7 +320,7 @@ function queueWorkspace(operation: () => Promise<void>): Promise<void> {
     .catch(async (error: unknown) => {
       for (const [uri, state] of documents) {
         nativeDiagnostics.delete(uri);
-        projectFailureReports.add(uri);
+        if (sourceDocuments.has(uri)) projectFailureReports.add(uri);
         await client.sendNotification("textDocument/publishDiagnostics", {
           uri,
           version: state.original.version,

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -143,6 +143,7 @@ const sourceDocuments = new Map<string, TextDocument>();
 const documents = new Map<string, DocumentState>();
 const virtualDocuments = new Map<string, DocumentState>();
 const nativeDiagnostics = new Map<string, readonly unknown[]>();
+const projectFailureReports = new Set<string>();
 let pullDiagnostics = false;
 let diagnosticRefreshSupported = false;
 const semanticTokenResults = new SemanticTokenResults();
@@ -292,6 +293,7 @@ function queueDocument(uri: string, operation: () => Promise<void>): Promise<voi
     .catch(async (error: unknown) => {
       if (error instanceof Error && error.name === "AbortError") return;
       nativeDiagnostics.delete(uri);
+      projectFailureReports.add(uri);
       await client.sendNotification("textDocument/publishDiagnostics", {
         uri,
         ...(latestDocumentVersions.get(uri) === undefined ? {} : { version: latestDocumentVersions.get(uri) }),
@@ -318,6 +320,7 @@ function queueWorkspace(operation: () => Promise<void>): Promise<void> {
     .catch(async (error: unknown) => {
       for (const [uri, state] of documents) {
         nativeDiagnostics.delete(uri);
+        projectFailureReports.add(uri);
         await client.sendNotification("textDocument/publishDiagnostics", {
           uri,
           version: state.original.version,
@@ -453,6 +456,14 @@ async function combinedDiagnostics(state: DocumentState): Promise<readonly unkno
 async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
   if (latestDocumentVersions.get(state.original.uri) !== state.original.version) return;
   if (pullDiagnostics) {
+    // Failure reports use push delivery even for pull clients. Clear that owned
+    // report once analysis recovers; requesting a pull alone does not remove it.
+    if (projectFailureReports.delete(state.original.uri))
+      await client.sendNotification("textDocument/publishDiagnostics", {
+        uri: state.original.uri,
+        version: state.original.version,
+        diagnostics: [],
+      });
     // A typed-sql-only push would replace the client's combined pull report and
     // erase TypeScript errors. Ask it to pull again after overlay invalidation.
     // Do not await: the new pull must be able to wait for this document queue.
@@ -467,6 +478,7 @@ async function publishCombinedDiagnostics(state: DocumentState): Promise<void> {
     (state.analysis !== undefined && !state.service.isAnalysisCurrent(state.original, state.analysis))
   )
     return;
+  projectFailureReports.delete(state.original.uri);
   await client.sendNotification("textDocument/publishDiagnostics", {
     uri: state.original.uri,
     version: state.original.version,
@@ -798,6 +810,7 @@ client.onNotification("textDocument/didChange", (rawParams) => {
 
 client.onNotification("textDocument/didClose", (rawParams) => {
   const params = rawParams as DidCloseParams;
+  projectFailureReports.delete(params.textDocument.uri);
   semanticTokenResults.delete(params.textDocument.uri);
   resolveContexts.delete(params.textDocument.uri);
   sourceDocuments.delete(params.textDocument.uri);

--- a/packages/language-server/test/language-server.test.ts
+++ b/packages/language-server/test/language-server.test.ts
@@ -91,6 +91,11 @@ await describe("typed-sql stdio language server", async () => {
       const report = (await failure) as { readonly diagnostics?: readonly { readonly message?: string }[] };
       strict.ok(report.diagnostics?.[0]?.message?.includes("Run typed-sql doctor"));
       strict.ok(!report.diagnostics?.[0]?.message?.includes("secret-missing-schema"));
+      strict.deepStrictEqual(
+        await client.request("textDocument/diagnostic", { textDocument: { uri } }),
+        { kind: "full", items: report.diagnostics },
+        "pull reports retain the same redacted failure instead of throwing or clearing it",
+      );
       await writeFile(missingSchema, await readFile(schemaFile, "utf8"));
       const recovered = client.notification(
         "textDocument/publishDiagnostics",

--- a/test/contracts/editor-hub.test.ts
+++ b/test/contracts/editor-hub.test.ts
@@ -23,6 +23,14 @@ await describe("editor grammar evidence hub", async () => {
     strict.strictEqual(matrix.cells.length, 2 * 4 * (interfaces.length + pendingInterfaces.length));
     strict.ok(matrix.cells.every((cell) => cell.status === "not-run"));
   });
+  await it("records schema lifecycle coverage without inventing synthetic column semantics", () => {
+    strict.ok(interfaces.includes("schema-file-refresh"));
+    strict.ok(!pendingInterfaces.includes("schema-file-refresh"));
+    for (const spec of grammarCases.filter((item) => item.id !== "synthetic")) {
+      strict.deepStrictEqual(spec.schemaRefresh, { table: "users", column: "name", type: "string | null" });
+    }
+    strict.strictEqual(grammarCases.find((item) => item.id === "synthetic")!.schemaRefresh, undefined);
+  });
   await it("does not promote partial, protocol or duplicate evidence into full host coverage", () => {
     const report = {
       editor: "vscode",

--- a/test/contracts/editor-hub.test.ts
+++ b/test/contracts/editor-hub.test.ts
@@ -1,8 +1,13 @@
+import { readFile } from "node:fs/promises";
 import { describe, it, strict } from "poku";
 import { grammarCases, interfaces, sourceFor } from "../editor-hub/cases.mjs";
 import { buildMatrix, pendingInterfaces } from "../editor-hub/matrix.mjs";
 
 await describe("editor grammar evidence hub", async () => {
+  await it("retains host failure evidence even when an editor job fails", async () => {
+    const workflow = await readFile(new URL("../../.github/workflows/ci.yml", import.meta.url), "utf8");
+    strict.match(workflow, /run: pnpm editor:artifacts:smoke\s+- if: always\(\)\s+uses: actions\/upload-artifact/u);
+  });
   await it("covers owned grammars and the external grammar without homogenizing semantics", () => {
     strict.deepStrictEqual(
       grammarCases.map((item) => item.id),

--- a/test/editor-hub/cases.d.mts
+++ b/test/editor-hub/cases.d.mts
@@ -14,6 +14,7 @@ export interface GrammarCase {
   wrongType: string;
   invalidQuery: string;
   diagnosticPattern: string;
+  schemaRefresh?: { table: string; column: string; type: string };
 }
 export const grammarCases: GrammarCase[];
 export const interfaces: string[];

--- a/test/editor-hub/cases.mjs
+++ b/test/editor-hub/cases.mjs
@@ -29,6 +29,7 @@ const sqlCase = (id, version, types) => ({
   wrongType: "number",
   invalidQuery: "SELECT not_a_column FROM users",
   diagnosticPattern: "not_a_column",
+  schemaRefresh: { table: "users", column: "name", type: "string | null" },
 });
 
 export const grammarCases = [
@@ -71,6 +72,7 @@ export const interfaces = [
   "ordinary-hover",
   "unsaved-query-refresh",
   "sql-diagnostic",
+  "schema-file-refresh",
 ];
 
 export function sourceFor(spec, variant = spec.initial) {

--- a/test/editor-hub/matrix.mjs
+++ b/test/editor-hub/matrix.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { grammarCases, interfaces } from "./cases.mjs";
 
 export const pendingInterfaces = [
-  "schema-file-refresh",
   "restart-recovery",
   "multi-root",
   "tsx",

--- a/test/editor-hub/scenario.mjs
+++ b/test/editor-hub/scenario.mjs
@@ -90,10 +90,10 @@ export async function runScenario(spec, host, record) {
       // do not use column metadata (the synthetic third-party fixture).
       await host.writeSchema({ ...spec.schema, dialectVersion: "0.0.0-incompatible" });
       await eventually("incompatible schema fails closed", async () => {
+        const diagnostics = await host.diagnostics();
         assert.ok(
-          (await host.diagnostics()).some(
-            (item) => item.source === "typed-sql" && /analysis is unavailable/.test(item.message),
-          ),
+          diagnostics.some((item) => item.source === "typed-sql" && /analysis is unavailable/.test(item.message)),
+          JSON.stringify(diagnostics),
         );
         const value = await host.hover(marker(spec.initial), memberOffset).catch(() => "");
         assert.ok(value.length === 0 || /\bunknown\b/.test(value), `must not retain stale inference: ${value}`);

--- a/test/editor-hub/scenario.mjs
+++ b/test/editor-hub/scenario.mjs
@@ -67,6 +67,55 @@ export async function runScenario(spec, host, record) {
   await check("ordinary-hover", async () =>
     assert.match(await host.hover("ordinary.count", "ordinary.".length), /number/),
   );
+  await check("schema-file-refresh", async () => {
+    try {
+      if (spec.schemaRefresh !== undefined) {
+        const changed = structuredClone(spec.schema);
+        changed.tables[spec.schemaRefresh.table].columns[spec.schemaRefresh.column].nullable = true;
+        await host.writeSchema(changed);
+        await eventually("schema nullability reaches hover", async () =>
+          assertType(
+            await host.hover(marker(spec.initial), memberOffset),
+            spec.initial.member,
+            spec.schemaRefresh.type,
+          ),
+        );
+        await eventually("schema nullability reaches diagnostics", async () =>
+          assert.ok(
+            (await host.diagnostics()).some((item) => item.error && item.line === 6 && /null/.test(item.message)),
+          ),
+        );
+      }
+      // Every grammar validates its envelope, even if its semantics intentionally
+      // do not use column metadata (the synthetic third-party fixture).
+      await host.writeSchema({ ...spec.schema, dialectVersion: "0.0.0-incompatible" });
+      await eventually("incompatible schema fails closed", async () => {
+        assert.ok(
+          (await host.diagnostics()).some(
+            (item) => item.source === "typed-sql" && /analysis is unavailable/.test(item.message),
+          ),
+        );
+        const value = await host.hover(marker(spec.initial), memberOffset).catch(() => "");
+        assert.ok(value.length === 0 || /\bunknown\b/.test(value), `must not retain stale inference: ${value}`);
+      });
+    } finally {
+      await host.writeSchema(spec.schema);
+    }
+    await eventually("restored schema restores inference and clears stale errors", async () => {
+      const value = await host.hover(marker(spec.initial), memberOffset);
+      assertType(value, spec.initial.member, spec.initial.type);
+      assert.doesNotMatch(value, /\bnull\b/);
+      const errors = (await host.diagnostics()).filter((item) => item.error);
+      assert.ok(
+        !errors.some((item) => item.line === 6 || /analysis is unavailable/.test(item.message)),
+        JSON.stringify(errors),
+      );
+      assert.ok(
+        errors.some((item) => item.line === 7 && /not assignable/.test(item.message)),
+        JSON.stringify(errors),
+      );
+    });
+  });
   await check("unsaved-query-refresh", async () => {
     await host.replace(sourceFor(spec, spec.changed));
     await eventually("unsaved inference", async () =>


### PR DESCRIPTION
## Outcome
The actual-host schema lifecycle test reproduced stale project-unavailable errors after valid schema recovery in all four grammar fixtures. Track owned project failure reports, clear them after recovery for pull clients, then refresh combined TypeScript/SQL diagnostics. Remove tracking on close and successful push delivery.

## Host evidence
- Write the real schema.json while the editor source buffer remains unchanged; no injected watched-file protocol notifications.
- PostgreSQL/MySQL/SQLite nullability changes reach hover and assignment diagnostics.
- All four grammars reject incompatible schema envelopes without returning stale inference, then recover after restoring the snapshot and clear obsolete errors.
- Synthetic grammar intentionally ignores column metadata; only envelope/recovery semantics are asserted there.
- All seven host scenarios pass locally on VS Code 1.134.0/macOS ARM64. Matrix now 32 passed, zero failed, 136 not-run.
- Nine language-server test files, focused Poku hub/distribution/documentation contracts, typecheck, build and quality pass.

Patch Changeset included. No runtime performance improvement claimed or budget changed. Zed actual-host evidence and process restart recovery remain pending.

Closes #184. Closes #185. Part of #155 and #153.