### PR TITLE
fix(cli): use exact compiler policy in init plans

### DIFF
--- a/.changeset/exact-init-compiler.md
+++ b/.changeset/exact-init-compiler.md
@@ -1,0 +1,5 @@
+---
+"@typed-sql/cli": patch
+---
+
+Derive the init plan's missing TypeScript dependency from the compiler's exact supported version policy, preserving existing dependency choices.

--- a/packages/cli/src/init-plan.ts
+++ b/packages/cli/src/init-plan.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, open, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { TYPESCRIPT_COMPILER_SUPPORT_POLICY } from "@typed-sql/compiler";
 
 const grammars = {
   postgres: { package: "@typed-sql/postgres", factory: "postgres" },
@@ -136,7 +137,7 @@ export async function planInit(options: Readonly<Record<string, string>>, versio
     ["@typed-sql/cli", `^${version}`],
     ["@typed-sql/core", "^2.1.0"],
     [grammars[grammar].package, "^2.1.0"],
-    ["typescript", "~7.0.2"],
+    ["typescript", TYPESCRIPT_COMPILER_SUPPORT_POLICY.exactVersion],
   ] as const) {
     const value = existing[name];
     if (value !== undefined && typeof value !== "string") throw new Error(`Invalid dependency ${name}`);

--- a/packages/cli/test/init-plan.test.ts
+++ b/packages/cli/test/init-plan.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { TYPESCRIPT_COMPILER_SUPPORT_POLICY } from "@typed-sql/compiler";
 import { describe, it, strict } from "poku";
 import { planInit } from "../src/init-plan.js";
 
@@ -30,6 +31,7 @@ await describe("nonexecuting init planner", async () => {
         strict.ok(plan.files.every((file) => file.beforeHash === null && file.path.startsWith(`${root}/`)));
         strict.ok(!plan.files.some((file) => file.path.endsWith("schema.json")));
         strict.equal(plan.dependencies[`@typed-sql/${grammar}`], "^2.1.0");
+        strict.equal(plan.dependencies.typescript, TYPESCRIPT_COMPILER_SUPPORT_POLICY.exactVersion);
         strict.ok(plan.pending.some((item) => item.includes("separate approval")));
         strict.deepEqual(await readdir(root), []);
       }


### PR DESCRIPTION
Closes #199.

Replace the duplicated TypeScript range in init planning with TYPESCRIPT_COMPILER_SUPPORT_POLICY.exactVersion from the existing stable compiler dependency. The compiler rejects untested patches, so generated dependency proposals must not float to them. Existing user dependency ranges are still preserved.

Adds a policy-backed assertion for every built-in grammar and a patch Changeset. Focused planner tests and formatting pass. Required CI gates merging.