### PR TITLE
fix(vscode): serialize client lifecycle and test recovery

### DIFF
--- a/.changeset/recover-inflight-diagnostic-pulls.md
+++ b/.changeset/recover-inflight-diagnostic-pulls.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Keep diagnostic pulls recoverable when schema analysis fails during a request, and request a retry for stale diagnostic snapshots instead of allowing an empty report to replace current errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ Each run writes `matrix.json` beside individual results, crossing VS Code/Zed, f
 the interface inventory. Missing and unimplemented cells stay `not-run`; protocol evidence is
 rejected as host evidence. Failures remain failures and prevent the host command from passing.
 The current VS Code host executes eight checks per grammar plus three independent trust scenarios.
+An additional controlled-server host scenario tests missing-path recovery, configuration changes
+during startup, automatic process-crash recovery and configuration teardown. It asserts one active
+server process and one hover provider after configuration settles. This probes client ownership,
+not SQL inference after restart; the per-grammar restart-recovery cells remain `not-run`.
 Schema lifecycle checks write the actual snapshot file while leaving the source buffer unchanged.
 PostgreSQL/MySQL/SQLite verify nullability refresh; every grammar verifies incompatible-envelope
 rejection, fail-closed inference and recovery after restoring the snapshot. The synthetic fixture

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Serialize client startup, configuration restarts and shutdown to avoid overlapping workspace servers.
+
 - Verify real SQL overlays, inferred completions, TypeScript diagnostics and unsaved edits through an isolated packaged VS Code host.
 
 - Declare the workspace trust requirement and unsupported virtual-workspace boundary explicitly.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -97,6 +97,7 @@
     }
   },
   "scripts": {
+    "test": "poku test/lifecycle.test.ts --reporter=compact --enforce",
     "test:host": "node test/run-host.mjs",
     "build:bundle": "esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=bundle/extension.cjs --external:vscode --external:tsx/* --sourcemap",
     "package:vsix": "node -e \"require('node:fs').mkdirSync('../../artifacts',{recursive:true})\" && pnpm build:bundle && vsce package --no-dependencies --out ../../artifacts/typed-sql-vscode.vsix"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -7,6 +7,7 @@ import {
   type ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
+import { LifecycleQueue } from "./lifecycle.js";
 
 interface TypedSqlServerStatus {
   readonly name: string;
@@ -47,6 +48,7 @@ const DEVELOPMENT_SERVER_RELATIVE_PATH = join(
 const TYPED_SQL_PROTOCOL_VERSION = 1;
 const TYPED_SQL_PROTOCOL_CAPABILITIES = ["analysis-identity", "diagnostic-fixes", "status"] as const;
 const clients = new Map<string, RunningClient>();
+const lifecycle = new LifecycleQueue();
 const failures = new Map<string, string>();
 const output = vscode.window.createOutputChannel("typed-sql", { log: true });
 let statusBar: vscode.StatusBarItem;
@@ -160,8 +162,7 @@ async function startClient(folder: vscode.WorkspaceFolder): Promise<void> {
   refreshStatusBar();
 }
 
-async function stopClient(folder: vscode.WorkspaceFolder): Promise<void> {
-  const key = folder.uri.toString();
+async function stopClient(key: string): Promise<void> {
   failures.delete(key);
   const running = clients.get(key);
   clients.delete(key);
@@ -173,9 +174,23 @@ async function stopClient(folder: vscode.WorkspaceFolder): Promise<void> {
 }
 
 async function restartClients(): Promise<void> {
+  await Promise.all([...clients.keys()].map(stopClient));
+  await synchronizeClients();
+}
+
+async function synchronizeClients(): Promise<void> {
   const folders = vscode.workspace.workspaceFolders ?? [];
-  await Promise.all(folders.map(stopClient));
+  const current = new Set(folders.map((folder) => folder.uri.toString()));
+  await Promise.all([...clients.keys()].filter((key) => !current.has(key)).map(stopClient));
+  for (const key of failures.keys()) if (!current.has(key)) failures.delete(key);
   await Promise.all(folders.map(startClient));
+  refreshStatusBar();
+}
+
+function scheduleLifecycle(operation: () => Promise<void>): Promise<void> {
+  return lifecycle.run(operation).catch((error: unknown) => {
+    output.appendLine(`typed-sql lifecycle failed: ${error instanceof Error ? error.message : String(error)}`);
+  });
 }
 
 async function showStatus(): Promise<void> {
@@ -204,24 +219,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     output,
     statusBar,
     vscode.commands.registerCommand("typedSql.showBridgeStatus", showStatus),
-    vscode.workspace.onDidChangeWorkspaceFolders(async ({ added, removed }) => {
-      await Promise.all(removed.map(stopClient));
-      await Promise.all(added.map(startClient));
-    }),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => scheduleLifecycle(synchronizeClients)),
     vscode.workspace.onDidChangeConfiguration(async (event) => {
-      if (event.affectsConfiguration("typedSql")) await restartClients();
+      if (event.affectsConfiguration("typedSql")) await scheduleLifecycle(restartClients);
     }),
   );
-  await Promise.all((vscode.workspace.workspaceFolders ?? []).map(startClient));
+  await scheduleLifecycle(synchronizeClients);
   refreshStatusBar();
 }
 
 export async function deactivate(): Promise<void> {
-  await Promise.all(
-    [...clients.values()].map(async ({ client, watcher }) => {
-      watcher.dispose();
-      await client.stop();
-    }),
-  );
-  clients.clear();
+  await lifecycle.close(async () => {
+    await Promise.all([...clients.keys()].map(stopClient));
+  });
 }

--- a/editors/vscode/src/lifecycle.ts
+++ b/editors/vscode/src/lifecycle.ts
@@ -1,0 +1,19 @@
+/** Serializes ownership changes; shutdown waits for in-flight work and skips queued starts. */
+export class LifecycleQueue {
+  #tail: Promise<void> = Promise.resolve();
+  #closing: Promise<void> | undefined;
+
+  run(operation: () => Promise<void>): Promise<void> {
+    if (this.#closing !== undefined) return Promise.resolve();
+    const pending = this.#tail.then(async () => {
+      if (this.#closing === undefined) await operation();
+    });
+    this.#tail = pending.catch(() => undefined);
+    return pending;
+  }
+
+  close(cleanup: () => Promise<void>): Promise<void> {
+    this.#closing ??= this.#tail.then(cleanup);
+    return this.#closing;
+  }
+}

--- a/editors/vscode/test/lifecycle-server.cjs
+++ b/editors/vscode/test/lifecycle-server.cjs
@@ -1,0 +1,32 @@
+const { appendFileSync } = require("node:fs");
+const record = (event, options) =>
+  appendFileSync(process.env.TYPED_SQL_HOST_MARKER, `${JSON.stringify({ event, pid: process.pid, options })}\n`);
+record("start");
+process.on("exit", () => record("exit"));
+process.on("SIGTERM", () => process.exit(0));
+let buffer = Buffer.alloc(0);
+function reply(id, result) {
+  const body = JSON.stringify({ jsonrpc: "2.0", id, result });
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+}
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  for (;;) {
+    const boundary = buffer.indexOf("\r\n\r\n");
+    if (boundary < 0) return;
+    const length = Number(/Content-Length:\s*(\d+)/i.exec(buffer.subarray(0, boundary).toString())[1]);
+    if (buffer.length < boundary + 4 + length) return;
+    const message = JSON.parse(buffer.subarray(boundary + 4, boundary + 4 + length));
+    buffer = buffer.subarray(boundary + 4 + length);
+    if (message.method === "exit") process.exit(0);
+    if (message.id === undefined) continue;
+    if (message.method === "initialize") {
+      setTimeout(() => {
+        record("ready", message.params.initializationOptions);
+        reply(message.id, { capabilities: { hoverProvider: true, textDocumentSync: 1 } });
+      }, 1000);
+    } else if (message.method === "textDocument/hover")
+      reply(message.id, { contents: { kind: "markdown", value: `probe-${process.pid}` } });
+    else reply(message.id, null);
+  }
+});

--- a/editors/vscode/test/lifecycle-suite.cjs
+++ b/editors/vscode/test/lifecycle-suite.cjs
@@ -1,0 +1,91 @@
+const assert = require("node:assert/strict");
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+const vscode = require("vscode");
+const events = () =>
+  existsSync(process.env.TYPED_SQL_HOST_MARKER)
+    ? readFileSync(process.env.TYPED_SQL_HOST_MARKER, "utf8").trim().split("\n").map(JSON.parse)
+    : [];
+async function eventually(check) {
+  const deadline = Date.now() + 25_000;
+  let last;
+  do {
+    try {
+      return await check();
+    } catch (error) {
+      last = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  } while (Date.now() < deadline);
+  throw last;
+}
+exports.run = async () => {
+  const uri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "query.ts");
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+  const extension = vscode.extensions.getExtension("lojhan.typed-sql");
+  assert.ok(extension);
+  await extension.activate();
+  assert.deepEqual(events(), [], "missing path must not launch a server");
+  const settings = vscode.workspace.getConfiguration("typedSql", uri);
+  await settings.update("serverPath", process.env.TYPED_SQL_HOST_PROBE, vscode.ConfigurationTarget.Workspace);
+  await eventually(() => assert.ok(events().some((event) => event.event === "start")));
+  // The probe intentionally delays initialize: change settings while startup is
+  // in flight, when the old implementation did not yet register its client.
+  await settings.update("analysisDebounceMs", 21, vscode.ConfigurationTarget.Workspace);
+  await settings.update("analysisDebounceMs", 22, vscode.ConfigurationTarget.Workspace);
+  await settings.update("analysisDebounceMs", 23, vscode.ConfigurationTarget.Workspace);
+  let count = 0;
+  let stableSince = Date.now();
+  await eventually(async () => {
+    const log = events();
+    if (count !== log.length) {
+      count = log.length;
+      stableSince = Date.now();
+    }
+    assert.ok(log.some((event) => event.event === "ready" && event.options.analysisDebounceMs === 23));
+    assert.ok(Date.now() - stableSince > 2000, "restart sequence must settle");
+    const hover = await vscode.commands.executeCommand("vscode.executeHoverProvider", uri, new vscode.Position(0, 14));
+    assert.equal(hover.length, 1, "exactly one provider must remain");
+  });
+  const active = new Set();
+  for (const event of events()) {
+    if (event.event === "start") active.add(event.pid);
+    if (event.event === "exit") active.delete(event.pid);
+    assert.ok(active.size <= 1, `overlapping server processes: ${JSON.stringify(events())}`);
+  }
+  assert.equal(active.size, 1);
+  // Exercise the actual language client's automatic process restart policy.
+  const crashed = [...active][0];
+  process.kill(crashed, "SIGTERM");
+  await eventually(async () => {
+    const ready = events()
+      .filter((event) => event.event === "ready")
+      .at(-1);
+    assert.ok(ready && ready.pid !== crashed);
+    const hover = await vscode.commands.executeCommand("vscode.executeHoverProvider", uri, new vscode.Position(0, 14));
+    assert.equal(hover.length, 1);
+    assert.ok(
+      hover[0].contents.some((content) => content.value === `probe-${ready.pid}`),
+      JSON.stringify({ ready, hover }),
+    );
+  });
+  await settings.update("serverPath", "missing-server.cjs", vscode.ConfigurationTarget.Workspace);
+  await eventually(() => {
+    const remaining = new Set();
+    for (const event of events()) {
+      if (event.event === "start") remaining.add(event.pid);
+      if (event.event === "exit") remaining.delete(event.pid);
+    }
+    assert.equal(remaining.size, 0, "configuration teardown must stop every owned server");
+  });
+  writeFileSync(
+    process.env.TYPED_SQL_HOST_REPORT,
+    JSON.stringify({
+      mode: "lifecycle",
+      vscode: vscode.version,
+      passed: true,
+      evidence: "actual-host-controlled-probe",
+      checks: ["missing-path-recovery", "overlapping-restarts", "process-crash-recovery", "configuration-teardown"],
+    }),
+  );
+};

--- a/editors/vscode/test/lifecycle.test.ts
+++ b/editors/vscode/test/lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, strict } from "poku";
+import { LifecycleQueue } from "../src/lifecycle.js";
+
+await describe("editor client lifecycle serialization", async () => {
+  await it("orders overlapping starts and recovers after a failed operation", async () => {
+    const queue = new LifecycleQueue();
+    const events: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = queue.run(async () => {
+      events.push("start");
+      await gate;
+      events.push("ready");
+    });
+    const second = queue.run(async () => {
+      events.push("restart");
+    });
+    await Promise.resolve();
+    strict.deepStrictEqual(events, ["start"]);
+    release();
+    await Promise.all([first, second]);
+    strict.deepStrictEqual(events, ["start", "ready", "restart"]);
+    await strict.rejects(
+      queue.run(async () => {
+        throw new Error("failed");
+      }),
+      /failed/,
+    );
+    await queue.run(async () => {
+      events.push("recovered");
+    });
+    strict.strictEqual(events.at(-1), "recovered");
+  });
+  await it("waits for in-flight startup, skips queued work and closes once", async () => {
+    const queue = new LifecycleQueue();
+    const events: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = queue.run(async () => {
+      events.push("start");
+      await gate;
+      events.push("ready");
+    });
+    await Promise.resolve();
+    const pending = queue.run(async () => {
+      events.push("unwanted restart");
+    });
+    const closed = queue.close(async () => {
+      events.push("stop");
+    });
+    strict.strictEqual(
+      queue.close(async () => {
+        events.push("duplicate stop");
+      }),
+      closed,
+    );
+    release();
+    await Promise.all([first, pending, closed]);
+    await queue.run(async () => {
+      events.push("late start");
+    });
+    strict.deepStrictEqual(events, ["start", "ready", "stop"]);
+  });
+});

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -118,6 +118,15 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
       passed: false,
       hostError: String(failure ?? "Host did not write a passing report").slice(0, 4000),
     };
+    // Preserve only this extension's bounded log from the isolated fixture,
+    // never the complete editor profile or unrelated extension logs.
+    const logs = join(profile, "logs");
+    const entries = await readdir(logs, { recursive: true }).catch(() => []);
+    report.clientLogs = await Promise.all(
+      entries
+        .filter((entry) => entry.replaceAll("\\", "/").endsWith("/lojhan.typed-sql/typed-sql.log"))
+        .map(async (entry) => (await readFile(join(logs, entry), "utf8")).slice(-32_768)),
+    );
   }
   await writeFile(join(results, `${id}.json`), JSON.stringify(report, null, 2));
   if (report.passed !== true) console.error(`Host failure ${id}: ${JSON.stringify(report)}`);

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -24,6 +24,7 @@ const executable = await downloadAndUnzipVSCode({
 const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable);
 const scenarios = [
   ...["trusted", "untrusted", "virtual"].map((mode) => ({ mode, id: mode })),
+  { mode: "lifecycle", id: "lifecycle" },
   ...grammarCases.map((spec) => ({ mode: "overlays", id: spec.id, spec })),
 ];
 const reports = [];
@@ -54,7 +55,9 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
     );
   await writeFile(
     join(workspace, ".vscode/settings.json"),
-    JSON.stringify({ "typedSql.serverPath": join(directory, "probe-server.cjs") }),
+    JSON.stringify({
+      "typedSql.serverPath": mode === "lifecycle" ? "missing-server.cjs" : join(directory, "probe-server.cjs"),
+    }),
   );
   if (mode === "overlays") await prepareOverlayWorkspace(workspace, root, spec);
   await mkdir(join(profile, "User"), { recursive: true });
@@ -82,7 +85,7 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
         "--disable-extension",
         "vscode.typescript-language-features",
         `--extensionDevelopmentPath=${join(directory, "harness")}`,
-        `--extensionTestsPath=${join(directory, mode === "overlays" ? "overlay-suite.cjs" : "host-suite.cjs")}`,
+        `--extensionTestsPath=${join(directory, mode === "overlays" ? "overlay-suite.cjs" : mode === "lifecycle" ? "lifecycle-suite.cjs" : "host-suite.cjs")}`,
         ...(mode !== "untrusted" ? ["--disable-workspace-trust"] : []),
       ],
       {
@@ -93,6 +96,7 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
           TYPED_SQL_HOST_MODE: mode,
           TYPED_SQL_HOST_GRAMMAR: spec?.id ?? "",
           TYPED_SQL_HOST_MARKER: join(base, "server-started"),
+          TYPED_SQL_HOST_PROBE: join(directory, "lifecycle-server.cjs"),
           TYPED_SQL_HOST_REPORT: join(base, "result.json"),
         },
       },

--- a/packages/language-server/src/diagnostic-response.ts
+++ b/packages/language-server/src/diagnostic-response.ts
@@ -1,0 +1,24 @@
+import { type CancellationToken, ResponseError } from "vscode-jsonrpc/node";
+
+/** Keep late analysis failures from stranding a client's diagnostic pull state. */
+export async function recoverDiagnosticPull(
+  operation: () => Promise<unknown>,
+  token: Pick<CancellationToken, "isCancellationRequested">,
+  failureDiagnostic: (error: unknown) => unknown,
+): Promise<unknown> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (
+      token.isCancellationRequested ||
+      (error instanceof Error && error.name === "AbortError") ||
+      (error instanceof ResponseError && [-32800, -32801, -32802].includes(error.code))
+    ) {
+      // ContentModified becomes an empty report in some pull clients. Diagnostic
+      // server cancellation explicitly requests a retry for a fresh snapshot.
+      throw new ResponseError(-32802, "Diagnostic snapshot changed; retry the request", { retriggerRequest: true });
+    }
+    // Do not cache this transient report: a subsequent pull can recover.
+    return { kind: "full", items: [failureDiagnostic(error)] };
+  }
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -16,6 +16,7 @@ import {
 } from "vscode-jsonrpc/node";
 import { TextDocument, type TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
 import { extendTypeScriptCapabilities } from "./capabilities.js";
+import { recoverDiagnosticPull } from "./diagnostic-response.js";
 import {
   negotiateTypedSqlProtocol,
   settingsFrom,
@@ -688,6 +689,13 @@ client.onRequest(TYPED_SQL_STATUS_REQUEST, async (): Promise<TypedSqlLanguageSer
 });
 
 client.onRequest(async (method, rawParams, token) => {
+  const operation = () => forwardRequest(method, rawParams, token);
+  return method === "textDocument/diagnostic"
+    ? recoverDiagnosticPull(operation, token, projectFailureDiagnostic)
+    : operation();
+});
+
+async function forwardRequest(method: string, rawParams: unknown, token: CancellationToken): Promise<unknown> {
   try {
     await workspaceReady;
   } catch (error) {
@@ -731,7 +739,7 @@ client.onRequest(async (method, rawParams, token) => {
     ...mappedResult,
     items: protocolDiagnostics([...items, ...typedDiagnostics]),
   };
-});
+}
 
 async function semanticTokens(
   method: string,

--- a/packages/language-server/test/diagnostic-response.test.ts
+++ b/packages/language-server/test/diagnostic-response.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, strict } from "poku";
+import { ResponseError } from "vscode-jsonrpc/node";
+import { recoverDiagnosticPull } from "../src/diagnostic-response.js";
+
+const token = { isCancellationRequested: false };
+const diagnostic = { code: "TYPED_SQL_PROJECT_UNAVAILABLE", message: "redacted failure" };
+await describe("diagnostic pull recovery", async () => {
+  await it("contains failures after asynchronous analysis and allows the next pull to recover", async () => {
+    const report = await recoverDiagnosticPull(
+      async () => {
+        await Promise.resolve();
+        throw new Error("private schema path failed validation");
+      },
+      token,
+      () => diagnostic,
+    );
+    strict.deepStrictEqual(report, { kind: "full", items: [diagnostic] });
+    const recovered = { kind: "full", items: [{ message: "current assignment error" }] };
+    strict.strictEqual(
+      await recoverDiagnosticPull(
+        async () => recovered,
+        token,
+        () => diagnostic,
+      ),
+      recovered,
+    );
+  });
+  await it("requests diagnostic retries for stale or cancelled snapshots instead of empty reports", async () => {
+    for (const error of [
+      new ResponseError(-32801, "stale"),
+      new ResponseError(-32800, "cancelled"),
+      new ResponseError(-32802, "server cancelled"),
+      Object.assign(new Error("cancelled"), { name: "AbortError" }),
+    ]) {
+      await strict.rejects(
+        () =>
+          recoverDiagnosticPull(
+            async () => {
+              throw error;
+            },
+            token,
+            () => diagnostic,
+          ),
+        (result: unknown) =>
+          result instanceof ResponseError && result.code === -32802 && result.data.retriggerRequest === true,
+      );
+    }
+    await strict.rejects(
+      () =>
+        recoverDiagnosticPull(
+          async () => {
+            throw new Error("cancelled work");
+          },
+          { isCancellationRequested: true },
+          () => diagnostic,
+        ),
+      (result: unknown) => result instanceof ResponseError && result.code === -32802,
+    );
+  });
+});

--- a/test/editor-hub/scenario.mjs
+++ b/test/editor-hub/scenario.mjs
@@ -121,11 +121,13 @@ export async function runScenario(spec, host, record) {
     await eventually("unsaved inference", async () =>
       assertType(await host.hover(marker(spec.changed), memberOffset), spec.changed.member, spec.changed.type),
     );
-    await eventually("refreshed diagnostic", async () =>
+    await eventually("refreshed diagnostic", async () => {
+      const diagnostics = await host.diagnostics();
       assert.ok(
-        (await host.diagnostics()).some((item) => item.error && item.line === 6 && /not assignable/.test(item.message)),
-      ),
-    );
+        diagnostics.some((item) => item.error && item.line === 6 && /not assignable/.test(item.message)),
+        JSON.stringify(diagnostics),
+      );
+    });
   });
   await check("sql-diagnostic", async () => {
     await host.replace(sourceFor(spec, { ...spec.changed, query: spec.invalidQuery }));

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "../packages/*/test/**/*.test.ts",
+    "../editors/vscode/test/**/*.test.ts",
     "../packages/*/test/helpers/**/*.ts",
     "contracts/**/*.test.ts",
     "fuzz/**/*.ts",
@@ -16,6 +17,7 @@
   ],
   "exclude": ["fixtures"],
   "references": [
+    { "path": "../editors/vscode" },
     { "path": "../packages/core" },
     { "path": "../packages/config" },
     { "path": "../packages/ast" },


### PR DESCRIPTION
## Summary
Closes #188. Closes #190. Advances #169 without claiming complete per-grammar restart coverage.

- Serialize VS Code startup, workspace reconciliation, configuration restart and shutdown; add Poku ordering/error/shutdown tests.
- Exercise the packaged VSIX with an actual-host controlled server: correct a missing path, change configuration during initialization, assert one live process/provider, crash the probe and verify its replacement hover, then verify teardown.
- Linux CI exposed a late schema-validation error escaping a diagnostic pull and stranding the client pull state. Add a diagnostic-only recovery boundary: redacted failure reports for analysis errors and retryable cancellation for stale snapshots. Add deterministic response-boundary tests and an experimental language-server patch Changeset.
- Retain diagnostic observations and bounded isolated extension logs on host failures. Matrix restart-recovery cells remain not-run because the lifecycle probe is not SQL inference evidence.

## Verification
Final local revision: typecheck, quality, all 10 language-server test files, lifecycle unit tests, all 36 contract files and all eight packaged VS Code host scenarios passed on macOS ARM64 / VS Code 1.134.0. Grammar matrix: 32 passed / 136 not-run / zero failed.

Earlier Linux revisions failed synthetic diagnostic delivery. The retained log identified an internal diagnostic error followed by a stranded pull. Those attempts are not passing evidence. An attempted watcher-free integration fixture did not reproduce the cached-state race; explicit asynchronous boundary tests cover that failure path instead. Existing host assertions and timeout bounds remain unchanged. Final-head CI pending.

## Scope
No stable API or dependency version changes. Private editor changelog plus language-server patch Changeset record behavior. No measured latency improvement is claimed; sequential restarts are not coalesced. Real grammar inference after restart, multi-root hosts, actual Zed execution and marketplace publication remain pending.