### PR TITLE
fix(editor): scoped configuration and safe rapid-open synchronization

### DIFF
--- a/.changeset/quiet-editors-recover.md
+++ b/.changeset/quiet-editors-recover.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/language-server": patch
+---
+
+Route SQL hover through grammar analysis and preserve upstream document synchronization when rapid edits supersede opening analysis. Keep queued source snapshots immutable.

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Honor per-folder project and server settings in multi-root workspaces.
+
 - Serialize client startup, configuration restarts and shutdown to avoid overlapping workspace servers.
 
 - Verify real SQL overlays, inferred completions, TypeScript diagnostics and unsaved edits through an isolated packaged VS Code host.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -51,43 +51,51 @@
       "title": "typed-sql",
       "properties": {
         "typedSql.configPath": {
+          "scope": "resource",
           "type": "string",
           "default": "",
           "description": "typed-sql config path. Empty discovers typed-sql.config.ts from the workspace folder."
         },
         "typedSql.schemaPath": {
+          "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Optional generated schema override. Empty uses schema.file from typed-sql.config.ts."
         },
         "typedSql.projectFile": {
+          "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Optional tsconfig override. Empty uses the projects declared by typed-sql.config.ts."
         },
         "typedSql.serverPath": {
+          "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Optional language-server module override. Empty uses the workspace-installed @typed-sql/language-server."
         },
         "typedSql.nativePreview": {
+          "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "Use the language server's pinned TypeScript 7.1 preview for authoritative transformed-source semantics."
         },
         "typedSql.maxCacheEntries": {
+          "scope": "resource",
           "type": "number",
           "default": 256,
           "minimum": 1,
           "description": "Maximum document analyses and native inspections retained by each workspace server."
         },
         "typedSql.maxWorkspaceFiles": {
+          "scope": "resource",
           "type": "number",
           "default": 2000,
           "minimum": 1,
           "description": "Maximum TypeScript files preloaded by each workspace server."
         },
         "typedSql.analysisDebounceMs": {
+          "scope": "resource",
           "type": "number",
           "default": 20,
           "minimum": 0,

--- a/editors/vscode/test/run-host.mjs
+++ b/editors/vscode/test/run-host.mjs
@@ -16,9 +16,10 @@ await mkdir(artifacts, { recursive: true });
 const dataRoot = resolve(process.env.TYPED_SQL_HOST_DATA_ROOT ?? artifacts);
 await mkdir(dataRoot, { recursive: true });
 const run = await mkdtemp(join(dataRoot, "v-"));
+await mkdir(join(artifacts, "downloads", "pinned"), { recursive: true });
 const executable = await downloadAndUnzipVSCode({
   version: "1.134.0",
-  cachePath: join(artifacts, "downloads"),
+  cachePath: join(artifacts, "downloads", "pinned"),
   timeout: 30_000,
 });
 const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable);
@@ -59,13 +60,27 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
       "typedSql.serverPath": mode === "lifecycle" ? "missing-server.cjs" : join(directory, "probe-server.cjs"),
     }),
   );
-  if (mode === "overlays") await prepareOverlayWorkspace(workspace, root, spec);
+  if (mode === "overlays") {
+    await prepareOverlayWorkspace(workspace, root, spec);
+    // A workspace file must still honor the folder-owned server/schema paths.
+    await writeFile(workspaceFile, JSON.stringify({ folders: [{ path: workspace }] }));
+  }
   await mkdir(join(profile, "User"), { recursive: true });
   await writeFile(
     join(profile, "User/settings.json"),
-    JSON.stringify({ "security.workspace.trust.startupPrompt": "never", "extensions.autoUpdate": false }),
+    JSON.stringify({
+      "security.workspace.trust.startupPrompt": "never",
+      "extensions.autoUpdate": false,
+      "update.mode": "none",
+      "update.enableWindowsBackgroundUpdates": false,
+    }),
   );
   const isolated = ["--user-data-dir", profile, "--extensions-dir", extensions];
+  const version = await execFile(cli, [...cliArgs, ...isolated, "--version"], { timeout: 30_000 });
+  if (version.stdout.trim().split(/\r?\n/)[0] !== "1.134.0")
+    throw new Error(
+      "Pinned VS Code cache version mismatch; preserve the cache for diagnosis and use a fresh pinned cache.",
+    );
   await execFile(cli, [...cliArgs, ...isolated, "--install-extension", join(root, "artifacts/typed-sql-vscode.vsix")], {
     timeout: 60_000,
   });
@@ -77,7 +92,7 @@ for (const [index, { mode, id, spec }] of scenarios.entries()) {
     await execFile(
       executable,
       [
-        mode === "virtual" ? workspaceFile : workspace,
+        mode === "virtual" || mode === "overlays" ? workspaceFile : workspace,
         ...isolated,
         "--skip-welcome",
         "--skip-release-notes",

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -613,6 +613,22 @@ client.onNotification("initialized", async (params) => {
   await workspaceReady;
 });
 
+client.onRequest("textDocument/hover", async (rawParams, token) => {
+  await workspaceReady;
+  const params = rawParams as JsonObject;
+  const uri = documentUri(params);
+  if (uri !== undefined) await waitForDocument(uri, token);
+  const state = stateFor(params);
+  if (state !== undefined && isObject(params.position)) {
+    const hover = await state.service.hover(state.original, params.position as unknown as Position);
+    ensureStateCurrent(state);
+    if (hover !== undefined) return hover;
+  }
+  const result = await nativeRequest("textDocument/hover", mapProtocolValue(params, "source-to-virtual", state), token);
+  ensureStateCurrent(state);
+  return mapProtocolValue(result, "virtual-to-source", state);
+});
+
 client.onRequest("textDocument/completion", async (rawParams, token) => {
   await workspaceReady;
   const params = rawParams as JsonObject;
@@ -814,25 +830,43 @@ client.onNotification("textDocument/didChange", (rawParams) => {
   const original =
     source === undefined
       ? undefined
-      : TextDocument.update(source, [...params.contentChanges], params.textDocument.version);
+      : TextDocument.update(
+          TextDocument.create(source.uri, source.languageId, source.version, source.getText()),
+          [...params.contentChanges],
+          params.textDocument.version,
+        );
   if (original !== undefined) sourceDocuments.set(original.uri, original);
   latestDocumentVersions.set(params.textDocument.uri, params.textDocument.version);
   const cancellation = beginDocumentAnalysis(params.textDocument.uri, source !== undefined);
   return queueDocument(params.textDocument.uri, async () => {
     await workspaceReady;
     await serviceForUri(params.textDocument.uri).debounce(cancellation);
-    const previous = documents.get(params.textDocument.uri);
+    const previous = documents.get(params.textDocument.uri) ?? virtualDocuments.get(params.textDocument.uri);
     if (original === undefined) {
-      await typescript.sendNotification("textDocument/didChange", params);
+      // An unopened document has no upstream overlay to change.
       return;
     }
     serviceForUri(original.uri).forget(original.uri);
     const state = await createState(original, previous, cancellation);
+    virtualDocuments.delete(original.uri);
     documents.set(original.uri, state);
-    await typescript.sendNotification("textDocument/didChange", {
-      textDocument: { uri: original.uri, version: state.virtualVersion },
-      contentChanges: [{ text: state.transformed.getText() }],
-    });
+    // A rapid change can cancel didOpen analysis before it reaches upstream.
+    await typescript.sendNotification(
+      previous === undefined ? "textDocument/didOpen" : "textDocument/didChange",
+      previous === undefined
+        ? {
+            textDocument: {
+              uri: original.uri,
+              languageId: original.languageId,
+              version: state.virtualVersion,
+              text: state.transformed.getText(),
+            },
+          }
+        : {
+            textDocument: { uri: original.uri, version: state.virtualVersion },
+            contentChanges: [{ text: state.transformed.getText() }],
+          },
+    );
     await publishCombinedDiagnostics(state);
   });
 });

--- a/packages/language-server/test/upstream-typescript.test.ts
+++ b/packages/language-server/test/upstream-typescript.test.ts
@@ -104,6 +104,31 @@ await describe("upstream TypeScript LSP integration", async () => {
         if (method.endsWith("rename")) strict.ok(JSON.stringify(expected).includes("verifyAccount"));
         strict.deepStrictEqual(await proxy.request(method, request), expected, method);
       }
+      const sqlHover = await proxy.request("textDocument/hover", {
+        textDocument: { uri },
+        position: positionAt(source, source.indexOf("SELECT") + 7),
+      });
+      strict.match(JSON.stringify(sqlHover), /typed-sql inferred query type/u);
+      // Do not wait between open and change: analysis of the initial open may
+      // be superseded before an overlay has ever reached the native server.
+      const rapidUri = pathToFileURL(join(fixture, "rapid-edit.ts")).href;
+      proxy.notify("textDocument/didOpen", {
+        textDocument: { uri: rapidUri, languageId: "typescript", version: 1, text: source },
+      });
+      let rapidSource = source;
+      for (let version = 2; version <= 4; version++) {
+        rapidSource = `${source}\nconst latestValue = ${version}; void latestValue;\n`;
+        proxy.notify("textDocument/didChange", {
+          textDocument: { uri: rapidUri, version },
+          contentChanges: [{ text: rapidSource }],
+        });
+      }
+      const rapidHover = await proxy.request("textDocument/hover", {
+        textDocument: { uri: rapidUri },
+        position: positionAt(rapidSource, rapidSource.lastIndexOf("latestValue")),
+      });
+      strict.match(JSON.stringify(rapidHover), /latestValue: 4/u);
+      proxy.notify("textDocument/didClose", { textDocument: { uri: rapidUri } });
       const exported = `${source}\nexport const shared = 1;\n`;
       const databaseUri = pathToFileURL(join(fixture, "database.ts")).href;
       const databaseSource = [

--- a/test/contracts/editor-distribution.test.ts
+++ b/test/contracts/editor-distribution.test.ts
@@ -10,6 +10,15 @@ async function text(path: string): Promise<string> {
 }
 
 await describe("external editor distribution", async () => {
+  await it("honors per-folder settings and pins isolated editor updates", async () => {
+    const manifest = JSON.parse(await text("editors/vscode/package.json"));
+    for (const setting of Object.values(manifest.contributes.configuration.properties))
+      strict.strictEqual((setting as { scope: string }).scope, "resource");
+    const runner = await text("editors/vscode/test/run-host.mjs");
+    strict.ok(runner.includes('"update.mode": "none"'));
+    strict.ok(runner.includes('"update.enableWindowsBackgroundUpdates": false'));
+    strict.ok(runner.includes("VS Code cache version mismatch"));
+  });
   await it("keeps the npm editor client in the editor tree and workspace workflows", async () => {
     const manifest = JSON.parse(await text("editors/vscode/package.json")) as {
       repository: { directory: string };


### PR DESCRIPTION
## Scope
Extract independently verified reliability fixes from draft matrix PR #193, which remains blocked by built-in TypeScript coexistence (#196).

Closes #192
Closes #194
Closes #195

- Resource-scope all folder-owned typedSql settings. Existing four-grammar actual VSIX hosts now open a .code-workspace file to exercise folder configuration.
- Disable application updates in isolated test profiles, use a fresh pinned cache, create it recursively on clean CI and reject version drift before launch.
- Route SQL hover through grammar analysis, retaining native TypeScript hover elsewhere.
- Preserve immutable source snapshots and send didOpen when rapid changes supersede initial analysis before any upstream overlay exists.
- Add real pinned-upstream rapid-edit and SQL-hover regression tests and a patch Changeset.

## Verification
Build, focused real-protocol integration and editor distribution contracts pass in this clean worktree. The same production changes also passed all 11 language-server test files plus 80/84 actual VS Code interface cells and all 20 edit cases in the expanded matrix. The four failures are built-in provider coexistence, tracked honestly in #196; no matrix assertion is weakened or skipped here. This PR retains the existing main host suite and adds folder-workspace coverage. Required CI must pass before merge.

No public API or dependency version changes. No user editor settings or extensions are changed by the tests.